### PR TITLE
[newrelic-infrastructure] support configuration of process metrics

### DIFF
--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 1.5.0
+version: 1.5.1
 appVersion: 1.26.1
 home: https://hub.docker.com/r/newrelic/infrastructure-k8s/
 source:

--- a/charts/newrelic-infrastructure/README.md
+++ b/charts/newrelic-infrastructure/README.md
@@ -47,6 +47,7 @@ This chart will deploy the New Relic Infrastructure agent as a Daemonset.
 | `schedulerEndpointUrl`         | Explicitly sets the scheduler component url.                                                                                                                                                                                                      |                                 |
 | `controllerManagerEndpointUrl` | Explicitly sets the controller manager component url.                                                                                                                                                                                             |                                 |
 | `eventQueueDepth`              | Increases the in-memory cache of the agent to accommodate for more samples at a time. | |
+| `enableProcessMetrics`         | Enables the sending of process metrics to New Relic.  | `false` |
 | `global.nrStaging` - `nrStaging` | Send data to staging (requires a staging license key). | `false` |
 | `discoveryCacheTTL`            | Duration since the discovered endpoints are stored in the cache until they expire. Valid time units: 'ns', 'us', 'ms', 's', 'm', 'h' | `1h` | |
 

--- a/charts/newrelic-infrastructure/templates/daemonset-windows.yaml
+++ b/charts/newrelic-infrastructure/templates/daemonset-windows.yaml
@@ -109,6 +109,10 @@ spec:
             - name: "DISCOVERY_CACHE_TTL"
               value: {{ .Values.discoveryCacheTTL | quote }}
             {{- end }}
+            {{- if .Values.enableProcessMetrics }}
+            - name: "NRIA_ENABLE_PROCESS_METRICS"
+              value: {{ .Values.enableProcessMetrics | quote }}
+            {{- end }}
             {{- if (include "newrelic.nrStaging" .) }}
             - name: "NRIA_STAGING"
               value: "true"

--- a/charts/newrelic-infrastructure/templates/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/daemonset.yaml
@@ -116,6 +116,10 @@ spec:
             - name: "DISCOVERY_CACHE_TTL"
               value: {{ .Values.discoveryCacheTTL | quote }}
             {{- end }}
+            {{- if .Values.enableProcessMetrics }}
+            - name: "NRIA_ENABLE_PROCESS_METRICS"
+              value: {{ .Values.enableProcessMetrics | quote }}
+            {{- end }}
             {{- if (include "newrelic.nrStaging" .) }}
             - name: "NRIA_STAGING"
               value: "true"


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No
#### What this PR does / why we need it:
It enables configuration of the NRIA_ENABLE_PROCESS_METRICS environment variable for the newrelic-infrastructure agent as described in [the agent configuration docs](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings#enable-process-metrics)
#### Which issue this PR fixes
  - fixes #141 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
