### PR TITLE
[charts/newrelic-logging] Add namespace to all namespaced resources

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet
 name: newrelic-logging
-version: 1.4.0
+version: 1.4.1
 appVersion: 1.4.3
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/templates/clusterrole.yaml
+++ b/charts/newrelic-logging/templates/clusterrole.yaml
@@ -2,6 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  namespace: {{ .Release.Namespace }}
   labels: {{ include "newrelic-logging.labels" . | indent 4 }}
   name: {{ template "newrelic-logging.fullname" . }}
 rules:

--- a/charts/newrelic-logging/templates/configmap.yaml
+++ b/charts/newrelic-logging/templates/configmap.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  namespace: {{ .Release.Namespace }}
   labels: {{ include "newrelic-logging.labels" . | indent 4 }}
   name: {{ template "newrelic-logging.fluentBitConfig" . }}
 data:

--- a/charts/newrelic-logging/templates/daemonset.yaml
+++ b/charts/newrelic-logging/templates/daemonset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 #apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  namespace: {{ .Release.Namespace }}
   labels: {{ include "newrelic-logging.labels" . | indent 4 }}
   name: {{ template "newrelic-logging.fullname" . }}
 spec:

--- a/charts/newrelic-logging/templates/secret.yaml
+++ b/charts/newrelic-logging/templates/secret.yaml
@@ -3,6 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  namespace: {{ .Release.Namespace }}
   labels: {{ include "newrelic-logging.labels" . | indent 4 }}
   name: {{ template "newrelic-logging.fullname" . }}-config
 type: Opaque

--- a/charts/newrelic-logging/templates/serviceaccount.yaml
+++ b/charts/newrelic-logging/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "newrelic-logging.name" . }}
     chart: {{ template "newrelic-logging.chart" . }}


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:

Uses `.Release.Namespace` to explicitly set the namespace on every namespaced resource.

#### Special notes for your reviewer:

This should allow us to properly deploy this chart to a specific namespace.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
