### PR TITLE
[nri-metadata-injection] Changes to support running newrelic metadata injector in Kubernetes clusters with restrictive Pod Security Policy.

### DIFF
--- a/charts/nri-metadata-injection/Chart.yaml
+++ b/charts/nri-metadata-injection/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic metadata injection webhook.
 name: nri-metadata-injection
-version: 1.1.0
+version: 1.1.1
 appVersion: 1.3.0
 home: https://hub.docker.com/r/newrelic/k8s-metadata-injection
 source:

--- a/charts/nri-metadata-injection/README.md
+++ b/charts/nri-metadata-injection/README.md
@@ -16,11 +16,17 @@ This chart will deploy the [New Relic Infrastructure metadata injection webhook]
 | `imageJob.repository`         | The job container to pull.                                   | `newrelic/k8s-webhook-cert-manager` |
 | `imageJob.pullPolicy`         | The job pull policy.                                         | `IfNotPresent`                      |
 | `imageJob.tag`                | The job version of the container to pull.                    | `1.3.0`                             |
+| `imageJob.volumeMounts`       | Additional Volume mounts for Cert Job                        | `[]`                                |
+| `imageJob.volumes`            | Additional Volumes for Cert Job                              | `[]`                                |
 | `replicas`                    | Number of replicas in the deployment                         | `1`                                 |
 | `resources`                   | Any resources you wish to assign to the pod.                 | See Resources below                 |
 | `serviveAccount.create`       | If true a service account would be created and assigned for the webhook and the job. | `true` |
 | `serviveAccount.name`         | The service account to assign to the webhook and the job. If `serviveAccount.create` is true then this name will be used when creating the service account; if this value is not set or it evaluates to false, then when creating the account the returned value from the template `nr-metadata-injection.fullname` will be used as name. | |
 | `customTLSCertificate`        | Use custom TLS certificate. Setting this options means that you will have to do some post install work as detailed in the *Manage custom certificates* section of the [official docs][1]. | `false` |
+| `podSecurityContext.enabled`  | Enable custom Pod Security Context                           | `false`                             |
+| `podSecurityContext.fsGroup`  | fsGroup for Pod Security Context                             | `1001`                              |
+| `podSecurityContext.runAsUser`| runAsUser UID for Pod Security Context                       | `1001`                              |
+| `podSecurityContext.runAsGroup`| runAsUser GID for Pod Security Context                      | `1001`                              |
 | `priorityClassName`           | Scheduling priority of the pod                               | `nil`                               |
 | `nodeSelector`                | Node label to use for scheduling                             | `{}`                                |
 | `tolerations`                 | List of node taints to tolerate (requires Kubernetes >= 1.6) | `[]`                                |

--- a/charts/nri-metadata-injection/templates/_helpers.tpl
+++ b/charts/nri-metadata-injection/templates/_helpers.tpl
@@ -76,3 +76,16 @@ Return the cluster
   {{- .Values.cluster | default "" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "tplvalues.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/charts/nri-metadata-injection/templates/deployment.yaml
+++ b/charts/nri-metadata-injection/templates/deployment.yaml
@@ -19,6 +19,12 @@ spec:
       {{- if not .Values.customTLSCertificate }}
       serviceAccountName: {{ template "nri-metadata-injection.serviceAccountName" . }}
       {{- end }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.podSecurityContext.runAsUser }}
+        runAsGroup: {{ .Values.podSecurityContext.runAsGroup }}
+        fsGroup: {{ .Values.podSecurityContext.fsGroup }}
+      {{- end }}
       containers:
       - name: {{ template "nri-metadata-injection.name" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/nri-metadata-injection/templates/job.yaml
+++ b/charts/nri-metadata-injection/templates/job.yaml
@@ -28,6 +28,14 @@ spec:
           - {{ template "nri-metadata-injection.fullname" . }}
           - "--namespace"
           - {{ .Release.Namespace }}
+        {{- if .Values.jobImage.volumeMounts }}
+        volumeMounts:
+        {{- include "tplvalues.render" ( dict "value" .Values.jobImage.volumeMounts "context" $ ) | nindent 10 }}
+        {{- end }}
       restartPolicy: Never
+      {{- if .Values.jobImage.volumes }}
+      volumes:
+      {{- include "tplvalues.render" ( dict "value" .Values.jobImage.volumes "context" $ ) | nindent 8 }}
+      {{- end }}
   backoffLimit: 1
 {{- end }}

--- a/charts/nri-metadata-injection/values.yaml
+++ b/charts/nri-metadata-injection/values.yaml
@@ -15,6 +15,16 @@ jobImage:
   repository: newrelic/k8s-webhook-cert-manager
   tag: 1.3.0
   pullPolicy: IfNotPresent
+  # Volume mounts to add to the job, you might want to mount tmp if Pod Security Policies
+  # Enforce a read-only root.
+  volumeMounts: []
+  #  - name: tmp
+  #    mountPath: /tmp
+
+  # Volumes to add to the job container
+  volumes: []
+  #  - name: tmp
+  #    emptyDir: {}
 
 replicas: 1
 
@@ -35,6 +45,13 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+
+# Configure podSecurityContext
+podSecurityContext:
+  enabled: false
+  fsGroup: 1001
+  runAsUser: 1001
+  runAsGroup: 1001
 
 # Use custom tls certificates for the webhook, or let the chart handle it
 # automatically.


### PR DESCRIPTION
The changes to deployment.yaml allow you to configure a Pod Security Context for the main metadata injector pod so that it doesn't run as root and get denied scheduling
The changes to the job.yaml allow you to configure mounts in the Pod so that /tmp can be mounted as an emptydir when policy enforces a read-only root filesystem.
Additional Values added to values.yaml
README.md updated with new configuration values
Chart version bumped.

Fixes #122
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
So that the metadata injector can run in more restrictive environments

#### Which issue this PR fixes
  - fixes #122

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
