### PR TITLE
[newrelic-logging] bumping chart version

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet
 name: newrelic-logging
-version: 1.2.3
+version: 1.2.4
 appVersion: 1.3.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg


### PR DESCRIPTION
A PR was rebased and we did not notice that the commit didn't have anymore the chart version bump needed

https://github.com/newrelic/helm-charts/commit/2bf6a9543df4d27b8b8475acbb618a8b49edc508

This caused the CI/CD to fail and the chart not to be released

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
