### PR TITLE
[nri-bundle] deploy ksm without prometheusScrape labels

### DIFF
--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to deploy New Relic integrations bundled together
 name: nri-bundle
-version: 2.11.1
+version: 2.12.0
 home: https://github.com/newrelic/helm-charts
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:

--- a/charts/nri-bundle/requirements.lock
+++ b/charts/nri-bundle/requirements.lock
@@ -26,5 +26,5 @@ dependencies:
 - name: newrelic-infra-operator
   repository: file://../newrelic-infra-operator
   version: 0.1.0
-digest: sha256:9921eb80658145def09692d13482ae463f6b984fe7a7c58be3a33a817a924d7a
-generated: "2021-05-19T19:05:26.253947+02:00"
+digest: sha256:2d9d0b638bb5300878db2499761ea4d92895e0517b7f0460974913ac2d643ba2
+generated: "2021-05-21T10:35:29.450132+02:00"

--- a/charts/nri-bundle/requirements.yaml
+++ b/charts/nri-bundle/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
   - name: newrelic-infrastructure
     repository: file://../newrelic-infrastructure
     condition: infrastructure.enabled
-    version: 2.4.2
+    version: 2.4.3
 
   - name: nri-prometheus
     repository: file://../nri-prometheus

--- a/charts/nri-bundle/values.yaml
+++ b/charts/nri-bundle/values.yaml
@@ -17,6 +17,8 @@ webhook:
 # enables kube-state-metrics
 ksm:
   enabled: false
+kube-state-metrics:
+  prometheusScrape: false  # Prevent nri-prometheus from scraping KSM, since newrelic-infrastructure already does that
 
 # enables nri-kube-events
 kubeEvents:


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No

#### What this PR does / why we need it:

By default, the Kubernetes wizard will deploy the New Relic solution with `nri-prometheus` turned on, and configured to scrape anything in the cluster with the "prometheus label". Since KSM is also deployed with this label enabled, `nri-prometheus` will attempt to scrape it as well, leading to unnecessary ingest of metrics as KSM is already parsed by `nri-kubernetes`.

This PR disables the prometheus scrape flag of KSM.

#### Special notes for your reviewer:

I'm still testing this, although no wrong side-effects are expected.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
