### PR TITLE
Revert "newrelic-logging: mount host's /var as read only (#472)"

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.8.0
+version: 1.10.0
 appVersion: 1.10.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.9.0
+version: 1.8.0
 appVersion: 1.10.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/templates/daemonset.yaml
+++ b/charts/newrelic-logging/templates/daemonset.yaml
@@ -99,7 +99,6 @@ spec:
               mountPath: /fluent-bit/etc
             - name: var
               mountPath: /var
-              readOnly: true
           {{- if .Values.resources }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
@@ -111,7 +110,6 @@ spec:
         - name: var
           hostPath:
             path: /var
-            type: Directory
       {{- if $.Values.priorityClassName }}
       priorityClassName: {{ $.Values.priorityClassName }}
       {{- end }}


### PR DESCRIPTION
It seems like FluentBit will refuse to start up if it cannot create a database in `/var/log/flb_kube.db`.

![image](https://user-images.githubusercontent.com/969721/135277688-6c700be2-399c-4a55-a511-735fdff839e1.png)

This reverts commit 47a199872643602337fe05a94cb037d912812199.
