### PR TITLE
nri-bundle: Add Kubernetes 1.22 support

### DIFF
--- a/charts/newrelic-infra-operator/Chart.yaml
+++ b/charts/newrelic-infra-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Kubernetes Operator.
 name: newrelic-infra-operator
-version: 0.1.3
-appVersion: 0.4.0
+version: 0.2.0
+appVersion: 0.5.0
 home: https://hub.docker.com/r/newrelic/newrelic-infra-operator
 sources:
   - https://github.com/newrelic/newrelic-infra-operator

--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 2.6.4
-appVersion: 2.7.1
+version: 2.7.0
+appVersion: 2.8.1
 home: https://hub.docker.com/r/newrelic/infrastructure-k8s/
 sources:
   - https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-infrastructure

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to deploy New Relic integrations bundled together
 name: nri-bundle
-version: 2.23.0
+version: 3.0.0
 home: https://github.com/newrelic/helm-charts
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:

--- a/charts/nri-bundle/requirements.lock
+++ b/charts/nri-bundle/requirements.lock
@@ -1,22 +1,22 @@
 dependencies:
 - name: newrelic-infrastructure
   repository: file://../newrelic-infrastructure
-  version: 2.6.4
+  version: 2.7.0
 - name: nri-prometheus
   repository: file://../nri-prometheus
-  version: 1.9.0
+  version: 1.10.0
 - name: nri-metadata-injection
   repository: file://../nri-metadata-injection
-  version: 1.5.4
+  version: 2.0.0
 - name: kube-state-metrics
   repository: https://kubernetes.github.io/kube-state-metrics
   version: 2.13.2
 - name: nri-kube-events
   repository: file://../nri-kube-events
-  version: 1.9.5
+  version: 1.10.0
 - name: newrelic-logging
   repository: file://../newrelic-logging
-  version: 1.8.0
+  version: 1.10.0
 - name: newrelic-pixie
   repository: file://../newrelic-pixie
   version: 1.4.0
@@ -25,6 +25,6 @@ dependencies:
   version: 0.0.10
 - name: newrelic-infra-operator
   repository: file://../newrelic-infra-operator
-  version: 0.1.2
-digest: sha256:f98952f4c28bc2f2f29c573fcfc264ddf5a6f12fa508d4ad9fc23742ecf4fa90
-generated: "2021-09-27T10:45:30.575114+02:00"
+  version: 0.2.0
+digest: sha256:d879bc52a0f79ea262b896e556f1caa43e147525dc17c84f68cbf1e67c3f23df
+generated: "2021-09-29T16:16:33.088048+02:00"

--- a/charts/nri-bundle/requirements.yaml
+++ b/charts/nri-bundle/requirements.yaml
@@ -2,17 +2,17 @@ dependencies:
   - name: newrelic-infrastructure
     repository: file://../newrelic-infrastructure
     condition: infrastructure.enabled
-    version: 2.6.4
+    version: 2.7.0
 
   - name: nri-prometheus
     repository: file://../nri-prometheus
     condition: prometheus.enabled
-    version: 1.9.0
+    version: 1.10.0
 
   - name: nri-metadata-injection
     repository: file://../nri-metadata-injection
     condition: webhook.enabled
-    version: 1.5.4
+    version: 2.0.0
 
   - name: kube-state-metrics
     repository: https://kubernetes.github.io/kube-state-metrics
@@ -22,12 +22,12 @@ dependencies:
   - name: nri-kube-events
     repository: file://../nri-kube-events
     condition: kubeEvents.enabled
-    version: 1.9.5
+    version: 1.10.0
 
   - name: newrelic-logging
     repository: file://../newrelic-logging
     condition: logging.enabled
-    version: 1.8.0
+    version: 1.10.0
 
   - name: newrelic-pixie
     repository: file://../newrelic-pixie
