### PR TITLE
[nri-prometheus] Make metric_api_url visible for configuration.

### DIFF
--- a/charts/nri-prometheus/Chart.yaml
+++ b/charts/nri-prometheus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.4.0
 description: A Helm chart to deploy the New Relic Prometheus OpenMetrics integration
 name: nri-prometheus
-version: 1.6.1
+version: 1.6.2
 engine: gotpl
 home: https://github.com/newrelic/nri-prometheus
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/nri-prometheus/values.yaml
+++ b/charts/nri-prometheus/values.yaml
@@ -63,7 +63,7 @@ config:
   # When standalone is set to false nri-prometheus requires an infrastructure agent to work and send data.
   # Default: true
   # standalone: true
-  
+
   # Set the Metrics API url. It should not be changed unless required (for example to use FedRamp approved endpoints)
   # metric_api_url: <url>
   

--- a/charts/nri-prometheus/values.yaml
+++ b/charts/nri-prometheus/values.yaml
@@ -66,7 +66,7 @@ config:
 
   # Set the Metrics API url. It should not be changed unless required (for example to use FedRamp approved endpoints)
   # metric_api_url: <url>
-  
+
   # How often the integration should run.
   # Default: "30s"
   # scrape_duration: "30s"

--- a/charts/nri-prometheus/values.yaml
+++ b/charts/nri-prometheus/values.yaml
@@ -63,7 +63,10 @@ config:
   # When standalone is set to false nri-prometheus requires an infrastructure agent to work and send data.
   # Default: true
   # standalone: true
-
+  
+  # Set the Metrics API url. It should not be changed unless required (for example to use FedRamp approved endpoints)
+  # metric_api_url: <url>
+  
   # How often the integration should run.
   # Default: "30s"
   # scrape_duration: "30s"


### PR DESCRIPTION
#### Is this a new chart
No
#### What this PR does / why we need it:

The configuration option can be set using the command line but because it's not visible in the chart, customers (and support) are not aware that it can be changed

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
