### PR TITLE
[newrelic-infrastructure]: Added OpenShift parameter and other minor updates

### DIFF
--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 1.5.4
+version: 1.6.0
 appVersion: 1.26.5
 home: https://hub.docker.com/r/newrelic/infrastructure-k8s/
 source:
@@ -18,6 +18,7 @@ maintainers:
   - name: jorik
   - name: alejandrodnm
   - name: rk295
+  - name: bpschmitt
 keywords:
   - infrastructure
   - newrelic

--- a/charts/newrelic-infrastructure/README.md
+++ b/charts/newrelic-infrastructure/README.md
@@ -44,13 +44,15 @@ This chart will deploy the New Relic Infrastructure agent as a Daemonset.
 | `etcdTlsSecretNamespace`       | Namespace where the secret specified in `etcdTlsSecretName` was created.                                                                                                                                                                          | `default`                       |
 | `etcdEndpointUrl`              | Explicitly sets the etcd component url.                                                                                                                                                                                                           |                                 |
 | `apiServerSecurePort`          | Set to query the API Server over a secure port.                                                                                                                                                                                                   |                                 |
-| `apiServerEndpointUrl`         | Explicitly sets the api server componenturl.                                                                                                                                                                                                      |                                 |
+| `apiServerEndpointUrl`         | Explicitly sets the api server component url.                                                                                                                                                                                                     |                                 |
 | `schedulerEndpointUrl`         | Explicitly sets the scheduler component url.                                                                                                                                                                                                      |                                 |
 | `controllerManagerEndpointUrl` | Explicitly sets the controller manager component url.                                                                                                                                                                                             |                                 |
 | `eventQueueDepth`              | Increases the in-memory cache of the agent to accommodate for more samples at a time. | |
 | `enableProcessMetrics`         | Enables the sending of process metrics to New Relic.  | `false` |
 | `global.nrStaging` - `nrStaging` | Send data to staging (requires a staging license key). | `false` |
-| `discoveryCacheTTL`            | Duration since the discovered endpoints are stored in the cache until they expire. Valid time units: 'ns', 'us', 'ms', 's', 'm', 'h' | `1h` | |
+| `discoveryCacheTTL`            | Duration since the discovered endpoints are stored in the cache until they expire. Valid time units: 'ns', 'us', 'ms', 's', 'm', 'h' | `1h` |
+| `openshift` | Enables OpenShift configuration options including OpenShift specific Control Plane endpoints | `false` |
+| `runAsUser` | Set when running in unprivileged mode or when hitting UID constraints in OpenShift. | `1000` |
 
 ## Example
 

--- a/charts/newrelic-infrastructure/templates/NOTES.txt
+++ b/charts/newrelic-infrastructure/templates/NOTES.txt
@@ -7,7 +7,7 @@ Your deployment of the New Relic Infrastructure agent is complete. You can check
 ####       ERROR: You did not set a licenseKey and/or cluster name.       ####
 ##############################################################################
 
-This deployment will be incomplete until you get your API key from New Relic.
+This deployment will be incomplete until you set your New Relic license key and a cluster name.
 
 Then run:
 

--- a/charts/newrelic-infrastructure/templates/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/daemonset.yaml
@@ -95,13 +95,13 @@ spec:
             {{- if .Values.openshift }}
             # OpenShift defaults
             - name: "ETCD_ENDPOINT_URL"
-              value: "https://localhost:9979"
+              value: {{ .Values.etcdEndpointUrl | quote | default "https://localhost:9979" }}
             - name: "API_SERVER_ENDPOINT_URL"
-              value: "https://localhost:6443"
+              value: {{ .Values.apiServerEndpointUrl | quote | default "https://localhost:6443" }}
             - name: "SCHEDULER_ENDPOINT_URL"
-              value: "https://localhost:10259"
+              value: {{ .Values.schedulerEndpointUrl | quote | default "https://localhost:10259" }}
             - name: "CONTROLLER_MANAGER_ENDPOINT_URL"
-              value: "https://localhost:10257"
+              value: {{ .Values.controllerManagerEndpointUrl | quote | default "https://localhost:10257" }}
             {{- else }}
             {{- if .Values.etcdEndpointUrl }}
             - name: "ETCD_ENDPOINT_URL"

--- a/charts/newrelic-infrastructure/templates/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/daemonset.yaml
@@ -43,7 +43,7 @@ spec:
             {{- if .Values.privileged }}
             privileged: true
             {{- else }}
-            runAsUser: 1000 # nri-agent
+            runAsUser: {{ .Values.runAsUser | default 1000 }}
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             {{- end }}
@@ -92,13 +92,20 @@ spec:
             - name: ETCD_TLS_SECRET_NAMESPACE
               value: {{ .Values.etcdTlsSecretNamespace | quote }}
             {{- end }}
+            {{- if .Values.openshift }}
+            # OpenShift defaults
+            - name: "ETCD_ENDPOINT_URL"
+              value: "https://localhost:9979"
+            - name: "API_SERVER_ENDPOINT_URL"
+              value: "https://localhost:6443"
+            - name: "SCHEDULER_ENDPOINT_URL"
+              value: "https://localhost:10259"
+            - name: "CONTROLLER_MANAGER_ENDPOINT_URL"
+              value: "https://localhost:10257"
+            {{- else }}
             {{- if .Values.etcdEndpointUrl }}
             - name: "ETCD_ENDPOINT_URL"
               value: {{ .Values.etcdEndpointUrl | quote }}
