### PR TITLE
[newrelic-infrastructure] Set integrations_config default value to []

### DIFF
--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 2.4.5
+version: 2.4.6
 appVersion: 2.6.0
 home: https://hub.docker.com/r/newrelic/infrastructure-k8s/
 sources:

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -238,7 +238,7 @@ customAttributes: "'{\"clusterName\":\"$(CLUSTER_NAME)\"}'"
   #             env: test
 # For more details on monitoring services on Kubernetes see
 # https://docs.newrelic.com/docs/integrations/kubernetes-integration/link-apps-services/monitor-services-running-kubernetes
-integrations_config: {}
+integrations_config: []
 
 # Sends data to staging, can be set as a global.
 # global.nrStaging


### PR DESCRIPTION
#### Is this a new chart

No 

#### What this PR does / why we need it:

As we expect an array here, not map and while definiting it as array,
Helm prints the following warning:

coalesce.go:200: warning: cannot overwrite table with non table for
integrations_config (map[])

This PR fixes that.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - Closes #405

#### Special notes for your reviewer:

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
