### PR TITLE
[nri-kube-events] - Infra-agent / Kube forwarder connects to New Relic One endpoint over the

### DIFF
--- a/charts/nri-kube-events/Chart.yaml
+++ b/charts/nri-kube-events/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Kube Events
 name: nri-kube-events
-version: 1.3.3
+version: 1.3.4
 appVersion: 1.3.0
 engine: gotpl
 home: https://docs.newrelic.com/docs/integrations/kubernetes-integration/kubernetes-events/install-kubernetes-events-integration
@@ -11,6 +11,6 @@ keywords:
   - newrelic
   - monitoring
 maintainers:
-- name: douglascamata
-- name: jorik
-- name: bpschmitt
+  - name: douglascamata
+  - name: jorik
+  - name: bpschmitt

--- a/charts/nri-kube-events/README.md
+++ b/charts/nri-kube-events/README.md
@@ -29,8 +29,9 @@ This chart will deploy the New Relic Events Routers as a Deployment.
 | `nodeSelector`                                             | Node label to use for scheduling                                                                                                                                                                                                               | `{}`                            |
 | `tolerations`                                              | List of node taints to tolerate (requires Kubernetes >= 1.6)                                                                                                                                                                                   | `[]`                            |
 | `affinity`                                                 | Node affinity to use for scheduling                                                                                                                                                                                                            | `{}`                            |
-| `global.nrStaging` - `nrStaging`                    | Send data to staging (requires a staging license key). | false |
-| `runAsUser` | Set when running in unprivileged mode or when hitting UID constraints in OpenShift. | `1000` |
+| `global.nrStaging` - `nrStaging`                           | Send data to staging (requires a staging license key).                                                                                                                                                                                         | false                           |
+| `runAsUser`                                                | Set when running in unprivileged mode or when hitting UID constraints in OpenShift.                                                                                                                                                            | `1000`                          |
+| `proxy`                                                    | Set proxy if you required as Kube-events-forwarder / infra-agent needs to send metrics to New Relic One.                                                                                                                                       |                                 |
 
 ## Example
 

--- a/charts/nri-kube-events/templates/deployment.yaml
+++ b/charts/nri-kube-events/templates/deployment.yaml
@@ -62,6 +62,10 @@ spec:
             - name: NRIA_STAGING
               value: "true"
             {{- end }}
+            {{- if .Values.proxy }}
+            - name: NRIA_PROXY
+              value: "{{ .Values.proxy }}"
+            {{- end }}
           volumeMounts:
             - mountPath: /var/db/newrelic-infra/data
               name: tmpfs-data

--- a/charts/nri-kube-events/values.yaml
+++ b/charts/nri-kube-events/values.yaml
@@ -24,6 +24,10 @@
 
 agentHTTPTimeout: "30s"
 
+# Kube-events container will spin up a infra-agent(event-forwarder) as a sidecar container to forward
+# events to New Relic One endpoint. However, due to security restrictions, some users might require
+# to use an http proxy to route traffic over the internet. If this is the case for you, set this value
+# to your http proxy endpoint.
 proxy: {}
 
 sinks:
@@ -44,7 +48,7 @@ image:
   ## It is possible to specify docker registry credentials
   ## See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
   # pullSecrets:
-    # - name: regsecret
+  # - name: regsecret
 
 # For unprivileged mode - default is 1000.
 # Can also be modified for OpenShift clusters where the runAsUser range
@@ -52,7 +56,8 @@ image:
 # https://www.openshift.com/blog/a-guide-to-openshift-and-uids
 runAsUser:
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/charts/nri-kube-events/values.yaml
+++ b/charts/nri-kube-events/values.yaml
@@ -24,6 +24,8 @@
 
 agentHTTPTimeout: "30s"
 
+proxy: {}
+
 sinks:
   # Enable the stdout sink to also see all events in the logs.
   stdout: false


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart: 
No

#### What this PR does / why we need it:
Infra-agent / Kube forwarder connects to New Relic One endpoint over the
internet. Hence, some of us require proxy to be set for this to work

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
