### PR TITLE
[nri-kube-events]: added configurable runAsUser

### DIFF
--- a/charts/nri-kube-events/Chart.yaml
+++ b/charts/nri-kube-events/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Kube Events
 name: nri-kube-events
-version: 1.3.2
+version: 1.3.3
 appVersion: 1.3.0
 engine: gotpl
 home: https://docs.newrelic.com/docs/integrations/kubernetes-integration/kubernetes-events/install-kubernetes-events-integration
@@ -13,3 +13,4 @@ keywords:
 maintainers:
 - name: douglascamata
 - name: jorik
+- name: bpschmitt

--- a/charts/nri-kube-events/README.md
+++ b/charts/nri-kube-events/README.md
@@ -30,6 +30,7 @@ This chart will deploy the New Relic Events Routers as a Deployment.
 | `tolerations`                                              | List of node taints to tolerate (requires Kubernetes >= 1.6)                                                                                                                                                                                   | `[]`                            |
 | `affinity`                                                 | Node affinity to use for scheduling                                                                                                                                                                                                            | `{}`                            |
 | `global.nrStaging` - `nrStaging`                    | Send data to staging (requires a staging license key). | false |
+| `runAsUser` | Set when running in unprivileged mode or when hitting UID constraints in OpenShift. | `1000` |
 
 ## Example
 

--- a/charts/nri-kube-events/templates/deployment.yaml
+++ b/charts/nri-kube-events/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}
       {{- end }}
       securityContext:
-        runAsUser: 1000 # nri-kube-events
+        runAsUser: {{ .Values.runAsUser | default 1000 }}
         runAsNonRoot: true
       containers:
         - name: kube-events

--- a/charts/nri-kube-events/values.yaml
+++ b/charts/nri-kube-events/values.yaml
@@ -44,6 +44,12 @@ image:
   # pullSecrets:
     # - name: regsecret
 
+# For unprivileged mode - default is 1000.
+# Can also be modified for OpenShift clusters where the runAsUser range
+# may be restricted.  See OpenShift docs for more information.
+# https://www.openshift.com/blog/a-guide-to-openshift-and-uids
+runAsUser:
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

- Makes the `runAsUser` parameter configurable

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
