### PR TITLE
[nri-statsd] Add ability to use kube secret for statsd deployment

### DIFF
--- a/charts/nri-statsd/Chart.yaml
+++ b/charts/nri-statsd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 2.0.0
+appVersion: v2.0.1
 description: A Helm chart to deploy the New Relic Statsd integration
 name: nri-statsd
-version: 1.0.0
+version: 1.1.0
 engine: gotpl
 home: https://github.com/newrelic/nri-statsd
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/nri-statsd/README.md
+++ b/charts/nri-statsd/README.md
@@ -10,6 +10,8 @@ This chart will deploy the New Relic's StatsD Integration. Keep in mind that due
 |------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------|
 | `global.cluster` - `cluster`                               | The cluster name for the Kubernetes cluster.                                                                                                                                                       |                                        |
 | `global.insightsKey` - `insightsKey`                       | The New Relic Inights API Key.                                                                                                                                                                     |                                        |
+| `global.customSecretName` - `customSecretName` | Uses the customSecretName variable found in the bundle chart |  |
+| `global.customSecretInsightsKey` - `customSecretInsightsKey` | Uses the customSecretInsightsKey variable found in the bundle chart |  |
 | `accountId`                                                | The New Relic account ID.                                                                                                                                                                          |                                        |
 | `flushType`                                                | The type of metric being reported. (`metrics`, `insights`, `infra`)                                                                                                                                |`metrics`                               |
 | `statsdPort`                                               | The port statsd pods and the service will listen on.                                                                                                                                               | `8125`                                 |
@@ -32,6 +34,7 @@ This chart will deploy the New Relic's StatsD Integration. Keep in mind that due
 | `tolerations`                                              | List of node taints to tolerate (requires Kubernetes >= 1.6)                                                                                                                                       | `[]`                                   |
 | `affinity`                                                 | Node affinity to use for scheduling                                                                                                                                                                | `{}`                                   |
 | `global.nrStaging` - `nrStaging`                           | Send data to staging (requires a staging license key)                                                                                                                                              | false                                  |
+| `enableConfigmap` | Enables the use of the packaged configmap for advanced configuration, otherwise, use the container's config generation script | true |
 
 ## Example
 

--- a/charts/nri-statsd/ci/test-values.yaml
+++ b/charts/nri-statsd/ci/test-values.yaml
@@ -2,3 +2,5 @@ global:
   licenseKey: 1234567890abcdef1234567890abcdef12345678
   cluster: test-cluster
   insightsKey: 1234567890abcdef1234567890abcdef12345678
+  #customSecretName: new-relic-insights-secret
+  #customSecretInsightsKey: NEW_RELIC_INSIGHTS_KEY

--- a/charts/nri-statsd/templates/_helpers.tpl
+++ b/charts/nri-statsd/templates/_helpers.tpl
@@ -90,6 +90,36 @@ Return the insightsKey
 {{- end -}}
 
 {{/*
+Return the customSecretName
+*/}}
+{{- define "nri-statsd.customSecretName" -}}
+{{- if .Values.global }}
+  {{- if .Values.global.customSecretName }}
+      {{- .Values.global.customSecretName -}}
+  {{- else -}}
+      {{- .Values.customSecretName | default "" -}}
+  {{- end -}}
+{{- else -}}
+    {{- .Values.customSecretName | default "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the customSecretInsightsKey
+*/}}
+{{- define "nri-statsd.customSecretInsightsKey" -}}
+{{- if .Values.global }}
+  {{- if .Values.global.customSecretInsightsKey }}
+      {{- .Values.global.customSecretInsightsKey -}}
+  {{- else -}}
+      {{- .Values.customSecretInsightsKey | default "" -}}
+  {{- end -}}
+{{- else -}}
+    {{- .Values.customSecretInsightsKey | default "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the cluster
 */}}
 {{- define "nri-statsd.cluster" -}}
@@ -124,5 +154,7 @@ insightsKey and cluster are set.
 {{- define "nri-statsd.areValuesValid" -}}
 {{- $cluster := include "nri-statsd.cluster" . -}}
 {{- $insightsKey := include "nri-statsd.insightsKey" . -}}
-{{- and (or $insightsKey) $cluster}}
+{{- $customSecretName := include "nri-statsd.customSecretName" . -}}
+{{- $customSecretInsightsKey := include "nri-statsd.customSecretInsightsKey" . -}}
+{{- and (or $insightsKey (and $customSecretName $customSecretInsightsKey)) $cluster }}
 {{- end -}}

--- a/charts/nri-statsd/templates/configmap.yaml
+++ b/charts/nri-statsd/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.enableConfigmap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -26,3 +27,4 @@ data:
   {{- range $k, $v := .Values.additionalNewRelicConfig }}
     {{ $k }} = {{ $v | squote }}
   {{- end }}
+{{ end }}

--- a/charts/nri-statsd/templates/deployment.yaml
+++ b/charts/nri-statsd/templates/deployment.yaml
@@ -38,10 +38,25 @@ spec:
         {{- else }}
             value: clusterName:{{ include "nri-statsd.cluster" .}}
         {{- end }}
+        {{- if and (not .Values.enableConfigmap) (or "$.Values.nri-statsd.insightsKey" (and "$.Values.nri-statsd.customSecretName" "$.Values.nri-statsd.customSecretInsightsKey")) }}
+          - name: NR_API_KEY
+            valueFrom:
+              secretKeyRef:
+                {{- if (include "nri-statsd.insightsKey" .) }}
+                name: {{ template "nri-statsd.fullname" . }}-config
+                key: insights
+                {{- else }}
+                name: {{ include "nri-statsd.customSecretName" . }}
+                key: {{ include "nri-statsd.customSecretInsightsKey" . }}
+                {{- end }}
+          - name: NR_ACCOUNT_ID
+            value: {{ .Values.accountId | quote }}
+        {{- end }}
         {{- if .Values.resources }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         {{- end }}
+        {{- if .Values.enableConfigmap }}
         volumeMounts:
         - name: config-volume
           mountPath: /etc/opt/newrelic/
@@ -49,6 +64,7 @@ spec:
         - name: config-volume
           configMap:
             name: {{ template "nri-statsd.fullname" . }}-config
+      {{- end }}
       {{- if $.Values.priorityClassName }}
       priorityClassName: {{ $.Values.priorityClassName }}
       {{- end }}

--- a/charts/nri-statsd/values.yaml
+++ b/charts/nri-statsd/values.yaml
@@ -47,7 +47,7 @@ serviceAccount:
 
 image:
   repository: newrelic/nri-statsd
-  tag: 2.0.0
+  tag: v2.0.1
   ## It is possible to specify docker registry credentials
   ## See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
   # pullSecrets:
@@ -78,3 +78,6 @@ affinity: {}
 # Sends data to staging, can be set as a global.
 # global.nrStaging
 nrStaging: false
+
+# If this is true, use the configmap, else use the generic configuration in the container
+enableConfigmap: true


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
Allows the use of kube secrets for the metrics key

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
