### PR TITLE
[newrelic-logging] LOGGING-3799 Fix deprecated Merge_JSON_Log option

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet
 name: newrelic-logging
-version: 1.3.0
+version: 1.3.1
 appVersion: 1.4.3
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/k8s/fluent-conf.yml
+++ b/charts/newrelic-logging/k8s/fluent-conf.yml
@@ -43,7 +43,7 @@ data:
         Name           kubernetes
         Match          kube.*
         Kube_URL       https://kubernetes.default.svc.cluster.local:443
-        Merge_JSON_Log Off
+        Merge_Log      Off
 
   output-newrelic.conf: |
     [OUTPUT]

--- a/charts/newrelic-logging/templates/configmap.yaml
+++ b/charts/newrelic-logging/templates/configmap.yaml
@@ -41,7 +41,7 @@ data:
         Name           kubernetes
         Match          kube.*
         Kube_URL       https://kubernetes.default.svc:443
-        Merge_JSON_Log Off
+        Merge_Log      Off
         K8S-Logging.Exclude ${K8S_LOGGING_EXCLUDE}
 
   output-newrelic.conf: |


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
In [this PR](https://github.com/newrelic/helm-charts/pull/165/files), the `newrelic-fluent-bit-output` plugin [Docker generated image](https://github.com/newrelic/newrelic-fluent-bit-output/blob/master/Dockerfile) version was increased from `1.3.0` to `1.4.3`. These versions use the pre-compiled FluentBit Docker image as starting point, [with versions 1.0.3 and 1.6.2 respectively](https://github.com/newrelic/newrelic-fluent-bit-output/compare/1.3.0...1.4.3#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R15).

We didn't detect, though, that Fluent Bit introduced a breaking change between these versions: the `Merge_JSON_Log` property from the `kubernetes` plugin, which [was available](https://fluentbit.io/documentation/0.11/filter/kubernetes.html) in Fluent Bit version `0.11`, seems [not to be available any longer](https://fluentbit.io/documentation/0.13/filter/kubernetes.html) in version `0.13`. It was probably still supported up until version 1.0.3 of Fluent Bit, but it's no longer supported in 1.6.2.


#### Which issue this PR fixes
This PR adapts the helm-chart and k8s manifests to use the new naming for the property: `Merge_Log`

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
