### PR TITLE
newrelic-infrastructure: fix use of updateStrategy in daemonset-windows

### DIFF
--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 2.6.2
+version: 2.6.3
 appVersion: 2.7.0
 home: https://hub.docker.com/r/newrelic/infrastructure-k8s/
 sources:

--- a/charts/newrelic-infrastructure/templates/daemonset-windows.yaml
+++ b/charts/newrelic-infrastructure/templates/daemonset-windows.yaml
@@ -1,4 +1,4 @@
-{{- if and (include "newrelic.areValuesValid" $)  $.Values.enableWindows }}
+{{- if and (include "newrelic.areValuesValid" .)  .Values.enableWindows }}
 {{- range .Values.windowsOsList }}
 apiVersion: apps/v1
 kind: DaemonSet
@@ -13,7 +13,7 @@ metadata:
 {{ toYaml  $.Values.daemonSet.annotations | indent 4 }}
   {{- end }}
 spec:
-  {{ include "newrelic.updateStrategy" . | indent 2 }}
+  {{ include "newrelic.updateStrategy" $ | indent 2 }}
   selector:
     matchLabels:
       app: {{ template "newrelic.name" $ }}


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

Fixes an error where the `updateStrategy` helper was not being called with the right argument in the daemonset-windows template.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
