### PR TITLE
[LOGGING-3985] Fix Json parsing issue

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet
 name: newrelic-logging
-version: 1.4.2
+version: 1.4.3
 appVersion: 1.4.3
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/k8s/fluent-conf.yml
+++ b/charts/newrelic-logging/k8s/fluent-conf.yml
@@ -60,7 +60,6 @@ data:
         Time_Key     time
         Time_Format  %Y-%m-%dT%H:%M:%S.%L
         Time_Keep    On
-        Decode_Field_As   escaped    log
 
     [PARSER]
         Name cri

--- a/charts/newrelic-logging/templates/configmap.yaml
+++ b/charts/newrelic-logging/templates/configmap.yaml
@@ -58,7 +58,6 @@ data:
         Time_Key     time
         Time_Format  %Y-%m-%dT%H:%M:%S.%L
         Time_Keep    On
-        Decode_Field_As   escaped    log
 
     [PARSER]
         Name cri


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

#### What this PR does / why we need it:
This PR fix a JSON parsing issue. 

The removed log line `Decode_Field_As   escaped    log` makes that fluentbit submit to NewRelic a not valid JSON. This line get a valid escaped JSON (that was escaped by Kubernetes) and convert into the real char. (eg. `\n` will be converted in the real brake line)

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
