### PR TITLE
[nri-prometheus] Updated image to 2.3.1, all config options, and updated ignore_metrics

### DIFF
--- a/charts/nri-prometheus/Chart.yaml
+++ b/charts/nri-prometheus/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 2.2.0
+appVersion: 2.3.1
 description: A Helm chart to deploy the New Relic Prometheus OpenMetrics integration
 name: nri-prometheus
-version: 1.5.0
+version: 1.5.1
 engine: gotpl
 home: https://github.com/newrelic/nri-prometheus
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
@@ -13,3 +13,4 @@ keywords:
 maintainers:
   - name: douglascamata
   - name: jorik
+  - name: bpschmitt

--- a/charts/nri-prometheus/values.yaml
+++ b/charts/nri-prometheus/values.yaml
@@ -60,20 +60,20 @@ serviceAccount:
 # If you wish to provide your own config.yaml file include it under config:
 # the sample config file is included here as an example.
 config:
-  # When standalone is set to false nri-prometheus requires an infrastructure agent to work and send data. 
+  # When standalone is set to false nri-prometheus requires an infrastructure agent to work and send data.
   # Default: true
   # standalone: true
 
-  # How often the integration should run. 
+  # How often the integration should run.
   # Default: "30s"
   # scrape_duration: "30s"
 
-  # The HTTP client timeout when fetching data from endpoints. 
+  # The HTTP client timeout when fetching data from endpoints.
   # Default: "5s"
   # scrape_timeout: "5s"
 
   # How old must the entries used for calculating the counters delta be
-  # before the telemetry emitter expires them. 
+  # before the telemetry emitter expires them.
   # Default: "5m"
   # telemetry_emitter_delta_expiration_age: "5m"
 
@@ -81,7 +81,7 @@ config:
   # Default: "5m"
   # telemetry_emitter_delta_expiration_check_interval: "5m"
 
-  # Wether the integration should run in verbose mode or not. 
+  # Wether the integration should run in verbose mode or not.
   # Default: false
   verbose: false
 
@@ -91,7 +91,7 @@ config:
   # Default: false
   audit: false
 
-  # Wether the integration should skip TLS verification or not. 
+  # Wether the integration should skip TLS verification or not.
   # Default: false
   insecure_skip_verify: false
 
@@ -100,7 +100,7 @@ config:
   # Default: "prometheus.io/scrape"
   scrape_enabled_label: "prometheus.io/scrape"
 
-  # Whether k8s nodes need to be labelled to be scraped or not. 
+  # Whether k8s nodes need to be labelled to be scraped or not.
   # Default: true
   require_scrape_enabled_label_for_nodes: true
 
@@ -130,7 +130,7 @@ config:
   # emitter_ca_file: "/path/to/cert/server.pem"
 
   # Set to true in order to stop autodiscovery in the k8s cluster. It can be useful when running the Pod with a service account
-  # having limited privileges. 
+  # having limited privileges.
   # Default: false
   # disable_autodiscovery: false
 

--- a/charts/nri-prometheus/values.yaml
+++ b/charts/nri-prometheus/values.yaml
@@ -26,7 +26,7 @@ fullnameOverride: ""
 
 image:
   repository: newrelic/nri-prometheus
-  tag: 2.3.0
+  tag: 2.3.1
   ## It is possible to specify docker registry credentials
   ## See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
   # pullSecrets:

--- a/charts/nri-prometheus/values.yaml
+++ b/charts/nri-prometheus/values.yaml
@@ -60,25 +60,97 @@ serviceAccount:
 # If you wish to provide your own config.yaml file include it under config:
 # the sample config file is included here as an example.
 config:
-  # How often the integration should run. Defaults to 30s.
+  # When standalone is set to false nri-prometheus requires an infrastructure agent to work and send data. 
+  # Default: true
+  # standalone: true
+
+  # How often the integration should run. 
+  # Default: "30s"
   # scrape_duration: "30s"
