### PR TITLE
[nri-metadata-injection] adding missing port info

### DIFF
--- a/charts/nri-metadata-injection/Chart.yaml
+++ b/charts/nri-metadata-injection/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic metadata injection webhook.
 name: nri-metadata-injection
-version: 1.5.1
+version: 1.5.2
 appVersion: 1.5.0
 home: https://hub.docker.com/r/newrelic/k8s-metadata-injection
 sources:

--- a/charts/nri-metadata-injection/templates/deployment.yaml
+++ b/charts/nri-metadata-injection/templates/deployment.yaml
@@ -41,6 +41,9 @@ spec:
         env:
         - name: clusterName
           value: {{ include "nri-metadata-injection.cluster" . }}
+        ports:
+          - containerPort: 8443
+            protocol: TCP
         volumeMounts:
         - name: tls-key-cert-pair
           mountPath: /etc/tls-key-cert-pair


### PR DESCRIPTION
Thanks @ghostsquad for noticing that, even if it is only an info it is best practice to add that:
```
RESOURCE: ports <[]Object>
DESCRIPTION:
     List of ports to expose from the container. Exposing a port here gives the
     system additional information about the network connections a container
     uses, but is primarily informational. Not specifying a port here DOES NOT
     prevent that port from being exposed. Any port which is listening on the
     default "0.0.0.0" address inside a container will be accessible from the
     network. Cannot be updated.
```

#### Is this a new chart
no

#### Which issue this PR fixes
  - fixes https://github.com/newrelic/helm-charts/issues/441

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
