### PR TITLE
[nri-metadata-injection]: Updating job image to support k8s 1.19

### DIFF
--- a/charts/nri-metadata-injection/Chart.yaml
+++ b/charts/nri-metadata-injection/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic metadata injection webhook.
 name: nri-metadata-injection
-version: 1.3.2
-appVersion: 1.3.1
+version: 1.3.3
+appVersion: 1.3.2
 home: https://hub.docker.com/r/newrelic/k8s-metadata-injection
 source:
   - https://github.com/newrelic/k8s-metadata-injection

--- a/charts/nri-metadata-injection/README.md
+++ b/charts/nri-metadata-injection/README.md
@@ -12,11 +12,11 @@ This chart will deploy the [New Relic Infrastructure metadata injection webhook]
 | `injectOnlyLabeledNamespaces` | Limit the injection of metadata only to specific namespaces that match the label `newrelic-metadata-injection: enabled`. | false |
 | `image.repository`            | The container to pull.                                       | `newrelic/k8s-metadata-injection`   |
 | `image.pullPolicy`            | The pull policy.                                             | `IfNotPresent`                      |
-| `image.tag`                   | The version of the container to pull.                        | `1.3.0`                             |
+| `image.tag`                   | The version of the container to pull.                        | `1.3.2`                             |
 | `imageJob.repository`         | The job container to pull.                                   | `newrelic/k8s-webhook-cert-manager` |
 | `imageJob.pullPolicy`         | The job pull policy.                                         | `IfNotPresent`                      |
 | `image.pullSecrets`           | Image pull secrets.                                          | `nil`                               |
-| `imageJob.tag`                | The job version of the container to pull.                    | `1.3.0`                             |
+| `imageJob.tag`                | The job version of the container to pull.                    | `1.3.2`                             |
 | `imageJob.volumeMounts`       | Additional Volume mounts for Cert Job                        | `[]`                                |
 | `imageJob.volumes`            | Additional Volumes for Cert Job                              | `[]`                                |
 | `replicas`                    | Number of replicas in the deployment                         | `1`                                 |

--- a/charts/nri-metadata-injection/values.yaml
+++ b/charts/nri-metadata-injection/values.yaml
@@ -8,7 +8,7 @@ injectOnlyLabeledNamespaces: false
 
 image:
   repository: newrelic/k8s-metadata-injection
-  tag: 1.3.1
+  tag: 1.3.2
   pullPolicy: IfNotPresent
   ## It is possible to specify docker registry credentials
   ## See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
@@ -17,7 +17,7 @@ image:
 
 jobImage:
   repository: newrelic/k8s-webhook-cert-manager
-  tag: 1.3.1
+  tag: 1.3.2
   pullPolicy: IfNotPresent
   # Volume mounts to add to the job, you might want to mount tmp if Pod Security Policies
   # Enforce a read-only root.


### PR DESCRIPTION
This PR updates the Job image of [nri-metadata-injection] in order to support k8s 1.19
 - https://github.com/newrelic/k8s-metadata-injection/releases/tag/v1.3.2
 - https://github.com/newrelic/k8s-webhook-cert-manager/releases/tag/v1.3.2


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
