### PR TITLE
feat: Auto bump chart version if not specified

### DIFF
--- a/.github/actions/chart-version-bumper/bump_chart_version.js
+++ b/.github/actions/chart-version-bumper/bump_chart_version.js
@@ -15,6 +15,13 @@ exports.bumpChartVersion = function(chartYAML, chartVersion, appVersion) {
     const currentChartVersion = doc.get("version");
     const currentAppVersion = doc.get("appVersion");
 
+    // if no chartVersion has been specified it will be bumped by 1
+    if (chartVersion == ""){
+        v = currentChartVersion.split('.')
+        v[v.length - 1] = parseInt(v[v.length - 1]) + 1
+        chartVersion = v.join('.')
+    }
+
     var changes = [] 
     if (chartVersion != "" && currentChartVersion != chartVersion) {
         doc.set("version", chartVersion);

--- a/.github/actions/chart-version-bumper/bump_chart_version.test.js
+++ b/.github/actions/chart-version-bumper/bump_chart_version.test.js
@@ -70,3 +70,16 @@ test("changing both chartVersion and appVersion", () => {
     expect(changes.length).toBe(2);
     expect(newYAML).toEqual(expectedYAML);
 });
+
+test("changing appVersion increase chartVersion by 1", () => {
+    const [oldChartVersion, newChartVersion] = ['1.21.19', '1.21.20'];
+    const [oldAppVersion, newAppVersion] = ['0.1', '0.2'];
+    
+    const givenYAML = createChart(oldChartVersion, quoted(oldAppVersion));
+    const expectedYAML = createChart(newChartVersion, quoted(newAppVersion));
+    
+    const {changes, newYAML} = bumpChartVersion(givenYAML, '', newAppVersion);
+
+    expect(changes.length).toBe(2);
+    expect(newYAML).toEqual(expectedYAML);
+});

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ This repository is configured to accept webhook requests to bump chart versions.
 A [GitHub Personal Access Token][github-personal-access-token] for this repository is required. If you have the token, execute the following POST request (tailor `client_payload` to your needs):
 
 `chart_name`: (required) Name of the helm chart to be bumped.
-`chart_version`: (optional) If specified the chart version will be set with this value. If empty the version of the chart will be bumped by 1 e.g: 1.2.19 -> 1.2.20
+`chart_version`: (optional) If specified the chart version will be set with this value. If left empty the patch version of the chart will be bumped by 1, e.g: 1.2.19 -> 1.2.20
 `app_version`: (required) Version of the application.
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -96,12 +96,16 @@ This repository is configured to accept webhook requests to bump chart versions.
 
 A [GitHub Personal Access Token][github-personal-access-token] for this repository is required. If you have the token, execute the following POST request (tailor `client_payload` to your needs):
 
+`chart_name`: (required) Name of the helm chart to be bumped.
+`chart_version`: (optional) If specified the chart version will be set with this value. If empty the version of the chart will be bumped by 1 e.g: 1.2.19 -> 1.2.20
+`app_version`: (required) Version of the application.
+
 ```sh
 curl -H "Accept: application/vnd.github.everest-preview+json" \
      -H "Authorization: token <PERSONAL_ACCESS_TOKEN>" \
      --request POST \
      --data '{"event_type": "bump-chart-version", "client_payload": { "chart_name": "simple-nginx", "chart_version": "1.2.3", "app_version": "1.45.7"}}' \
-     https://api.github.com/repos/newrelic-experimental/helm-charts/dispatches
+     https://api.github.com/repos/newrelic/helm-charts/dispatches
 ```
 
 Notice the sample `client_payload` object in the request body: the request generates a pull request for the `simple-nginx` chart to update `app_version` to `1.45.7` and `chart_version` to `1.2.3`.


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No
#### What this PR does / why we need it:
It modify the version bumper GHA to increase the chartVersion by 1 if has not been specified.
This way external repos like nri-prometheus could automate the process of updating the app version without knowing the chart version.
#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
