### PR TITLE
[newrelic-infrastructure] better detection for enableProcessMetrics

### DIFF
--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 2.4.0
+version: 2.4.1
 appVersion: 2.4.0
 home: https://hub.docker.com/r/newrelic/infrastructure-k8s/
 sources:

--- a/charts/newrelic-infrastructure/templates/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/daemonset.yaml
@@ -136,6 +136,7 @@ spec:
             - name: "DISCOVERY_CACHE_TTL"
               value: {{ .Values.discoveryCacheTTL | quote }}
             {{- end }}
+            {{- /* Ugly hack to check if .Values.enableProcessMetrics is defined: */}}
             {{- if ne (print .Values.enableProcessMetrics) "<nil>" }}
             - name: "NRIA_ENABLE_PROCESS_METRICS"
               value: {{ .Values.enableProcessMetrics | quote }}

--- a/charts/newrelic-infrastructure/templates/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/daemonset.yaml
@@ -136,7 +136,7 @@ spec:
             - name: "DISCOVERY_CACHE_TTL"
               value: {{ .Values.discoveryCacheTTL | quote }}
             {{- end }}
-            {{- if ne (print .Values.enableProcessMetrics) "" }}
+            {{- if ne (print .Values.enableProcessMetrics) "<nil>" }}
             - name: "NRIA_ENABLE_PROCESS_METRICS"
               value: {{ .Values.enableProcessMetrics | quote }}
             {{- end }}

--- a/charts/newrelic-infrastructure/templates/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/daemonset.yaml
@@ -136,7 +136,7 @@ spec:
             - name: "DISCOVERY_CACHE_TTL"
               value: {{ .Values.discoveryCacheTTL | quote }}
             {{- end }}
-            {{- if .Values.enableProcessMetrics }}
+            {{- if ne (print .Values.enableProcessMetrics) "" }}
             - name: "NRIA_ENABLE_PROCESS_METRICS"
               value: {{ .Values.enableProcessMetrics | quote }}
             {{- end }}

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to deploy New Relic integrations bundled together
 name: nri-bundle
-version: 2.8.1
+version: 2.8.2
 home: https://github.com/newrelic/helm-charts
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:

--- a/charts/nri-bundle/requirements.lock
+++ b/charts/nri-bundle/requirements.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: newrelic-infrastructure
   repository: file://../newrelic-infrastructure
-  version: 2.4.0
+  version: 2.4.1
 - name: nri-prometheus
   repository: file://../nri-prometheus
   version: 1.7.0
@@ -17,5 +17,5 @@ dependencies:
 - name: newrelic-logging
   repository: file://../newrelic-logging
   version: 1.4.7
-digest: sha256:49b8f2a3a554c5bbf3554651b3a9f4c615b2b33487a3aafbbff08746d810f38b
-generated: "2021-04-16T17:00:39.917899+02:00"
+digest: sha256:d59d7714fa635ce348518f3f475a20238341b33ff971adf1414d8c44655b20eb
+generated: "2021-04-21T17:05:47.762427+02:00"

--- a/charts/nri-bundle/requirements.yaml
+++ b/charts/nri-bundle/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
   - name: newrelic-infrastructure
     repository: file://../newrelic-infrastructure
     condition: infrastructure.enabled
-    version: 2.4.0
+    version: 2.4.1
 
   - name: nri-prometheus
     repository: file://../nri-prometheus


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

Previously, if the user defined `enableProcessMetrics` to `false`, it wouldn't be printed into the template. This could be workarounded by definining it as `"false"` in the values file, but this is not possible from the command line with `--set`.

This PR implements an alternative (and perhaps rather hacky) approach to detect an undefined `.Values.enableProcessMetrics`.

#### Special notes for your reviewer:

Any less hacky solution is welcome.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
