### PR TITLE
[newrelic-logging] fix nrStaging bug when there is no global

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet
 name: newrelic-logging
-version: 1.1.0
+version: 1.1.1
 appVersion: 1.3.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/templates/_helpers.tpl
+++ b/charts/newrelic-logging/templates/_helpers.tpl
@@ -127,7 +127,13 @@ Return the customSecretLicenseKey
 Returns nrStaging
 */}}
 {{- define "newrelic.nrStaging" -}}
-{{- or .Values.global.nrStaging .Values.nrStaging }}
+{{- if .Values.global }}
+  {{- if .Values.global.nrStaging }}
+    {{- .Values.global.nrStaging -}}
+  {{- end -}}
+{{- else if .Values.nrStaging }}
+  {{- .Values.nrStaging -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/newrelic-logging/templates/daemonset.yaml
+++ b/charts/newrelic-logging/templates/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           env:
             - name: ENDPOINT
-              {{- if eq (include "newrelic.nrStaging" .) "true" }}
+              {{- if (include "newrelic.nrStaging" .) }}
               value: "https://staging-log-api.newrelic.com/log/v1"
               {{- else if .Values.endpoint }}
               value: {{ .Values.endpoint }}


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

#### What this PR does / why we need it:
Fixes bug with `nrStaging` when there is no `global` set. I missed this because I was doing my tests using `--set global.licenseKey=zxc` which hid the bug. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] Chart Version bumped
- [x ] Variables are documented in the README.md
- [x ] Title of the PR starts with chart name (e.g. `[mychartname]`)
