### PR TITLE
[nri-bundle] Update newrelic-pixie to the latest version

### DIFF
--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to deploy New Relic integrations bundled together
 name: nri-bundle
-version: 2.18.0
+version: 2.19.0
 home: https://github.com/newrelic/helm-charts
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:

--- a/charts/nri-bundle/requirements.lock
+++ b/charts/nri-bundle/requirements.lock
@@ -19,12 +19,12 @@ dependencies:
   version: 1.6.0
 - name: newrelic-pixie
   repository: file://../newrelic-pixie
-  version: 1.1.1
+  version: 1.2.0
 - name: pixie-operator-helm2-chart
   repository: https://pixie-operator-charts.storage.googleapis.com
   version: 0.0.5
 - name: newrelic-infra-operator
   repository: file://../newrelic-infra-operator
   version: 0.1.1
-digest: sha256:01775a7fa05fca27b437121d70f2fab31df6041b57fc3c0d83f90158b4bf6f6c
-generated: "2021-08-20T14:55:45.613292+02:00"
+digest: sha256:596e0b003d4445ff00e8ca5e94920ca3d6a4d7b9b93d17f23ecf39ee70203d19
+generated: "2021-08-24T14:19:31.262264+02:00"

--- a/charts/nri-bundle/requirements.yaml
+++ b/charts/nri-bundle/requirements.yaml
@@ -32,7 +32,7 @@ dependencies:
   - name: newrelic-pixie
     repository: file://../newrelic-pixie
     condition: newrelic-pixie.enabled
-    version: 1.1.1
+    version: 1.2.0
 
   - name: pixie-operator-helm2-chart
     alias: pixie-chart


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
Bump the nri-bundle chart to the latest version of the newrelic-integration chart version.

#### Which issue this PR fixes
* Trace database request on the client side only.

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
