### PR TITLE
renovate: run helm dependency update after bumping dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,11 @@
     "config:base"
   ],
   "bumpVersion": "patch",
+  "postUpgradeTasks": {
+    "commands": ["helm dependency update"],
+    "fileFilters": ["Chart.*", "requirements.*"],
+    "executionMode": "update"
+  },
   "packageRules": [
     {
       // Group all GHA bumps together in a single PR.


### PR DESCRIPTION
This should update the requirements.lock (and/or Chart.lock) files with updated checksums
