### PR TITLE
[newrelic-pixie] Introducing low data mode & bump to v1.4.0

### DIFF
--- a/charts/newrelic-pixie/Chart.yaml
+++ b/charts/newrelic-pixie/Chart.yaml
@@ -9,9 +9,11 @@ sources:
 engine: gotpl
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:
-  - name: paologallinaharbur
-  - name: davidbrota
+  - name: alvarocabanas
+  - name: carlossscastro
   - name: gsanchezgavier
+  - name: kang-makes
+  - name: paologallinaharbur
   - name: roobre
 keywords:
   - newrelic

--- a/charts/newrelic-pixie/Chart.yaml
+++ b/charts/newrelic-pixie/Chart.yaml
@@ -1,15 +1,18 @@
 apiVersion: v1
 description: A Helm chart for the New Relic Pixie integration.
 name: newrelic-pixie
-version: 1.3.2
-appVersion: 1.3.0
+version: 1.4.0
+appVersion: 1.4.0
 home: https://hub.docker.com/u/newrelic
 sources:
   - https://github.com/newrelic/
 engine: gotpl
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:
-  - name: douglascamata
+  - name: paologallinaharbur
+  - name: davidbrota
+  - name: gsanchezgavier
+  - name: roobre
 keywords:
   - newrelic
   - pixie

--- a/charts/newrelic-pixie/README.md
+++ b/charts/newrelic-pixie/README.md
@@ -14,6 +14,7 @@ By default, Pixie is installed in the `pl` namespace.
 | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
 | `global.cluster` - `cluster`                               | The cluster name for the Kubernetes cluster. Required.                                                                                                                                             |                       |
 | `global.licenseKey` - `licenseKey`                         | The New Relic license key (stored in a secret). Required.                                                                                                                                          |                       |
+| `global.lowDataMode` - `lowDataMode`                       | If `true`, the integration performs heavier sampling on the Pixie span data and sets the collect interval to 15 seconds instead of 10 seconds.                                                     | false                 |
 | `global.nrStaging` - `nrStaging`                           | Send data to staging (requires a staging license key).                                                                                                                                             | false                 |
 | `apiKey`                                                   | The Pixie API key (stored in a secret). Required.                                                                                                                                                  |                       |
 | `verbose`                                                  | Whether the integration should run in verbose mode or not.                                                                                                                                         | false                 |
@@ -57,6 +58,7 @@ More information on globals and subcharts can be found at [Helm's official docum
 | `global.licenseKey`             |
 | `global.customSecretName`       |
 | `global.customSecretLicenseKey` |
+| `global.lowDataMode`            |
 | `global.nrStaging`              |
 
 ## Resources

--- a/charts/newrelic-pixie/templates/_helpers.tpl
+++ b/charts/newrelic-pixie/templates/_helpers.tpl
@@ -83,6 +83,19 @@ release: {{.Release.Name }}
 {{- end -}}
 
 {{/*
+Returns lowDataMode
+*/}}
+{{- define "newrelic-pixie.lowDataMode" -}}
+{{- if .Values.global }}
+  {{- if .Values.global.lowDataMode }}
+    {{- .Values.global.lowDataMode -}}
+  {{- end -}}
+{{- else if .Values.lowDataMode }}
+  {{- .Values.lowDataMode -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the customSecretName where the New Relic license is being stored.
 */}}
 {{- define "newrelic-pixie.customSecretName" -}}

--- a/charts/newrelic-pixie/templates/deployment.yaml
+++ b/charts/newrelic-pixie/templates/deployment.yaml
@@ -58,6 +58,14 @@ spec:
         - name: VERBOSE
           value: "true"
         {{- end }}
+        {{- if (include "newrelic-pixie.lowDataMode" .) }}
+        - name: COLLECT_INTERVAL_SEC
+          value: "15"
+        - name: HTTP_SPAN_LIMIT
+          value: "750"
+        - name: DB_SPAN_LIMIT
+          value: "250"
+        {{- end }}
         {{- if (include "newrelic-pixie.nrStaging" .) }}
         - name: NR_OTLP_HOST
           value: "staging-otlp.nr-data.net:4317"

--- a/charts/newrelic-pixie/values.yaml
+++ b/charts/newrelic-pixie/values.yaml
@@ -39,3 +39,8 @@ affinity: {}
 
 excludeNamespacesRegex:
 excludePodsRegex:
+
+# When low data mode is enabled the integration performs heavier sampling on the Pixie span data
+# and sets the collect interval to 15 seconds instead of 10 seconds.
+# Can be set as a global: global.lowDataMode
+lowDataMode: false


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
* Bump the Pixie integration version to 1.4.0
* Introduces low data mode

#### Which issue this PR fixes
* Communication to Pixie now uses end-to-end encryption
* OTLP protobuf updated to v0.9.0

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
