### PR TITLE
[newrelic-logging] Added other variant of global clusterName

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet
 name: newrelic-logging
-version: 1.2.0
+version: 1.2.1
 appVersion: 1.3.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/templates/_helpers.tpl
+++ b/charts/newrelic-logging/templates/_helpers.tpl
@@ -78,7 +78,11 @@ Return the clusterName
   {{- if .Values.global.clusterName }}
       {{- .Values.global.clusterName -}}
   {{- else -}}
+    {{- if .Values.global.cluster }}
+      {{- .Values.global.cluster -}}
+    {{- else -}}
       {{- .Values.clusterName | default "" -}}
+    {{- end -}}
   {{- end -}}
 {{- else -}}
     {{- .Values.clusterName | default "" -}}


### PR DESCRIPTION

#### Is this a new chart

no

#### What this PR does / why we need it:

nri-bundle passes the cluster name as `global.cluster` instead of `global.clusterName`.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
