### PR TITLE
[nri-bundle] Bump up newrelic-pixie chart to 0.1.0-alpha.2

### DIFF
--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to deploy New Relic integrations bundled together
 name: nri-bundle
-version: 2.10.2
+version: 2.10.3
 home: https://github.com/newrelic/helm-charts
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:

--- a/charts/nri-bundle/requirements.lock
+++ b/charts/nri-bundle/requirements.lock
@@ -19,9 +19,9 @@ dependencies:
   version: 1.4.7
 - name: newrelic-pixie
   repository: file://../newrelic-pixie
-  version: 0.1.0-alpha.1
+  version: 0.1.0-alpha.2
 - name: pixie-chart
   repository: https://pixie-helm-charts.storage.googleapis.com
   version: 0.7.2
-digest: sha256:d0fafdbe7a712aca9d623e1551f96ac0640a91f5050d647a0cb15bb1081b2100
-generated: "2021-04-30T17:48:28.155236+02:00"
+digest: sha256:8ca32d52a10c8b984460f5c137ff29e49372808b3bb2ba3a9cf3287dd2c46199
+generated: "2021-05-04T15:47:38.71887+02:00"

--- a/charts/nri-bundle/requirements.yaml
+++ b/charts/nri-bundle/requirements.yaml
@@ -32,7 +32,7 @@ dependencies:
   - name: newrelic-pixie
     repository: file://../newrelic-pixie
     condition: newrelic-pixie.enabled
-    version: 0.1.0
+    version: 0.1.0-alpha.2
 
   - name: pixie-chart
     repository: https://pixie-helm-charts.storage.googleapis.com


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No.

#### What this PR does / why we need it:
Updates the version of newrelic-pixie chart in the bundle to 0.1.0-alpha.2

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