-            {{- end }}
-            {{- if .Values.apiServerSecurePort }}
-            - name: "API_SERVER_SECURE_PORT"
-              value: {{ .Values.apiServerSecurePort | quote }}
             {{- end }}
             {{- if .Values.apiServerEndpointUrl }}
             - name: "API_SERVER_ENDPOINT_URL"
@@ -111,6 +118,11 @@ spec:
             {{- if .Values.controllerManagerEndpointUrl }}
             - name: "CONTROLLER_MANAGER_ENDPOINT_URL"
               value: {{ .Values.controllerManagerEndpointUrl | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.apiServerSecurePort }}
+            - name: "API_SERVER_SECURE_PORT"
+              value: {{ .Values.apiServerSecurePort | quote }}
             {{- end }}
             {{- if .Values.eventQueueDepth }}
             - name: "NRIA_EVENT_QUEUE_DEPTH"
@@ -169,8 +181,13 @@ spec:
             {{- if .Values.privileged }}
             - name: dev
               mountPath: /dev
+            {{- if .Values.openshift }}
+            - name: host-crio-socket
+              mountPath: /var/run/crio.sock
+            {{- else }}
             - name: host-docker-socket
               mountPath: /var/run/docker.sock
+            {{- end }}
             - name: log
               mountPath: /var/log
             - name: host-volume
@@ -195,9 +212,15 @@ spec:
         - name: dev
           hostPath:
             path: /dev
+        {{- if .Values.openshift }}
+        - name: host-crio-socket
+          hostPath:
+            path: /var/run/crio.sock
+        {{- else }}
         - name: host-docker-socket
           hostPath:
             path: /var/run/docker.sock
+        {{- end }}
         - name: log
           hostPath:
             path: /var/log

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -68,8 +68,43 @@ serviceAccount:
   # Specify any annotations to add to the ServiceAccount
   annotations:
 
-# If you wish to provide additional labels to apply to the pod(s), specify
-# them here
+# For unprivileged mode - default is 1000.
+# Can also be modified for OpenShift clusters where the runAsUser range
+# may be restricted.  See OpenShift docs for more information.
+# https://www.openshift.com/blog/a-guide-to-openshift-and-uids
+runAsUser:
+
+### Openshift 4.x ###
+# Set openshift: true if installing in an OpenShift 4.x Cluster
+# This setting will enable /var/run/crio.sock instead of /var/run/docker.sock
+# when running in privileged mode. It also automatically enables
+# the OpenShift Control Plane Endpoints.
+openshift: false
+
+### Customize the Control Plane Endpoints ###
+# The New Relic Kubernetest daemonset will attempt to automatically discover the Control Plane endpoints.
+#
+# See docs for more details and default values:
+#  https://docs.newrelic.com/docs/integrations/kubernetes-integration/installation/configure-control-plane-monitoring#discover-nodes-components
+#
+# If you need to customize the endpoint URLs, enable the following variables and configure based upon your environment.
+#  https://docs.newrelic.com/docs/integrations/kubernetes-integration/installation/configure-control-plane-monitoring#openshift-4x-configuration
+#
+# schedulerEndpointUrl: "https://localhost:10259"
+# etcdEndpointUrl: "https://localhost:9979"
+# controllerManagerEndpointUrl: "https://localhost:10257"
+# apiServerEndpointUrl: "https://localhost:6443"
+
+### ETCD mTLS
+# In order to set mTLS for querying ETCD, use the follow configuration options.
+#
+# https://docs.newrelic.com/docs/integrations/kubernetes-integration/installation/configure-control-plane-monitoring#mtls-how-to
+# https://docs.newrelic.com/docs/integrations/kubernetes-integration/installation/configure-control-plane-monitoring#mtls-how-to-openshift
+#
+# etcdTlsSecretName: newrelic-infra-etcd-tls-secret
+# etcdTlsSecretNamespace: newrelic
+
+# If you wish to provide additional labels to apply to the pod(s), specify them here
 # podLabels:
 
 # If you wish to provide your own newrelic.yml file include it under config:
@@ -127,9 +162,6 @@ updateStrategy: RollingUpdate
 
 # Custom attributes to be passed to the New Relic agent
 customAttributes: "'{\"clusterName\":\"$(CLUSTER_NAME)\"}'"
-
-# etcdTlsSecretName: newrelic-infra-etcd-tls-secret
-etcdTlsSecretNamespace: default
 
 # If you wish to monitor services running on Kubernetes you can provide integrations
 # configuration under integrations_config. You just need to create a new entry where


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

- Added `openshift` parameter which enables `/var/run/crio.sock` and auto-enables Control Plane endpoints
- Added a comment and docs links about ETCD mTLS (the parameters were already there previously)
- Made runAsUser configurable. Previously, it was statically set in the daemonset.yaml file.
- Updated the README with the new parameters

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
