### PR TITLE
[newrelic-logging] Removes buffering-related configuration parameters

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet
 name: newrelic-logging
-version: 1.1.2
+version: 1.1.3
 appVersion: 1.3.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/k8s/fluent-conf.yml
+++ b/charts/newrelic-logging/k8s/fluent-conf.yml
@@ -51,8 +51,6 @@ data:
         Match *
         licenseKey ${LICENSE_KEY}
         endpoint ${ENDPOINT}
-        maxBufferSize ${BUFFER_SIZE}
-        maxRecords ${MAX_RECORDS}
 
   parsers.conf: |
     [PARSER]

--- a/charts/newrelic-logging/k8s/new-relic-fluent-plugin.yml
+++ b/charts/newrelic-logging/k8s/new-relic-fluent-plugin.yml
@@ -34,10 +34,6 @@ spec:
               value: <YOUR_LICENSE_KEY>
             - name: CLUSTER_NAME
               value: <YOUR CLUSTER NAME>
-            - name: BUFFER_SIZE
-              value: "256000"
-            - name: MAX_RECORDS
-              value: "500"
             - name: LOG_LEVEL
               value: "info"
             - name: PATH

--- a/charts/newrelic-logging/templates/configmap.yaml
+++ b/charts/newrelic-logging/templates/configmap.yaml
@@ -49,8 +49,6 @@ data:
         Match *
         licenseKey ${LICENSE_KEY}
         endpoint ${ENDPOINT}
-        maxBufferSize ${BUFFER_SIZE}
-        maxRecords ${MAX_RECORDS}
 
   parsers.conf: |
     [PARSER]

--- a/charts/newrelic-logging/templates/daemonset.yaml
+++ b/charts/newrelic-logging/templates/daemonset.yaml
@@ -59,10 +59,6 @@ spec:
                   {{- end }}
             - name: CLUSTER_NAME
               value: {{ include "newrelic-logging.clusterName" . }}
-            - name: BUFFER_SIZE
-              value: {{ .Values.fluentBit.bufferSize | quote }}
-            - name: MAX_RECORDS
-              value: {{ .Values.fluentBit.maxRecords| quote }}
             - name: LOG_LEVEL
               value: {{ .Values.fluentBit.logLevel | quote }}
             - name: PATH

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -21,8 +21,6 @@
 # endpoint: https://log-api.newrelic.com/log/v1
 
 fluentBit:
-  bufferSize: "256000"
-  maxRecords: "500"
   logLevel: "info"
   path: "/var/log/containers/*.log"
 


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Removes buffering-related configuration options from the chart/K8s manifests. These options have been deprecated, and specifying them leads to getting WARN messages, so we have removed them to avoid extra noise.

#### Which issue this PR fixes
- Fixes LOGGING-2584.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
