### PR TITLE
[newrelic-infrastructure] fix NPD in .Values.global

### DIFF
--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 2.4.2
+version: 2.4.3
 appVersion: 2.4.0
 home: https://hub.docker.com/r/newrelic/infrastructure-k8s/
 sources:

--- a/charts/newrelic-infrastructure/templates/NOTES.txt
+++ b/charts/newrelic-infrastructure/templates/NOTES.txt
@@ -25,7 +25,7 @@ Then run:
 ####  it will be removed in the future, please consider to update the configuration  ####
 
 {{- end -}}
-{{- if and .Values.global.fargate .Values.nodeAffinity }}
+{{- if and (include "newrelic.fargate" .) .Values.nodeAffinity }}
 ###########
 # WARNING #
 ###########

--- a/charts/newrelic-infrastructure/templates/_helpers.tpl
+++ b/charts/newrelic-infrastructure/templates/_helpers.tpl
@@ -140,6 +140,19 @@ Returns nrStaging
 {{- end -}}
 
 {{/*
+Returns fargate
+*/}}
+{{- define "newrelic.fargate" -}}
+{{- if .Values.global }}
+  {{- if .Values.global.fargate }}
+    {{- .Values.global.fargate -}}
+  {{- end -}}
+{{- else if .Values.fargate }}
+  {{- .Values.fargate -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Returns if the template should render, it checks if the required values
 licenseKey and cluster are set.
 */}}

--- a/charts/newrelic-infrastructure/templates/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/daemonset.yaml
@@ -260,7 +260,7 @@ spec:
       {{- if .Values.nodeAffinity }}
       affinity:
         nodeAffinity: {{ .Values.nodeAffinity | toYaml | nindent 10 }}
-      {{- else if .Values.global.fargate }}
+      {{- else if include "newrelic.fargate" . }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Despite being a convention, .Values.global is not automatically initialized to anything. When trying to render this chart alone, attempting to check for truthyness of .Values.global.fargate caused a NPD.
This commit adds a helper similar to newrelic.nrStaging taking care of checking if .Values.global is defined before attempting to deference it.

<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

Nope

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