-  # The HTTP client timeout when fetching data from endpoints. Defaults to 30s.
-  # scrape_timeout: "30s"
-  # Wether the integration should run in verbose mode or not. Defaults to false.
-  # verbose: true
-  # Wether the integration should skip TLS verification or not. Defaults to false.
-  # insecure_skip_verify: false
-  # The label used to identify scrapable targets. Defaults to "prometheus.io/scrape".
-  # scrape_enabled_label: "prometheus.io/scrape"
-  # Wether k8s nodes needs to be labelled to be scraped or not. Defaults to false.
-  # require_scrape_enabled_label_for_nodes: true
-  # Wether the integraton sends metrics directly to New Relic (true) or to the Infrastructure agent (false)
-  # standalone: false
-  # Number of worker threads used for scraping targets. Defaults to 4
+
+  # The HTTP client timeout when fetching data from endpoints. 
+  # Default: "5s"
+  # scrape_timeout: "5s"
+
+  # How old must the entries used for calculating the counters delta be
+  # before the telemetry emitter expires them. 
+  # Default: "5m"
+  # telemetry_emitter_delta_expiration_age: "5m"
+
+  # How often must the telemetry emitter check for expired delta entries.
+  # Default: "5m"
+  # telemetry_emitter_delta_expiration_check_interval: "5m"
+
+  # Wether the integration should run in verbose mode or not. 
+  # Default: false
+  verbose: false
+
+  # Whether the integration should run in audit mode or not. Defaults to false.
+  # Audit mode logs the uncompressed data sent to New Relic. Use this to log all data sent.
+  # It does not include verbose mode. This can lead to a high log volume, use with care.
+  # Default: false
+  audit: false
+
+  # Wether the integration should skip TLS verification or not. 
+  # Default: false
+  insecure_skip_verify: false
+
+  # The label used to identify scrapeable targets.
+  # Targets can be identified using a label or annotation.
+  # Default: "prometheus.io/scrape"
+  scrape_enabled_label: "prometheus.io/scrape"
+
+  # Whether k8s nodes need to be labelled to be scraped or not. 
+  # Default: true
+  require_scrape_enabled_label_for_nodes: true
+
+  # Number of worker threads used for scraping targets.
+  # For large clusters with many endpoints, increase to 10.
+  # Default: 4
   # worker_threads: 4
 
+  # targets:
+  #   - description: Secure etcd example
+  #     urls: ["https://192.168.3.1:2379", "https://192.168.3.2:2379", "https://192.168.3.3:2379"]
+  #     tls_config:
+  #       ca_file_path: "/etc/etcd/etcd-client-ca.crt"
+  #       cert_file_path: "/etc/etcd/etcd-client.crt"
+  #       key_file_path: "/etc/etcd/etcd-client.key"
+
+  # Proxy to be used by the emitters when submitting metrics. It should be
+  # in the format [scheme]://[domain]:[port].
+  # The emitter is the component in charge of sending the scraped metrics.
+  # This proxy won't be used when scraping metrics from the targets.
+  # By default it's empty, meaning that no proxy will be used.
+  # emitter_proxy: "http://localhost:8888"
+
+  # Certificate to add to the root CA that the emitter will use when
+  # verifying server certificates.
+  # If left empty, TLS uses the host's root CA set.
+  # emitter_ca_file: "/path/to/cert/server.pem"
+
+  # Set to true in order to stop autodiscovery in the k8s cluster. It can be useful when running the Pod with a service account
+  # having limited privileges. 
+  # Default: false
+  # disable_autodiscovery: false
+
+  # Whether the emitter should skip TLS verification when submitting data.
+  # Default: false
+  # emitter_insecure_skip_verify: false
+
+  # Histogram support is based on New Relic's guidelines for higher
+  # level metrics abstractions https://github.com/newrelic/newrelic-exporter-specs/blob/master/Guidelines.md.
+  # To better support visualization of this data, percentiles are calculated
+  # based on the histogram metrics and sent to New Relic.
+  # By default, the following percentiles are calculated: 50, 95 and 99.
+  #
+  # percentiles:
+  #   - 50
+  #   - 95
+  #   - 99
+
   # transformations:
-  #   - description: "General processing rules"
+  #   - description: "Uncomment if running New Relic Kubernetes Integration"
   #     rename_attributes:
   #       - metric_prefix: ""
   #         attributes:
@@ -90,22 +162,19 @@ config:
   #           pod: "podName"
   #           deployment: "deploymentName"
   #     ignore_metrics:
-  #       # Ignore all the metrics except the ones listed below.
-  #       # This is a list that complements the data retrieved by the New
-  #       # Relic Kubernetes Integration, that's why Pods and containers are
-  #       # not included, because they are already collected by the
-  #       # Kubernetes Integration.
-  #       - except:
-  #         - kube_hpa_
-  #         - kube_daemonset_ #### K8s Daemonset
-  #         - kube_statefulset_ #### K8s Daemonset
-  #         - kube_endpoint_ #### K8s Daemonset
-  #         - kube_service_ #### K8s Daemonset
-  #         - kube_limitrange
-  #         - kube_node_ #K8s Daemonset
-  #         - kube_poddisruptionbudget_
-  #         - kube_resourcequota
-  #         - nr_stats
+  #       # Ignore the following metrics.
+  #       # These metrics are already collected by the New Relic Kubernetes Integration.
+  #       - prefixes:
+  #         - kube_daemonset_
+  #         - kube_deployment_
+  #         - kube_endpoint_
+  #         - kube_namespace_
+  #         - kube_node_
+  #         - kube_persistentvolume_
+  #         - kube_pod_
+  #         - kube_replicaset_
+  #         - kube_service_
+  #         - kube_statefulset_
   #     copy_attributes:
   #       # Copy all the labels from the timeseries with metric name
   #       # `kube_hpa_labels` into every timeseries with a metric name that

