### PR TITLE
[nri-metadata-injection] cert-manager support for webhook

### DIFF
--- a/charts/nri-metadata-injection/Chart.yaml
+++ b/charts/nri-metadata-injection/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic metadata injection webhook.
 name: nri-metadata-injection
-version: 1.1.2
+version: 1.2.0
 appVersion: 1.3.0
 home: https://hub.docker.com/r/newrelic/k8s-metadata-injection
 source:

--- a/charts/nri-metadata-injection/README.md
+++ b/charts/nri-metadata-injection/README.md
@@ -24,6 +24,7 @@ This chart will deploy the [New Relic Infrastructure metadata injection webhook]
 | `serviveAccount.create`       | If true a service account would be created and assigned for the webhook and the job. | `true` |
 | `serviveAccount.name`         | The service account to assign to the webhook and the job. If `serviveAccount.create` is true then this name will be used when creating the service account; if this value is not set or it evaluates to false, then when creating the account the returned value from the template `nr-metadata-injection.fullname` will be used as name. | |
 | `customTLSCertificate`        | Use custom TLS certificate. Setting this options means that you will have to do some post install work as detailed in the *Manage custom certificates* section of the [official docs][1]. | `false` |
+| `certManager.enabled`         | Use cert-manager to provision the MutatingWebhookConfiguration certs. | `false` |
 | `podSecurityContext.enabled`  | Enable custom Pod Security Context                           | `false`                             |
 | `podSecurityContext.fsGroup`  | fsGroup for Pod Security Context                             | `1001`                              |
 | `podSecurityContext.runAsUser`| runAsUser UID for Pod Security Context                       | `1001`                              |
@@ -56,3 +57,4 @@ The default set of resources assigned to the pods is shown below:
         memory: 30M
 
 [1]: https://docs.newrelic.com/docs/integrations/kubernetes-integration/link-your-applications/link-your-applications-kubernetes#configure-injection
+[2]: https://cert-manager.io/

--- a/charts/nri-metadata-injection/templates/cert-manager.yaml
+++ b/charts/nri-metadata-injection/templates/cert-manager.yaml
@@ -1,0 +1,49 @@
+{{ if .Values.certManager.enabled }}
+---
+# Create a selfsigned Issuer, in order to create a root CA certificate for
+# signing webhook serving certificates
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ template "nri-metadata-injection.fullname" . }}-self-signed-issuer
+spec:
+  selfSigned: {}
+---
+# Generate a CA Certificate used to sign certificates for the webhook
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ template "nri-metadata-injection.fullname" . }}-root-cert
+spec:
+  secretName: {{ template "nri-metadata-injection.fullname" . }}-root-cert
+  duration: 43800h # 5y
+  issuerRef:
+    name: {{ template "nri-metadata-injection.fullname" . }}-self-signed-issuer
+  commonName: "ca.webhook.nri"
+  isCA: true
+---
+# Create an Issuer that uses the above generated CA certificate to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ template "nri-metadata-injection.fullname" . }}-root-issuer
+spec:
+  ca:
+    secretName: {{ template "nri-metadata-injection.fullname" . }}-root-cert
+---
+
+# Finally, generate a serving certificate for the webhook to use
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ template "nri-metadata-injection.fullname" . }}-webhook-cert
+spec:
+  secretName: {{ template "nri-metadata-injection.fullname" . }}
+  duration: 8760h # 1y
+  issuerRef:
+    name: {{ template "nri-metadata-injection.fullname" . }}-root-issuer
+  dnsNames:
+  - {{ template "nri-metadata-injection.fullname" . }}
+  - {{ template "nri-metadata-injection.fullname" . }}.{{ .Release.Namespace }}
+  - {{ template "nri-metadata-injection.fullname" . }}.{{ .Release.Namespace }}.svc
+{{ end }}

--- a/charts/nri-metadata-injection/templates/clusterrole.yaml
+++ b/charts/nri-metadata-injection/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.customTLSCertificate }}
+{{- if (and (not .Values.customTLSCertificate) (not .Values.certManager.enabled)) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/nri-metadata-injection/templates/clusterrolebinding.yaml
+++ b/charts/nri-metadata-injection/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.customTLSCertificate }}
+{{- if (and (not .Values.customTLSCertificate) (not .Values.certManager.enabled)) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/nri-metadata-injection/templates/deployment.yaml
+++ b/charts/nri-metadata-injection/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         {{- include "nri-metadata-injection.labels" . | nindent 8 }}
     spec:
-      {{- if not .Values.customTLSCertificate }}
+      {{- if (and (not .Values.customTLSCertificate) (not .Values.certManager.enabled)) }}
       serviceAccountName: {{ template "nri-metadata-injection.serviceAccountName" . }}
       {{- end }}
       {{- if .Values.podSecurityContext.enabled }}

--- a/charts/nri-metadata-injection/templates/job.yaml
+++ b/charts/nri-metadata-injection/templates/job.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.customTLSCertificate }}
+{{- if (and (not .Values.customTLSCertificate) (not .Values.certManager.enabled)) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/nri-metadata-injection/templates/mutationwebhookconfiguration.yaml
+++ b/charts/nri-metadata-injection/templates/mutationwebhookconfiguration.yaml
@@ -2,6 +2,11 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ template "nri-metadata-injection.fullname" . }}
+{{- if .Values.certManager.enabled }}
+  annotations:
+    certmanager.k8s.io/inject-ca-from: {{ printf "%s/%s-root-cert" .Release.Namespace (include "nri-metadata-injection.fullname" .) | quote }}
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s-root-cert" .Release.Namespace (include "nri-metadata-injection.fullname" .) | quote }}
+{{- end }}
   labels:
     {{- include "nri-metadata-injection.labels" . | nindent 4 }}
 webhooks:
@@ -11,7 +16,9 @@ webhooks:
       name: {{ template "nri-metadata-injection.fullname" . }}
       namespace: {{ .Release.Namespace }}
       path: "/mutate"
+{{- if not .Values.certManager.enabled }}
     caBundle: ""
+{{- end }}
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]

--- a/charts/nri-metadata-injection/templates/serviceaccount.yaml
+++ b/charts/nri-metadata-injection/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if (and .Values.serviceAccount.create (not .Values.customTLSCertificate)) }}
+{{- if (and .Values.serviceAccount.create (not .Values.customTLSCertificate) (not .Values.certManager.enabled)) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/nri-metadata-injection/values.yaml
+++ b/charts/nri-metadata-injection/values.yaml
@@ -76,3 +76,7 @@ customTLSCertificate: false
 #
 # Ref: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts
 timeoutSeconds: 30
+
+# Use cert manager for webhook certs
+certManager:
+  enabled: false


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No
#### What this PR does / why we need it:
Add cert-manager support for webhook. We use cert-manager for all our other validating/mutating webhooks, so it makes sense for newrelic to also support this.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md