### PR TITLE
[newrelic-logging] Add value to control fluentd k8s-logging.exclude configuration

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet
 name: newrelic-logging
-version: 1.2.2
+version: 1.2.3
 appVersion: 1.3.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/README.md
+++ b/charts/newrelic-logging/README.md
@@ -70,6 +70,7 @@ See [values.yaml](values.yaml) for the default values
 | `serviceAccount.create`                                    | If true, a service account would be created and assigned to the deployment                                                                                                                                                                        | true                                 |
 | `serviceAccount.name`                                      | The service account to assign to the deployment. If `serviceAccount.create` is true then this name will be used when creating the service account                                                                                                 |                                      |
 | `global.nrStaging` - `nrStaging`                           | Send data to staging (requires a staging license key)                                                                                                                                                                                             | false                                |
+| `fluentBit.k8sLoggingExclude`                  | Set to "On" to allow excluding pods by adding the annotation `fluentbit.io/exclude: "true"` to pods you wish to exclude.                                                                                                                          | `Off`                                |
 
 
 ## Uninstall the Kubernetes plugin

--- a/charts/newrelic-logging/templates/configmap.yaml
+++ b/charts/newrelic-logging/templates/configmap.yaml
@@ -42,6 +42,7 @@ data:
         Match          kube.*
         Kube_URL       https://kubernetes.default.svc:443
         Merge_JSON_Log Off
+        K8S-Logging.Exclude ${K8S_LOGGING_EXCLUDE}
 
   output-newrelic.conf: |
     [OUTPUT]

--- a/charts/newrelic-logging/templates/daemonset.yaml
+++ b/charts/newrelic-logging/templates/daemonset.yaml
@@ -63,6 +63,8 @@ spec:
               value: {{ .Values.fluentBit.logLevel | quote }}
             - name: PATH
               value: {{ .Values.fluentBit.path | quote }}
+            - name: K8S_LOGGING_EXCLUDE
+              value: {{ .Values.fluentBit.k8sLoggingExclude | quote }}
           command:
             - /fluent-bit/bin/fluent-bit
             - -c

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -23,6 +23,7 @@
 fluentBit:
   logLevel: "info"
   path: "/var/log/containers/*.log"
+  k8sLoggingExclude: "Off"
 
 image:
   repository: newrelic/newrelic-fluentbit-output


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No

#### What this PR does / why we need it:

This adds a value configuration so we can configure the `K8S-Logging.Exclude` part of FluentBit. The [new relic blog post](https://blog.newrelic.com/engineering/disable-new-relic-logging-for-kubernetes/) explains how this needs to be turned on in order for FluentBit to ignore certain pods with the annotation `fluentbit.io/exclude: "true"`

#### Special Notes:
@bmcfeely 
@jsubirat 
@matildasmeds
@tejunior


#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