@@ -43,4 +43,4 @@ dependencies:
   - name: newrelic-infra-operator
     repository: file://../newrelic-infra-operator
     condition: newrelic-infra-operator.enabled
-    version: 0.1.2
+    version: 0.2.0

--- a/charts/nri-kube-events/Chart.yaml
+++ b/charts/nri-kube-events/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Kube Events
 name: nri-kube-events
-version: 1.9.5
-appVersion: 1.5.1
+version: 1.10.0
+appVersion: 1.6.0
 engine: gotpl
 home: https://docs.newrelic.com/docs/integrations/kubernetes-integration/kubernetes-events/install-kubernetes-events-integration
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/nri-metadata-injection/Chart.yaml
+++ b/charts/nri-metadata-injection/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic metadata injection webhook.
 name: nri-metadata-injection
-version: 1.5.4
-appVersion: 1.5.0
+version: 2.0.0
+appVersion: 1.6.0
 home: https://hub.docker.com/r/newrelic/k8s-metadata-injection
 sources:
   - https://github.com/newrelic/k8s-metadata-injection

--- a/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/clusterrole.yaml
+++ b/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/clusterrole.yaml
@@ -17,12 +17,7 @@ rules:
     verbs:
       - get
       - update
-{{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
-{{- if semverCompare "> 1.15.0-0" $kubeTargetVersion }}
   - apiGroups: ['policy']
-{{- else }}
-  - apiGroups: ['extensions']
-{{- end }}
     resources: ['podsecuritypolicies']
     verbs: ['use']
     resourceNames:

--- a/charts/nri-metadata-injection/templates/admission-webhooks/mutatingWebhookConfiguration.yaml
+++ b/charts/nri-metadata-injection/templates/admission-webhooks/mutatingWebhookConfiguration.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ template "nri-metadata-injection.fullname" . }}
@@ -30,6 +30,8 @@ webhooks:
       newrelic-metadata-injection: enabled
 {{- end }}
   failurePolicy: Ignore
-{{ if (gt (.Capabilities.KubeVersion.Minor | atoi) 14) }}
   timeoutSeconds: {{ .Values.timeoutSeconds }}
-{{- end }}
+  sideEffects: None
+  admissionReviewVersions:
+  - v1beta1
+  - v1

--- a/charts/nri-metadata-injection/values.yaml
+++ b/charts/nri-metadata-injection/values.yaml
@@ -16,8 +16,8 @@ image:
     # - name: regsecret
 
 jobImage:
-  repository: jettech/kube-webhook-certgen
-  tag: v1.5.0
+  repository: k8s.gcr.io/ingress-nginx/kube-webhook-certgen
+  tag: v1.0
   pullPolicy: IfNotPresent
   # Volume mounts to add to the job, you might want to mount tmp if Pod Security Policies
   # Enforce a read-only root.

--- a/charts/nri-prometheus/Chart.yaml
+++ b/charts/nri-prometheus/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 2.7.0
+appVersion: 2.9.0
 description: A Helm chart to deploy the New Relic Prometheus OpenMetrics integration
 name: nri-prometheus
-version: 1.9.0
+version: 1.10.0
 engine: gotpl
 home: https://github.com/newrelic/nri-prometheus
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg


### PR DESCRIPTION
#### ⚠️ Breaking changes ⚠️ 

This PR *introduces Kubernetes 1.22.x* support for the New Relic Kuberentes solution, and *removes support for kubernetes 1.15.x and below*.

Users may still use previous versions of the `nri-bundle` and other charts to instrument their clusters, and limited support will be offered for them. Development for said older versions is considered stopped and New Relic does guarantee feature parity or bugfixes (security or otherwise) for those older versions.

#### Is this a new chart

No

#### What this PR does / why we need it:

Bumps versions in individual charts and the bundle to point to the latest released versions of all Kubernetes components, which include support for Kubernetes 1.22.

Additionally, some changes to the charts themselves are also included to make them compatible with said version.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped

Includes changes from #468 