### PR TITLE
[newrelic-logging] Adds filters from values file to newrelic-logging

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet
 name: newrelic-logging
-version: 1.4.2
+version: 1.4.3
 appVersion: 1.4.3
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/templates/configmap.yaml
+++ b/charts/newrelic-logging/templates/configmap.yaml
@@ -42,7 +42,9 @@ data:
         Match          kube.*
         Kube_URL       https://kubernetes.default.svc:443
         K8S-Logging.Exclude ${K8S_LOGGING_EXCLUDE}
-
+{{ if.Values.filters }}
+{{ .Values.filters | indent 4 }}
+{{- end }}
   output-newrelic.conf: |
     [OUTPUT]
         Name  newrelic

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -26,6 +26,21 @@ fluentBit:
   criEnabled: false
   k8sLoggingExclude: "Off"
 
+# If you wish to specify additional filters to for example add additional attributes do 
+# so here
+# filters: |
+#    # Kubernetes saves log files in /var/log/containers/<namespace>_<pod_name>_<pod_id>/<container_name>/
+#    # This chart defines the tag kube.* which encodes the log path 
+#    # (see https://docs.fluentbit.io/manual/pipeline/filters/kubernetes#workflow-of-tail-kubernetes-filter)
+#    #
+#    # Example: This filter adds the attribute logtype=nginx to any log with 'nginx' in the pod name, 
+#    # namespace or container name
+#    [FILTER]
+#        Name           record_modifier
+#        Match          kube.var.log.containers.*nginx*
+#        Record         logtype nginx
+#    
+
 image:
   repository: newrelic/newrelic-fluentbit-output
   tag: ""


### PR DESCRIPTION
#### Is this a new chart
No
#### What this PR does / why we need it:
It allows adding additional [FILTER] entries to `filter-kubernetes.conf` in the config map using a values file. 
I need this to add `logtype` attributes to my logs, but I there are many other uses.
Currently modifying the fluentbit configuration requires modification of the configmap.yml file directly, which means the chart needs to be downloaded and cannot be simply installed from the repo.
 
#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
