### PR TITLE
[newrelic-logging] Adds Logging K8s manifests for manual (non-helm) installation

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet
 name: newrelic-logging
-version: 1.1.1
+version: 1.1.2
 appVersion: 1.3.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/k8s/README.md
+++ b/charts/newrelic-logging/k8s/README.md
@@ -1,0 +1,60 @@
+# New Relic Logs: Kubernetes manifests
+This directory provides plain Kubernetes manifests that can be applied to your cluster to install the Kubernetes Logging plugin. It is provided as an alternative for those users who prefer not using Helm.
+
+## Installation instructions
+* Copy all the manifest files in this folder (*.yml files) in your local working directory.
+* Configure the plugin. In new-relic-fluent-plugin.yml:
+  * Specify your New Relic license key in the value for LICENSE_KEY
+  * Specify your Kubernetes cluster name in the value for CLUSTER_NAME
+  * If you are in the EU:
+    * Override the ENDPOINT environment variable to https://log-api.eu.newrelic.com/log/v1
+    * Make sure that the license key you are using is an EU key
+* From your working directory, run `kubectl apply -f .` on your cluster
+* Check [New Relic for your logs](https://docs.newrelic.com/docs/logs/new-relic-logs/get-started/introduction-new-relic-logs#find-data)
+
+## Find and use your data
+
+For how to find and query your data in New Relic, see [Find log data](https://docs.newrelic.com/docs/logs/new-relic-logs/get-started/introduction-new-relic-logs#find-data).
+
+For general querying information, see:
+- [Query New Relic data](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/query-new-relic-data)
+- [Intro to NRQL](https://docs.newrelic.com/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql)
+
+## Configuration notes
+
+We default to tailing `/var/log/containers/*.log`. If you want to change what's tailed, just update the `PATH` 
+value in `new-relic-fluent-plugin.yml`.
+
+## Parsing
+
+We currently support parsing json and docker logs. If you want more parsing, feel free to add more parsers in `fluent-conf.yml`.
+
+Here are some parsers for your parsing pleasure. 
+
+```
+[PARSER]
+    Name   apache
+    Format regex
+    Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
+    Time_Key time
+    Time_Format %d/%b/%Y:%H:%M:%S %z
+
+[PARSER]
+    Name   apache2
+    Format regex
+    Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
+    Time_Key time
+    Time_Format %d/%b/%Y:%H:%M:%S %z
+
+[PARSER]
+    Name   apache_error
+    Format regex
+    Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$
+
+[PARSER]
+    Name   nginx
+    Format regex
+    Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
+    Time_Key time
+    Time_Format %d/%b/%Y:%H:%M:%S %z
+  ```   

--- a/charts/newrelic-logging/k8s/fluent-conf.yml
+++ b/charts/newrelic-logging/k8s/fluent-conf.yml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluent-bit-config
+  namespace: default
+  labels:
+    k8s-app: newrelic-logging
+data:
+  # Configuration files: server, input, filters and output
+  # ======================================================
+  fluent-bit.conf: |
+    [SERVICE]
+        Flush         1
+        Log_Level     ${LOG_LEVEL}
+        Daemon        off
+        Parsers_File  parsers.conf
+        HTTP_Server   On
+        HTTP_Listen   0.0.0.0
+        HTTP_Port     2020
+
+    @INCLUDE input-kubernetes.conf
+    @INCLUDE output-newrelic.conf
+    @INCLUDE filter-kubernetes.conf
+
+  input-kubernetes.conf: |
+    [INPUT]
+        Name              tail
+        Tag               kube.*
+        Path              ${PATH}
+        Parser            docker
+        DB                /var/log/flb_kube.db
+        Mem_Buf_Limit     7MB
+        Skip_Long_Lines   On
+        Refresh_Interval  10
+
+  filter-kubernetes.conf: |
+    [FILTER]
+        Name record_modifier
+        Match *
+        Record cluster_name ${CLUSTER_NAME}
+
+    [FILTER]
+        Name           kubernetes
+        Match          kube.*
+        Kube_URL       https://kubernetes.default.svc.cluster.local:443
+        Merge_JSON_Log Off
+
+  output-newrelic.conf: |
+    [OUTPUT]
+        Name  newrelic
+        Match *
+        licenseKey ${LICENSE_KEY}
+        endpoint ${ENDPOINT}
+        maxBufferSize ${BUFFER_SIZE}
+        maxRecords ${MAX_RECORDS}
+
+  parsers.conf: |
+    [PARSER]
+        Name   json
+        Format json
+        Time_Key time
+        Time_Format %d/%b/%Y:%H:%M:%S %z
+
+    [PARSER]
+        Name        docker
+        Format      json
+        Time_Key    time
+        Time_Format %Y-%m-%dT%H:%M:%S.%L
+        Time_Keep   On
+        # Command      |  Decoder | Field | Optional Action
+        # =============|==================|=================
+        Decode_Field_As   escaped    log

--- a/charts/newrelic-logging/k8s/new-relic-fluent-plugin.yml
+++ b/charts/newrelic-logging/k8s/new-relic-fluent-plugin.yml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: newrelic-logging
+  namespace: default
+  labels:
+    k8s-app: newrelic-logging
+    version: v1
+    kubernetes.io/cluster-service: "true"
+    name: newrelic-logging
+    app.kubernetes.io/name: newrelic-logging
+spec:
+  selector:
+    matchLabels:
+      name: newrelic-logging
+  template:
+    metadata:
+      labels:
+        k8s-app: newrelic-logging
+        version: v1
+        kubernetes.io/cluster-service: "true"
+        name: newrelic-logging
+        app.kubernetes.io/name: newrelic-logging
+    spec:
+      serviceAccountName: newrelic-logging
+      containers:
+        - name: newrelic-logging
+          env:
+            - name: ENDPOINT
+              value : "https://log-api.newrelic.com/log/v1"
+            - name: SOURCE
+              value: "kubernetes"
+            - name: LICENSE_KEY
+              value: <YOUR_LICENSE_KEY>
+            - name: CLUSTER_NAME
+              value: <YOUR CLUSTER NAME>
+            - name: BUFFER_SIZE
+              value: "256000"
+            - name: MAX_RECORDS
+              value: "500"
+            - name: LOG_LEVEL
+              value: "info"
+            - name: PATH
+              value: "/var/log/containers/*.log"
+          image: newrelic/newrelic-fluentbit-output:1.3.0
+          command:
+            - /fluent-bit/bin/fluent-bit
+            - -c
+            - /fluent-bit/etc/fluent-bit.conf
+            - -e
+            - /fluent-bit/bin/out_newrelic.so
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 250m
+              memory: 64Mi
+          volumeMounts:
+            - name: config
+              mountPath: /fluent-bit/etc
+            - name: varlog
+              mountPath: /var
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: fluent-bit-config
+        - name: varlog
+          hostPath:
+            path: /var

--- a/charts/newrelic-logging/k8s/rbac.yml
+++ b/charts/newrelic-logging/k8s/rbac.yml
@@ -1,0 +1,31 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fluent-bit-read
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: fluent-bit-read
+subjects:
+  - kind: ServiceAccount
+    name: newrelic-logging
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fluent-bit-read
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - pods
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: newrelic-logging
+  namespace: default
+automountServiceAccountToken: true


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
It includes the K8s manifests that can be used to install it manually, instead of using Helm. It is required for customers that do not use Helm.

#### Which issue this PR fixes
None.

#### Special notes for your reviewer:
Discussed with @alejandrodnm and @douglascamata

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
