### PR TITLE
[newrelic-logging] Bump fluent bit output plugin docker image version

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet
 name: newrelic-logging
-version: 1.4.8
-appVersion: 1.4.6
+version: 1.5.0
+appVersion: 1.6.1
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:
@@ -11,6 +11,8 @@ maintainers:
   - name: tejunior
   - name: jodstrcil
   - name: edmocosta
+  - name: Noly
+  - name: danybmx
 keywords:
   - logging
   - newrelic

--- a/charts/newrelic-logging/k8s/new-relic-fluent-plugin.yml
+++ b/charts/newrelic-logging/k8s/new-relic-fluent-plugin.yml
@@ -41,7 +41,7 @@ spec:
               value: "docker"
             - name: PATH
               value: "/var/log/containers/*.log"
-          image: newrelic/newrelic-fluentbit-output:1.4.6
+          image: newrelic/newrelic-fluentbit-output:1.6.1
           command:
             - /fluent-bit/bin/fluent-bit
             - -c


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
This updates the newrelic fluent bit output plugin docker image version from 1.4.6 to 1.6.1 which implies fluent bit 1.8.1 

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
