### PR TITLE
[newrelic-logging] Update newrelic-logging to appVersion 1.8.0 to support multiarchitecture image

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet
 name: newrelic-logging
-version: 1.5.0
-appVersion: 1.6.1
+version: 1.6.0
+appVersion: 1.8.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
Updates the `newrelic-logging` Helm chart to use the `1.8.0` version of the image, which adds support for multiarchitecture images.

#### Which issue this PR fixes
* Adds support for multiarchitecture images by using the latest 1.8.0 image version (appVersion)

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
