### PR TITLE
[nri-metadata-injection] Allow support to modify the webhook timeout value

### DIFF
--- a/charts/nri-metadata-injection/Chart.yaml
+++ b/charts/nri-metadata-injection/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic metadata injection webhook.
 name: nri-metadata-injection
-version: 1.1.0
+version: 1.1.1
 appVersion: 1.3.0
 home: https://hub.docker.com/r/newrelic/k8s-metadata-injection
 source:

--- a/charts/nri-metadata-injection/README.md
+++ b/charts/nri-metadata-injection/README.md
@@ -23,6 +23,7 @@ This chart will deploy the [New Relic Infrastructure metadata injection webhook]
 | `customTLSCertificate`        | Use custom TLS certificate. Setting this options means that you will have to do some post install work as detailed in the *Manage custom certificates* section of the [official docs][1]. | `false` |
 | `priorityClassName`           | Scheduling priority of the pod                               | `nil`                               |
 | `nodeSelector`                | Node label to use for scheduling                             | `{}`                                |
+| `timeoutSeconds`              | Seconds to wait for a webhook to respond. The timeout value must be between 1 and 30 seconds| `10`                             |
 | `tolerations`                 | List of node taints to tolerate (requires Kubernetes >= 1.6) | `[]`                                |
 | `affinity`                    | Node affinity to use for scheduling                          | `{}`                                |
 

--- a/charts/nri-metadata-injection/templates/mutationwebhookconfiguration.yaml
+++ b/charts/nri-metadata-injection/templates/mutationwebhookconfiguration.yaml
@@ -23,3 +23,4 @@ webhooks:
       newrelic-metadata-injection: enabled
 {{- end }}
   failurePolicy: Ignore
+  timeoutSeconds: {{ .Values.timeoutSeconds }}

--- a/charts/nri-metadata-injection/values.yaml
+++ b/charts/nri-metadata-injection/values.yaml
@@ -48,3 +48,10 @@ customTLSCertificate: false
 # Pod scheduling priority
 # Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
 # priorityClassName: high-priority
+
+# Webhook timeout
+#
+# Configure how long the API server should wait for a webhook to respond before treating the call as a failure
+#
+# Ref: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts
+timeoutSeconds: 10

--- a/charts/nri-metadata-injection/values.yaml
+++ b/charts/nri-metadata-injection/values.yaml
@@ -54,4 +54,4 @@ customTLSCertificate: false
 # Configure how long the API server should wait for a webhook to respond before treating the call as a failure
 #
 # Ref: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts
-timeoutSeconds: 10
+timeoutSeconds: 30


### PR DESCRIPTION


<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No
#### What this PR does / why we need it:
Webhooks add to API request latency, they should evaluate as quickly as possible.
Admission webhooks created using `admissionregistration.k8s.io/v1beta1` default timeouts to `30` seconds. This can cause potential problems with the scheduler and block new pods from being created. This is fixed to default to `10` seconds in `admissionregistration.k8s.io/v1`. However, it would be nice to have it configurable to allow for a shorter time or longer if necessary. 
#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
Reference: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
