### PR TITLE
[newrelic-pixie] Add proxy configuration for Pixie integration.

### DIFF
--- a/charts/newrelic-pixie/Chart.yaml
+++ b/charts/newrelic-pixie/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the New Relic Pixie integration.
 name: newrelic-pixie
-version: 1.1.0
+version: 1.1.1
 appVersion: 1.1.0
 home: https://hub.docker.com/u/newrelic
 sources:

--- a/charts/newrelic-pixie/README.md
+++ b/charts/newrelic-pixie/README.md
@@ -21,6 +21,7 @@ By default, Pixie is installed in the `pl` namespace.
 | `global.customSecretLicenseKey` - `customSecretLicenseKey` | Key in the existing Secret object, indicated by `customSecretName`, where the New Relic license key is stored.                                                                                                                                                             |                                 |
 | `customSecretApiKeyName` | Name of an existing Secret object, not created by this chart, where the Pixie API key is stored.    |                                 |
 | `customSecretApiKeyKey` | Key in the existing Secret object, indicated by `customSecretApiKeyName`, where the Pixie API key is stored.   |                                 |
+| `proxy` | Set proxy to connect to Pixie Cloud and New Relic. |                                 |
 
 ## Example
 

--- a/charts/newrelic-pixie/templates/deployment.yaml
+++ b/charts/newrelic-pixie/templates/deployment.yaml
@@ -66,6 +66,12 @@ spec:
         - name: PIXIE_ENDPOINT
           value: "staging.withpixie.dev:443"
         {{- end }}
+        {{- if .Values.proxy }}
+        - name: HTTP_PROXY
+          value: "{{ .Values.proxy }}"
+        - name: HTTPS_PROXY
+          value: "{{ .Values.proxy }}"
+        {{- end }}
         {{- if .Values.resources }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/charts/newrelic-pixie/templates/deployment.yaml
+++ b/charts/newrelic-pixie/templates/deployment.yaml
@@ -68,9 +68,9 @@ spec:
         {{- end }}
         {{- if .Values.proxy }}
         - name: HTTP_PROXY
-          value: "{{ .Values.proxy }}"
+          value: {{ .Values.proxy | quote }}
         - name: HTTPS_PROXY
-          value: "{{ .Values.proxy }}"
+          value: {{ .Values.proxy | quote }}
         {{- end }}
         {{- if .Values.resources }}
         resources:

--- a/charts/newrelic-pixie/values.yaml
+++ b/charts/newrelic-pixie/values.yaml
@@ -30,4 +30,3 @@ resources:
     memory: 250M
 
 proxy: {}
-

--- a/charts/newrelic-pixie/values.yaml
+++ b/charts/newrelic-pixie/values.yaml
@@ -28,3 +28,6 @@ resources:
   requests:
     cpu: 100m
     memory: 250M
+
+proxy: {}
+


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
It adds a proxy configuration field to the Pixie integration Helm chart.

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
