### PR TITLE
[synthetics-minion] upgrading authorization API from v1beta1 to v1

### DIFF
--- a/charts/synthetics-minion/Chart.yaml
+++ b/charts/synthetics-minion/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: synthetics-minion
 description: New Relic Synthetics Containerized Private Minion (CPM)
 type: application
-version: 1.0.36
+version: 1.0.38
 appVersion: 3.0.48
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:

--- a/charts/synthetics-minion/templates/role.yml
+++ b/charts/synthetics-minion/templates/role.yml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: synthetics-minion-role

--- a/charts/synthetics-minion/templates/roleBinding.yml
+++ b/charts/synthetics-minion/templates/roleBinding.yml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: synthetics-minion-role-binding


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No
#### What this PR does / why we need it:
This PR updates which Authorization API the synthetics-minion uses to v1 from v1beta1.
#### Which issue this PR fixes
Fixes customer issues where they can't build the CPM with K8s v1.22

#### Special notes for your reviewer:
Thank you!

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
