### PR TITLE
newrelic-infrastructure: make updateStrategy backwards-compatible

### DIFF
--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 2.6.1
+version: 2.6.2
 appVersion: 2.7.0
 home: https://hub.docker.com/r/newrelic/infrastructure-k8s/
 sources:

--- a/charts/newrelic-infrastructure/templates/_helpers.tpl
+++ b/charts/newrelic-infrastructure/templates/_helpers.tpl
@@ -155,14 +155,17 @@ Returns fargate
 {{/*
 Returns the updateStrategy, either .Values.updateStrategy directly if it is an object, or wrapped if it is a string
 This is done to keep compatibility with old values and --reuse-values.
+Defining updateStrategy as a string is deprecated and will be removed in a future version of the chart.
 */}}
 {{- define "newrelic.updateStrategy" -}}
 {{- if .Values.updateStrategy }}
 {{- if eq "string" (printf "%T" .Values.updateStrategy) }}
 updateStrategy:
   type: {{ .Values.updateStrategy }}
+  {{- if eq .Values.updateStrategy "RollingUpdate" }}
   rollingUpdate:
     maxUnavailable: 1
+  {{- end }}
 {{- else }}
 updateStrategy:
 {{ .Values.updateStrategy | toYaml | indent 2 }}

--- a/charts/newrelic-infrastructure/templates/_helpers.tpl
+++ b/charts/newrelic-infrastructure/templates/_helpers.tpl
@@ -153,6 +153,24 @@ Returns fargate
 {{- end -}}
 
 {{/*
+Returns the updateStrategy, either .Values.updateStrategy directly if it is an object, or wrapped if it is a string
+This is done to keep compatibility with old values and --reuse-values.
+*/}}
+{{- define "newrelic.updateStrategy" -}}
+{{- if .Values.updateStrategy }}
+{{- if eq "string" (printf "%T" .Values.updateStrategy) }}
+updateStrategy:
+  type: {{ .Values.updateStrategy }}
+  rollingUpdate:
+    maxUnavailable: 1
+{{- else }}
+updateStrategy:
+{{ .Values.updateStrategy | toYaml | indent 2 }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Returns if the template should render, it checks if the required values
 licenseKey and cluster are set.
 */}}

--- a/charts/newrelic-infrastructure/templates/daemonset-windows.yaml
+++ b/charts/newrelic-infrastructure/templates/daemonset-windows.yaml
@@ -13,10 +13,7 @@ metadata:
 {{ toYaml  $.Values.daemonSet.annotations | indent 4 }}
   {{- end }}
 spec:
-  updateStrategy:
-    {{- with .Values.updateStrategy }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{ include "newrelic.updateStrategy" . | indent 2 }}
   selector:
     matchLabels:
       app: {{ template "newrelic.name" $ }}

--- a/charts/newrelic-infrastructure/templates/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/daemonset.yaml
@@ -9,10 +9,7 @@ metadata:
   annotations: {{ toYaml .Values.daemonSet.annotations | nindent 4 }}
   {{- end }}
 spec:
-  updateStrategy:
-    {{- with .Values.updateStrategy }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{ include "newrelic.updateStrategy" . | indent 2 }}
   selector:
     matchLabels:
       app: {{ template "newrelic.name" . }}


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No

#### What this PR does / why we need it:

Fixes a regression introduced in #421 which caused upgrade to fail if `--reuse-values` were specified in the CLI.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
