### PR TITLE
ci: prevent concurrent releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+# Prevent two release workflows from running concurrently, which might cause WAR race conditions in the repository
+# Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
+concurrency: helm-release
+
 jobs:
   # Sometimes chart-releaser might fetch an outdated index.yaml from gh-pages, causing a WAW hazard on the repo
   # This job checks the remote file is up to date with the local one on release


### PR DESCRIPTION
Previously, merging two PRs to `master` at the same time (or very close in time) might cause two `Release` workflows to trigger in parallel. Since the release is done by pushing to the `gh-pages` branch, which is shared, a write-after-read race might occur, resulting in one of the releases failing or overwriting the other one.

This PR sets the `concurrency` key of the release workflow to instruct GHA to allow only one parallel run of said workflow.