### PR TITLE
[newrelic-logging] Adds option for additional filter from values file

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet
 name: newrelic-logging
-version: 1.4.2
+version: 1.4.3
 appVersion: 1.4.3
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/README.md
+++ b/charts/newrelic-logging/README.md
@@ -68,11 +68,11 @@ Since Fluent Bit Kubernetes plugin is using [newrelic-fluent-bit-output](https:/
         ...
      ```
  3. Continue to the next steps
- 
+
  ##### Custom proxy
- 
+
  If you want to set up a custom proxy (eg. using self-signed certificate):
- 
+
   1. Complete the step 1 in [Install the Kubernetes manifests manually](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging#install-the-kubernetes-manifests-manually)
   2. Modify the `fluent-conf.yml` and define in the ConfigMap a `caBundle.pem` file with the self-signed certificate:
       ```yaml
@@ -84,7 +84,7 @@ Since Fluent Bit Kubernetes plugin is using [newrelic-fluent-bit-output](https:/
                 endpoint ${ENDPOINT}
                 proxy https://https-proxy-hostname:PORT
                 caBundleFile ${CA_BUNDLE_FILE}
-            
+
             caBundle.pem: |
                 -----BEGIN CERTIFICATE-----
                 MIIB+zCCAWSgAwIBAgIQTiHC/d/NhpHFptZCIoCbNzANBgkrhtiG9w0BAQsFADAS
@@ -107,7 +107,7 @@ Since Fluent Bit Kubernetes plugin is using [newrelic-fluent-bit-output](https:/
           ...
        ```
   4. Continue to the next steps
- 
+
 ## Configuration
 
 See [values.yaml](values.yaml) for the default values
@@ -133,7 +133,7 @@ See [values.yaml](values.yaml) for the default values
 | `global.nrStaging` - `nrStaging`                           | Send data to staging (requires a staging license key)                                                                                                                                                                                                                        | `false`                              |
 | `fluentBit.criEnabled`                                     | We assume that `kubelet`directly communicates with the Docker container engine. Set this to `true` if your K8s installation uses [CRI](https://kubernetes.io/blog/2016/12/container-runtime-interface-cri-in-kubernetes/) instead, in order to get the logs properly parsed. | `false`                              |
 | `fluentBit.k8sLoggingExclude`                              | Set to "On" to allow excluding pods by adding the annotation `fluentbit.io/exclude: "true"` to pods you wish to exclude.                                                                                                                                                     | `Off`                                |
-
+| `fluentBit.filters`                                        | When defined the content is appended to the end of `filter-kubernetes.conf`. This allows configuration of custom  filters.                                                                                                                                                     |                                |
 
 ## Uninstall the Kubernetes plugin
 

--- a/charts/newrelic-logging/templates/configmap.yaml
+++ b/charts/newrelic-logging/templates/configmap.yaml
@@ -42,7 +42,9 @@ data:
         Match          kube.*
         Kube_URL       https://kubernetes.default.svc:443
         K8S-Logging.Exclude ${K8S_LOGGING_EXCLUDE}
-
+{{ if.Values.fluentBit.filters }}
+{{ .Values.fluentBit.filters | indent 4 }}
+{{- end }}
   output-newrelic.conf: |
     [OUTPUT]
         Name  newrelic

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -25,6 +25,22 @@ fluentBit:
   path: "/var/log/containers/*.log"
   criEnabled: false
   k8sLoggingExclude: "Off"
+  # filters - optinal field used to add additional filters to the FluentBit configuration. 
+  #
+  # Example:
+  #
+  # Kubernetes saves log files in /var/log/containers/<namespace>_<pod_name>_<pod_id>/<container_name>/
+  # This chart already defines a filter that adds the tag kube.* (see
+  # https://docs.fluentbit.io/manual/pipeline/filters/kubernetes#workflow-of-tail-kubernetes-filter).
+  #
+  # The following filter adds the attribute logtype=nginx to any log with 'nginx' in the pod name,namespace
+  # or container name.
+
+  # filters: |
+  #    [FILTER]
+  #        Name           record_modifier
+  #        Match          kube.var.log.containers.*nginx*
+  #        Record         logtype nginx
 
 image:
   repository: newrelic/newrelic-fluentbit-output


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No
#### What this PR does / why we need it:
This change allows adding additional filters to fluent bit from the values file. Currently this requires downloading and modifying the chart.
I've used this to add logtype attributes to logs.
#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
