### PR TITLE
[nri-metadata-injection] append random characters to job name

### DIFF
--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to deploy New Relic integrations bundled together
 name: nri-bundle
-version: 2.8.0
+version: 2.8.1
 home: https://github.com/newrelic/helm-charts
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:

--- a/charts/nri-bundle/requirements.lock
+++ b/charts/nri-bundle/requirements.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 1.7.0
 - name: nri-metadata-injection
   repository: file://../nri-metadata-injection
-  version: 1.4.0
+  version: 1.4.1
 - name: kube-state-metrics
   repository: https://kubernetes.github.io/kube-state-metrics
   version: 2.13.2
@@ -17,5 +17,5 @@ dependencies:
 - name: newrelic-logging
   repository: file://../newrelic-logging
   version: 1.4.7
-digest: sha256:fd97710b4f4db5c1d71f4a106d966ee7b8e3c4d3d311acdc6bd9cc1c6b4cb866
-generated: "2021-04-16T16:32:45.741212+02:00"
+digest: sha256:49b8f2a3a554c5bbf3554651b3a9f4c615b2b33487a3aafbbff08746d810f38b
+generated: "2021-04-16T17:00:39.917899+02:00"

--- a/charts/nri-bundle/requirements.yaml
+++ b/charts/nri-bundle/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   - name: nri-metadata-injection
     repository: file://../nri-metadata-injection
     condition: webhook.enabled
-    version: 1.4.0
+    version: 1.4.1
 
   - name: kube-state-metrics
     repository: https://kubernetes.github.io/kube-state-metrics

--- a/charts/nri-metadata-injection/Chart.yaml
+++ b/charts/nri-metadata-injection/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic metadata injection webhook.
 name: nri-metadata-injection
-version: 1.4.0
+version: 1.4.1
 appVersion: 1.4.0
 home: https://hub.docker.com/r/newrelic/k8s-metadata-injection
 sources:

--- a/charts/nri-metadata-injection/templates/job.yaml
+++ b/charts/nri-metadata-injection/templates/job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "nri-metadata-injection.fullname" . }}-job
+  name: {{ template "nri-metadata-injection.fullname" . }}-job-{{ randAlphaNum 6 }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "nri-metadata-injection.labels" . | nindent 4 }}

--- a/charts/nri-metadata-injection/templates/job.yaml
+++ b/charts/nri-metadata-injection/templates/job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "nri-metadata-injection.fullname" . }}-job-{{ randAlphaNum 6 }}
+  name: {{ template "nri-metadata-injection.fullname" . }}-job-{{ randAlphaNum 6 | lower }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "nri-metadata-injection.labels" . | nindent 4 }}


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No

#### What this PR does / why we need it:

This PR appends 6 random alphanumeric characters (considered enough to provide unicity) to the job charged with signing certificates for the metadata injection.

This allows upgrades to proceed smoothly when the image of container ran in the job is updated, which would otherwise fail as the pod inside a job is immutable.

#### Which issue this PR fixes
  - Fixes #248
  - Fixes #280

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
