### PR TITLE
[nri-metadata-injection] Make replicas as configurable

### DIFF
--- a/charts/nri-metadata-injection/Chart.yaml
+++ b/charts/nri-metadata-injection/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic metadata injection webhook.
 name: nri-metadata-injection
-version: 1.0.2
+version: 1.0.3
 appVersion: 1.2.0
 home: https://hub.docker.com/r/newrelic/k8s-metadata-injection
 source:

--- a/charts/nri-metadata-injection/README.md
+++ b/charts/nri-metadata-injection/README.md
@@ -16,6 +16,7 @@ This chart will deploy the [New Relic Infrastructure metadata injection webhook]
 | `imageJob.repository`         | The job container to pull.                                   | `newrelic/k8s-webhook-cert-manager` |
 | `imageJob.pullPolicy`         | The job pull policy.                                         | `IfNotPresent`                      |
 | `imageJob.tag`                | The job version of the container to pull.                    | `1.2.1`                             |
+| `replicas`                    | Number of replicas in the deployment                         | `1`                                 |
 | `resources`                   | Any resources you wish to assign to the pod.                 | See Resources below                 |
 | `serviveAccount.create`       | If true a service account would be created and assigned for the webhook and the job. | `true` |
 | `serviveAccount.name`         | The service account to assign to the webhook and the job. If `serviveAccount.create` is true then this name will be used when creating the service account; if this value is not set or it evaluates to false, then when creating the account the returned value from the template `nr-metadata-injection.fullname` will be used as name. | |

--- a/charts/nri-metadata-injection/templates/deployment.yaml
+++ b/charts/nri-metadata-injection/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "nri-metadata-injection.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       {{- include "nri-metadata-injection.appLabel" . | nindent 6 }}

--- a/charts/nri-metadata-injection/values.yaml
+++ b/charts/nri-metadata-injection/values.yaml
@@ -19,6 +19,8 @@ jobImage:
   tag: 1.2.1
   pullPolicy: IfNotPresent
 
+replicas: 1
+
 resources:
   limits:
     memory: 80M


### PR DESCRIPTION
#### Is this a new chart
No
#### What this PR does / why we need it:
Made the replicas as configurable for `nri-metadata-injection` chart
#### Which issue this PR fixes
  - fixes #47 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
