### PR TITLE
[nri-bundle] upgrade nri-metadata-injection to 1.4.2

### DIFF
--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to deploy New Relic integrations bundled together
 name: nri-bundle
-version: 2.9.0
+version: 2.9.1
 home: https://github.com/newrelic/helm-charts
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to deploy New Relic integrations bundled together
 name: nri-bundle
-version: 2.9.1
+version: 2.10.0
 home: https://github.com/newrelic/helm-charts
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:

--- a/charts/nri-bundle/requirements.lock
+++ b/charts/nri-bundle/requirements.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 1.7.0
 - name: nri-metadata-injection
   repository: file://../nri-metadata-injection
-  version: 1.4.1
+  version: 1.4.2
 - name: kube-state-metrics
   repository: https://kubernetes.github.io/kube-state-metrics
   version: 2.13.2
@@ -23,5 +23,5 @@ dependencies:
 - name: pixie-chart
   repository: https://pixie-helm-charts.storage.googleapis.com
   version: 0.7.1
-digest: sha256:730631ee776f91e74ba4253e9164eb53d23c9aa5de7905fbc6e148255935cb65
-generated: "2021-04-27T18:50:28.761395+02:00"
+digest: sha256:b29f9b2b213c1d88b9b2810ba3cf5b1e1e8836612905c769950a291c884d5aea
+generated: "2021-04-29T10:39:44.787575+02:00"

--- a/charts/nri-bundle/requirements.yaml
+++ b/charts/nri-bundle/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   - name: nri-metadata-injection
     repository: file://../nri-metadata-injection
     condition: webhook.enabled
-    version: 1.4.1
+    version: 1.4.2
 
   - name: kube-state-metrics
     repository: https://kubernetes.github.io/kube-state-metrics


### PR DESCRIPTION
this version introduces kube-webhook-certgen as the way to generate webhook certificates

<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No

#### What this PR does / why we need it:

Incorporates kube-webhook-certgen  1.4.2 (#334) into the bundle.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
