### PR TITLE
[newrelic-infrastructure] Some options should be enabled for some versions only

### DIFF
--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 1.6.1
+version: 1.6.2
 appVersion: 1.26.6
 home: https://hub.docker.com/r/newrelic/infrastructure-k8s/
 source:

--- a/charts/newrelic-infrastructure/README.md
+++ b/charts/newrelic-infrastructure/README.md
@@ -51,7 +51,8 @@ This chart will deploy the New Relic Infrastructure agent as a Daemonset.
 | `enableProcessMetrics`         | Enables the sending of process metrics to New Relic.  | `false` |
 | `global.nrStaging` - `nrStaging` | Send data to staging (requires a staging license key). | `false` |
 | `discoveryCacheTTL`            | Duration since the discovered endpoints are stored in the cache until they expire. Valid time units: 'ns', 'us', 'ms', 's', 'm', 'h' | `1h` |
-| `openshift` | Enables OpenShift configuration options including OpenShift specific Control Plane endpoints | `false` |
+| `openshift.enabled` | Enables OpenShift configuration options. | `false` |
+| `openshift.version` | OpenShift version for witch enable specific configuration options. Values supported ["3.x","4.x"]. For 4.x it includes OpenShift specific Control Plane endpoints and CRI-O runtime |  |
 | `runAsUser` | Set when running in unprivileged mode or when hitting UID constraints in OpenShift. | `1000` |
 
 ## Example

--- a/charts/newrelic-infrastructure/templates/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/daemonset.yaml
@@ -92,7 +92,7 @@ spec:
             - name: ETCD_TLS_SECRET_NAMESPACE
               value: {{ .Values.etcdTlsSecretNamespace | quote }}
             {{- end }}
-            {{- if .Values.openshift }}
+            {{- if and (.Values.openshift.enabled) (eq .Values.openshift.version "4.x") }}
             # OpenShift defaults
             - name: "ETCD_ENDPOINT_URL"
               value: {{ .Values.etcdEndpointUrl | quote | default "https://localhost:9979" }}
@@ -181,7 +181,7 @@ spec:
             {{- if .Values.privileged }}
             - name: dev
               mountPath: /dev
-            {{- if .Values.openshift }}
+            {{- if and (.Values.openshift.enabled) (eq .Values.openshift.version "4.x") }}
             - name: host-crio-socket
               mountPath: /var/run/crio.sock
             {{- else }}
@@ -212,7 +212,7 @@ spec:
         - name: dev
           hostPath:
             path: /dev
-        {{- if .Values.openshift }}
+        {{- if and (.Values.openshift.enabled) (eq .Values.openshift.version "4.x") }}
         - name: host-crio-socket
           hostPath:
             path: /var/run/crio.sock

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -74,12 +74,15 @@ serviceAccount:
 # https://www.openshift.com/blog/a-guide-to-openshift-and-uids
 runAsUser:
 
-### Openshift 4.x ###
-# Set openshift: true if installing in an OpenShift 4.x Cluster
-# This setting will enable /var/run/crio.sock instead of /var/run/docker.sock
-# when running in privileged mode. It also automatically enables
-# the OpenShift Control Plane Endpoints.
-openshift: false
+### Openshift ###
+# Set openshift.enabled true if installing in an OpenShift Cluster
+# It also automatically enables the OpenShift Control Plane Endpoints.
+openshift:
+  enabled: false
+# When running in privileged mode if the version is equal to "4.x" it will enable
+# /var/run/crio.sock instead of /var/run/docker.sock .
+# Values supported ["3.x","4.x"]
+  version: "4.x"
 
 ### Customize the Control Plane Endpoints ###
 # The New Relic Kubernetest daemonset will attempt to automatically discover the Control Plane endpoints.

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -78,9 +78,9 @@ runAsUser:
 # Set openshift.enabled true when installing in an OpenShift Cluster
 openshift:
   enabled: false
-  
+
 # When running in privileged mode if the version is equal to "4.x" it will enable
-# /var/run/crio.sock instead of /var/run/docker.sock .
+# /var/run/crio.sock instead of /var/run/docker.sock.
 # It also automatically enables the OpenShift Control Plane Endpoints.
 # Values supported ["3.x","4.x"]
   version: "4.x"

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -75,12 +75,13 @@ serviceAccount:
 runAsUser:
 
 ### Openshift ###
-# Set openshift.enabled true if installing in an OpenShift Cluster
-# It also automatically enables the OpenShift Control Plane Endpoints.
+# Set openshift.enabled true when installing in an OpenShift Cluster
 openshift:
   enabled: false
+  
 # When running in privileged mode if the version is equal to "4.x" it will enable
 # /var/run/crio.sock instead of /var/run/docker.sock .
+# It also automatically enables the OpenShift Control Plane Endpoints.
 # Values supported ["3.x","4.x"]
   version: "4.x"
 

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -83,7 +83,7 @@ openshift:
 # /var/run/crio.sock instead of /var/run/docker.sock.
 # It also automatically enables the OpenShift Control Plane Endpoints.
 # Values supported ["3.x","4.x"]
-  version: "4.x"
+  version: ""
 
 ### Customize the Control Plane Endpoints ###
 # The New Relic Kubernetest daemonset will attempt to automatically discover the Control Plane endpoints.


### PR DESCRIPTION
#### Is this a new chart
no

#### What this PR does / why we need it:
The configuration was a bit misleading and could lead a customer running a 3.x openshift to enable configuration needed by 4.x only

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)


Fix https://github.com/newrelic/helm-charts/issues/192

