### PR TITLE
renovate: disable bumping requirements as renovate does not support updating lockfile

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,13 @@
     "config:base"
   ],
   "bumpVersion": "patch",
+  "enabledManagers": [
+    "helm-values",
+    "helmv3",
+    // Disable helm-requirements as it bumps requirements.yaml but _not_ requirements.lock, breaking CI workflow.
+    // helmv3 manager should be able to bump Chart.lock, so hopefully we should be fine once we upgrade to Helm 3.
+    // "helm-requirements"
+  ],
   "packageRules": [
     {
       // Group all GHA bumps together in a single PR.


### PR DESCRIPTION
Seems like the `helm-requirements` module for Renovate does not support updating the `requirements.lock` file, which our CI and workflow requires.

This PR disables that feature to avoid noise.

Docker image bumping should still work, although might require manual intevention.

Theoretically this should not be a problem with the Helm v3 module.