### PR TITLE
[newrelic-logging] Update version in logging K8s manifest to 1.8.0

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet
 name: newrelic-logging
-version: 1.6.0
+version: 1.6.1
 appVersion: 1.8.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/k8s/new-relic-fluent-plugin.yml
+++ b/charts/newrelic-logging/k8s/new-relic-fluent-plugin.yml
@@ -41,7 +41,7 @@ spec:
               value: "docker"
             - name: PATH
               value: "/var/log/containers/*.log"
-          image: newrelic/newrelic-fluentbit-output:1.6.1
+          image: newrelic/newrelic-fluentbit-output:1.8.0
           command:
             - /fluent-bit/bin/fluent-bit
             - -c


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
Updates docker image version in newrelic-logging K8s manifest (not in the Helm chart, just the raw manifests). There is no need to bump the chart version due to this commit, since it doesn't affect the Helm chart at all.

#### Which issue this PR fixes
- Updates version in logging K8s manifest.

#### Special notes for your reviewer: There is no need to bump the chart version due to this commit, since it doesn't affect the Helm chart at all.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