--- a/charts/nri-prometheus/values.yaml
+++ b/charts/nri-prometheus/values.yaml
@@ -26,7 +26,7 @@ fullnameOverride: ""
 
 image:
   repository: newrelic/nri-prometheus
-  tag: 2.2.0
+  tag: 2.3.0
   ## It is possible to specify docker registry credentials
   ## See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
   # pullSecrets:
@@ -71,11 +71,78 @@ config:
   # The label used to identify scrapable targets. Defaults to "prometheus.io/scrape".
   # scrape_enabled_label: "prometheus.io/scrape"
   # Wether k8s nodes needs to be labelled to be scraped or not. Defaults to false.
-  require_scrape_enabled_label_for_nodes: true
+  # require_scrape_enabled_label_for_nodes: true
   # Wether the integraton sends metrics directly to New Relic (true) or to the Infrastructure agent (false)
   # standalone: false
   # Number of worker threads used for scraping targets. Defaults to 4
   # worker_threads: 4
+
+  # transformations:
+  #   - description: "General processing rules"
+  #     rename_attributes:
+  #       - metric_prefix: ""
+  #         attributes:
+  #           container_name: "containerName"
+  #           pod_name: "podName"
+  #           namespace: "namespaceName"
+  #           node: "nodeName"
+  #           container: "containerName"
+  #           pod: "podName"
+  #           deployment: "deploymentName"
+  #     ignore_metrics:
+  #       # Ignore all the metrics except the ones listed below.
+  #       # This is a list that complements the data retrieved by the New
+  #       # Relic Kubernetes Integration, that's why Pods and containers are
+  #       # not included, because they are already collected by the
+  #       # Kubernetes Integration.
+  #       - except:
+  #         - kube_hpa_
+  #         - kube_daemonset_ #### K8s Daemonset
+  #         - kube_statefulset_ #### K8s Daemonset
+  #         - kube_endpoint_ #### K8s Daemonset
+  #         - kube_service_ #### K8s Daemonset
+  #         - kube_limitrange
+  #         - kube_node_ #K8s Daemonset
+  #         - kube_poddisruptionbudget_
+  #         - kube_resourcequota
+  #         - nr_stats
+  #     copy_attributes:
+  #       # Copy all the labels from the timeseries with metric name
+  #       # `kube_hpa_labels` into every timeseries with a metric name that
+  #       # starts with `kube_hpa_` only if they share the same `namespace`
+  #       # and `hpa` labels.
+  #       - from_metric: "kube_hpa_labels"
+  #         to_metrics: "kube_hpa_"
+  #         match_by:
+  #           - namespace
+  #           - hpa
+  #       - from_metric: "kube_daemonset_labels"
+  #         to_metrics: "kube_daemonset_"
+  #         match_by:
+  #           - namespace
+  #           - daemonset
+  #       - from_metric: "kube_statefulset_labels"
+  #         to_metrics: "kube_statefulset_"
+  #         match_by:
+  #           - namespace
+  #           - statefulset
+  #       - from_metric: "kube_endpoint_labels"
+  #         to_metrics: "kube_endpoint_"
+  #         match_by:
+  #           - namespace
+  #           - endpoint
+  #       - from_metric: "kube_service_labels"
+  #         to_metrics: "kube_service_"
+  #         match_by:
+  #           - namespace
+  #           - service
+  #       - from_metric: "kube_node_labels"
+  #         to_metrics: "kube_node_"
+  #         match_by:
+  #           - namespace
+  #           - node
+  # integration definition files required to map metrics to entities
+  # definition_files_path: /etc/newrelic-infra/definition-files
 
 # If you wish to provide additional annotations to apply to the pod(s), specify
 # them here


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

- Updated the POMI image tag from 2.2.0 to 2.3.1
- Updated the values.yaml config section to include all config options including an updated `ignore_metrics` list.  A lot of this was previously missing.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

Closed out [#232](https://github.com/newrelic/helm-charts/pull/232) in favor of this one.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
