### PR TITLE
add custom interval to scrape metrics

### DIFF
--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 2.4.1
+version: 2.4.2
 appVersion: 2.4.0
 home: https://hub.docker.com/r/newrelic/infrastructure-k8s/
 sources:

--- a/charts/newrelic-infrastructure/README.md
+++ b/charts/newrelic-infrastructure/README.md
@@ -60,7 +60,8 @@ This chart will deploy the New Relic Infrastructure agent as a Daemonset.
 | `openshift.enabled` | Enables OpenShift configuration options. | `false` |
 | `openshift.version` | OpenShift version for witch enable specific configuration options. Values supported ["3.x","4.x"]. For 4.x it includes OpenShift specific Control Plane endpoints and CRI-O runtime |  |
 | `runAsUser` | Set when running in unprivileged mode or when hitting UID constraints in OpenShift. | `1000` |
-| `daemonSet.annotations`   | The annotations to add to the `DaemonSet`.
+| `daemonSet.annotations`   | The annotations to add to the `DaemonSet`.| |
+| `nriKubernetesMetricsInterval` | The metrics interval to send the data to New Relic. | `20` |
 
 > 1: Default value will depend on the creation date of the account owning the specified License Key:
 > * Accounts and subaccounts created before July 20, 2020 will report, by default, process metrics unless this config option is explicitly set to `false`. This is done to respect the old default behavior of the Infrastructure Agent.

--- a/charts/newrelic-infrastructure/templates/configmap.yaml
+++ b/charts/newrelic-infrastructure/templates/configmap.yaml
@@ -24,3 +24,23 @@ data:
 {{ toYaml .data | indent  4 }}
 {{ end }}
 {{ end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "newrelic.labels" . | indent 4 }}
+  name: nri-kubernetes-definition
+data:
+    nri-kubernetes-definition.yml: |
+      name: com.newrelic.kubernetes
+      description: "This New Relic Infrastructure integration collects metrics for your Kubernetes clusters and allows you to alert on them. To learn more, visit: https://docs.newrelic.com/docs/kubernetes-monitoring-integration-beta."
+      protocol_version: 2
+      os: linux
+
+      commands:
+        metrics:
+          command:
+            - ./bin/nri-kubernetes
+            - --metrics
+          interval: {{ .Values.nriKubernetesMetricsInterval }}

--- a/charts/newrelic-infrastructure/templates/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/daemonset.yaml
@@ -208,6 +208,9 @@ spec:
             - mountPath: /var/cache/nr-kubernetes
               name: tmpfs-cache
             {{- end }}
+            - mountPath: /var/db/newrelic-infra/newrelic-integrations/nri-kubernetes-definition.yml
+              name: nri-kubernetes-definition
+              subPath: nri-kubernetes-definition.yml
           {{- if .Values.resources }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
@@ -250,6 +253,9 @@ spec:
             - key: newrelic-infra.yml
               path: newrelic-infra.yml
         {{- end }}
+        - name: nri-kubernetes-definition
+          configMap:
+            name: nri-kubernetes-definition
         {{- if .Values.integrations_config }}
         - name: nri-integrations-cfg-volume
           configMap:

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -240,3 +240,6 @@ useNodeNameAsDisplayName: true
 daemonSet:
   # Annotations to add to the DaemonSet.
   annotations: {}
+
+# scraping internal for NRI Kubernetes
+nriKubernetesMetricsInterval: 20


### PR DESCRIPTION
#### Is this a new chart
No
#### What this PR does / why we need it:
This PR lets us set the interval on nri-kubernetes-definition.yml which can help customize the frequency of the datapoints that are sent to Newrelic.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
