### PR TITLE
wip: otel-k8s-prometheus: add chart

### DIFF
--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to deploy New Relic integrations bundled together
 name: nri-bundle
-version: 3.2.7
+version: 3.3.0
 home: https://github.com/newrelic/helm-charts
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:

--- a/charts/nri-bundle/requirements.lock
+++ b/charts/nri-bundle/requirements.lock
@@ -29,5 +29,8 @@ dependencies:
 - name: newrelic-infra-operator
   repository: file://../newrelic-infra-operator
   version: 0.4.0
-digest: sha256:1ae3c45e3f0f8595eddc40ebdd7fd2ed0e6204d56ef0e5e5ede316da3b2d554d
-generated: "2021-11-11T11:22:18.246987+01:00"
+- name: otel-k8s-prometheus
+  repository: file://../otel-k8s-prometheus
+  version: 0.1.0
+digest: sha256:7641aa2fa9780860ec73753570ab4eb5bdb100c3dede19716bf14ae7c7195034
+generated: "2021-11-11T16:51:23.290373+01:00"

--- a/charts/nri-bundle/requirements.yaml
+++ b/charts/nri-bundle/requirements.yaml
@@ -49,3 +49,8 @@ dependencies:
     repository: file://../newrelic-infra-operator
     condition: newrelic-infra-operator.enabled
     version: 0.4.0
+
+  - name: otel-k8s-prometheus
+    repository: file://../otel-k8s-prometheus
+    condition: otel-k8s-prometheus.enabled
+    version: 0.1.0

--- a/charts/nri-bundle/values.yaml
+++ b/charts/nri-bundle/values.yaml
@@ -25,6 +25,9 @@ webhook:
 # enables kube-state-metrics
 ksm:
   enabled: false
+# Remove prometheus.io/scrape annotation from bundled KSM deployment
+kube-state-metrics:
+  prometheusScrape: false
 
 # enables nri-kube-events
 kubeEvents:

--- a/charts/nri-bundle/values.yaml
+++ b/charts/nri-bundle/values.yaml
@@ -10,6 +10,14 @@ infrastructure:
 prometheus:
   enabled: false
 
+otel-k8s-prometheus:
+  enabled: false
+  config:
+    nrConventionsProcessors:
+      enabled: true
+    otlpExporter:
+      enabled: true
+
 # enables nri-metadata-injection
 webhook:
   enabled: true

--- a/charts/otel-k8s-prometheus/.helmignore
+++ b/charts/otel-k8s-prometheus/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/otel-k8s-prometheus/Chart.yaml
+++ b/charts/otel-k8s-prometheus/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: otel-k8s-prometheus
+description: A chart to scrape prometheus endpoints using the opentelemetry collector
+maintainers:
+  - name: roobre
+type: application
+
+version: 0.1.0
+appVersion: "0.38.0"

--- a/charts/otel-k8s-prometheus/README.md
+++ b/charts/otel-k8s-prometheus/README.md
@@ -1,0 +1,38 @@
+# otel-k8s-prometheus
+
+## Chart Details
+
+This chart deploys the [OpenTelemetry collector](https://github.com/open-telemetry/opentelemetry-collector-contrib)
+preconfigured to scrape prometheus endpoints from a Kubernetes cluster.
+
+Reasonable flexibility is offered to add extra processors, and change the labels or annotations that are used to
+identify prometheus endpoints, filter metrics, etc.
+
+## Configuration
+
+Most relevant values for the chart are listed below. For a complete list, please check the `values.yml` file.
+
+| Parameter                                                                       | Description                                                                                                                                                                                                                                                                                                                                 | Default                                                                                              |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `global.cluster` - `cluster` | The cluster name for the Kubernetes cluster.                                                                                                                                                                                                                                                                                                |                                                                                                      |
+| `global.licenseKey` - `licenseKey` | The [license key](https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/license-key) for your New Relic Account. This will be preferred configuration option if both `licenseKey` and `customSecret` are specified.                                                                                                       |                                                                                                      |
+| `global.customSecretName` - `customSecretName` | Instead of creating a secret with the License Key above, read it from this externally created one |  |
+| `global.customSecretLicenseKey` - `customSecretLicenseKey` | Key holding the License Key in the secret defined above |  |
+| `config.labels` | List of labels used to identify pods or services that export prometheus metrics | `prometheus.io/scrape` |
+| `config.annotations` | List of annotations used to identify pods or services that export prometheus metrics | `prometheus.io/scrape` |
+| `config.interval` | Interval at which metrics will be scraped and pushed | `30s` |
+| `config.jobs.podsEndpoints.enabled` | Whether to scrape annotated pods and endpoints behind annotated services. | `true` |
+| `config.jobs.headless.enabled` | Whether to scrape annotated headless services. | `true` |
+| `config.extraScrapeConfigs` | List of [Prometheus server `scrape_config`s](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config) to add to the two jobs above. | `[]` |
+| `config.extraProcessors` | Additional [otelcol processors](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor) to use in the pipeline. | `{}` |
+| `config.otlpExporter` | Config for the OTLP exporter. |  |
+
+## Example
+
+Make sure you have [added the New Relic chart repository.](../../README.md#install)
+
+Then, to install this chart, run the following command:
+
+```sh
+helm upgrade --install [release-name] newrelic/otel-k8s-prometheus --set cluster=my_cluster_name --set licenseKey=[your-license-key]
+```

--- a/charts/otel-k8s-prometheus/ci/test-values.yaml
+++ b/charts/otel-k8s-prometheus/ci/test-values.yaml
@@ -1,0 +1,3 @@
+global:
+  licenseKey: 1234567890abcdef1234567890abcdef12345678
+  cluster: test-cluster

--- a/charts/otel-k8s-prometheus/templates/_helpers.tpl
+++ b/charts/otel-k8s-prometheus/templates/_helpers.tpl
@@ -1,0 +1,135 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "otel-k8s-prometheus.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "otel-k8s-prometheus.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "otel-k8s-prometheus.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "otel-k8s-prometheus.labels" -}}
+helm.sh/chart: {{ include "otel-k8s-prometheus.chart" . }}
+{{ include "otel-k8s-prometheus.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "otel-k8s-prometheus.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "otel-k8s-prometheus.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "otel-k8s-prometheus.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "otel-k8s-prometheus.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the cluster name
+*/}}
+{{- define "newrelic.clusterGlobal" -}}
+{{- if .Values.cluster -}}
+  {{- .Values.cluster -}}
+{{- else if .Values.global -}}
+  {{- if .Values.global.cluster -}}
+    {{- .Values.global.cluster -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the cluster name
+*/}}
+{{- define "newrelic.cluster" -}}
+{{ include "newrelic.clusterGlobal" . | default (include "otel-k8s-prometheus.fullname" . ) }}
+{{- end -}}
+
+{{/*
+Return local licenseKey if set, global otherwise
+*/}}
+{{- define "newrelic.licenseKey" -}}
+{{- if .Values.licenseKey -}}
+  {{- .Values.licenseKey -}}
+{{- else if .Values.global -}}
+  {{- if .Values.global.licenseKey -}}
+    {{- .Values.global.licenseKey -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the name of the secret holding the License Key
+*/}}
+{{- define "newrelic.licenseCustomSecretName" -}}
+{{- if .Values.customSecretName -}}
+  {{- .Values.customSecretName -}}
+{{- else if and .Values.global -}}
+  {{- if .Values.global.customSecretName -}}
+    {{- .Values.global.customSecretName -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the name of the secret holding the License Key
+*/}}
+{{- define "newrelic.licenseSecretName" -}}
+{{ include "newrelic.licenseCustomSecretName" . | default (printf "%s-license" (include "otel-k8s-prometheus.fullname" . )) }}
+{{- end -}}
+
+{{/*
+Return the name key for the License Key inside the secret
+*/}}
+{{- define "newrelic.licenseCustomSecretKey" -}}
+{{- if .Values.customSecretLicenseKey -}}
+  {{- .Values.customSecretLicenseKey -}}
+{{- else if .Values.global -}}
+  {{- if .Values.global.customSecretLicenseKey }}
+    {{- .Values.global.customSecretLicenseKey -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the name key for the License Key inside the secret
+*/}}
+{{- define "newrelic.licenseSecretKey" -}}
+{{ include "newrelic.licenseCustomSecretKey" . | default "licenseKey" }}
+{{- end -}}

--- a/charts/otel-k8s-prometheus/templates/configmap.yaml
+++ b/charts/otel-k8s-prometheus/templates/configmap.yaml
@@ -52,22 +52,24 @@ data:
     {{- if .batchProcessor.enabled }}
       batch: {}
     {{- end }}
-    {{- if .nrConventionsProcessor.enabled }}
+    {{- if .nrConventionsProcessors.enabled }}
+      resource/nrConventions:
+        attributes:
+          # Rename service.name, which is actually the prometheus job name, and will confuse NR pipeline
+          - action: insert
+            key: otelmeta.service.name
+            from_attribute: service.name
+          - action: delete
+            key: service.name
+          - action: insert
+            key: k8s.cluster.name
+            value: ${NR_CLUSTER_NAME}
       metricstransform/nrConventions:
         transforms:
           - include: ".*"
             match_type: regexp
             action: update
             operations:
-              - action: add_label
-                new_label: k8s.cluster.name
-                new_value: ${NR_CLUSTER_NAME}
-
-              # TODO: This one is not working, unsure why
-              - action: update_label
-                label: service.name
-                new_label: otelmeta.service.name
-
               # K8s labels
               - action: update_label
                 label: kubernetes_pod_name
@@ -126,7 +128,8 @@ data:
             {{- if .batchProcessor.enabled }}
             - batch
             {{- end }}
-            {{- if .nrConventionsProcessor.enabled }}
+            {{- if .nrConventionsProcessors.enabled }}
+            - resource/nrConventions
             - metricstransform/nrConventions
             {{- end }}
             {{- range $processor, $_ := .extraProcessors }}

--- a/charts/otel-k8s-prometheus/templates/configmap.yaml
+++ b/charts/otel-k8s-prometheus/templates/configmap.yaml
@@ -23,7 +23,7 @@ data:
                 - role: pod
               relabel_configs:
                 # K8s scrape labels and transformations
-                {{- include "newrelic.prometheusOtelRelabel" $.Values.config | nindent 16 }}
+                {{- include "newrelic.prometheusOtelRelabel" $.Values | nindent 16 }}
                 # Use replace labels to support prometheus.io/port and prometheus.io/path annotations.
                 - source_labels: [ __address__, __meta_kubernetes_pod_annotation_prometheus_io_port ]
                   action: replace
@@ -61,7 +61,7 @@ data:
                   regex: ".+"
                   action: keep
                 # K8s scrape labels and transformations
-                {{- include "newrelic.prometheusOtelRelabel" $.Values.config | nindent 16 }}
+                {{- include "newrelic.prometheusOtelRelabel" $.Values | nindent 16 }}
           {{- end }}
           {{- end }}
 

--- a/charts/otel-k8s-prometheus/templates/configmap.yaml
+++ b/charts/otel-k8s-prometheus/templates/configmap.yaml
@@ -61,8 +61,13 @@ data:
             from_attribute: service.name
           - action: delete
             key: service.name
+          # Cluster name
           - action: insert
             key: k8s.cluster.name
+            value: ${NR_CLUSTER_NAME}
+          # Legacy cluster name attribute
+          - action: insert
+            key: clusterName
             value: ${NR_CLUSTER_NAME}
       metricstransform/nrConventions:
         transforms:

--- a/charts/otel-k8s-prometheus/templates/configmap.yaml
+++ b/charts/otel-k8s-prometheus/templates/configmap.yaml
@@ -1,0 +1,148 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "otel-k8s-prometheus.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "otel-k8s-prometheus.labels" . | nindent 4 }}
+data:
+  otel-prometheus-config.yaml: |
+  {{- with .Values.config }}
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+          {{- with .jobs.podsEndpoints }}
+          {{- if .enabled }}
+            - job_name: {{ include "otel-k8s-prometheus.name" $ | include "toPrometheus" }}_pods_endpoints
+              scrape_interval: {{ $.Values.config.interval }}
+              kubernetes_sd_configs:
+                # Attempt to scrape endpoints (pods behind annotated services)
+                - role: endpoints
+                # And also pods that are annotated directly and are not behind a service
+                - role: pod
+              relabel_configs:
+                # K8s scrape labels and transformations
+                {{- include "newrelic.prometheusOtelRelabel" $.Values.config | nindent 16 }}
+          {{- end }}
+          {{- end }}
+
+          {{- with .jobs.external }}
+          {{- if .enabled }}
+            - job_name: {{ include "otel-k8s-prometheus.name" $ | include "toPrometheus" }}_external
+              scrape_interval: {{ $.Values.config.interval }}
+              kubernetes_sd_configs:
+                - role: service
+              relabel_configs:
+                # Drop targets that are not services with an externalName
+                - source_labels:
+                  - __meta_kubernetes_service_external_name
+                  regex: ".+"
+                  action: keep
+                # K8s scrape labels and transformations
+                {{- include "newrelic.prometheusOtelRelabel" $.Values.config | nindent 16 }}
+          {{- end }}
+          {{- end }}
+
+          {{- with .extraScrapeConfigs }}
+          {{- . | toYaml | nindent 12 }}
+          {{- end }}
+
+    processors:
+    {{- if .batchProcessor.enabled }}
+      batch: {}
+    {{- end }}
+    {{- if .nrConventionsProcessor.enabled }}
+      metricstransform/nrConventions:
+        transforms:
+          - include: ".*"
+            match_type: regexp
+            action: update
+            operations:
+              - action: add_label
+                new_label: k8s.cluster.name
+                new_value: ${NR_CLUSTER_NAME}
+
+              # TODO: This one is not working, unsure why
+              - action: update_label
+                label: service.name
+                new_label: otelmeta.service.name
+
+              # K8s labels
+              - action: update_label
+                label: kubernetes_pod_name
+                new_label: k8s.pod.name
+              - action: update_label
+                label: kubernetes_namespace
+                new_label: k8s.namespace
+              - action: update_label
+                label: kubernetes_pod_container_name
+                new_label: k8s.pod.container.name
+              - action: update_label
+                label: kubernetes_pod_node_name
+                new_label: k8s.pod.node.name
+              - action: update_label
+                label: kubernetes_service_name
+                new_label: k8s.service.name
+    {{- end }}
+    {{- with .extraProcessors }}
+      {{- . | toYaml | nindent 6 }}
+    {{- end }}
+
+    exporters:
+      {{- with .otlpExporter }}
+      {{- if .enabled }}
+      otlp:
+        {{- omit . "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      {{- end }}
+      {{- with .loggingExporter }}
+      {{- if .enabled }}
+      logging:
+        {{- omit . "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      {{- end }}
+      {{- with $.Values.service.prometheusDebug }}
+      {{- if .enabled }}
+      prometheus:
+        endpoint: ":9000"
+        resource_to_telemetry_conversion:
+          enabled: true
+      {{- end }}
+      {{- end }}
+      {{- with .extraExporters }}
+      {{- . | toYaml | nindent 6 }}
+      {{- end }}
+
+    extensions:
+      health_check:
+
+    service:
+      extensions: [ health_check ]
+      pipelines:
+        metrics:
+          receivers: [ prometheus ]
+          processors:
+            {{- if .batchProcessor.enabled }}
+            - batch
+            {{- end }}
+            {{- if .nrConventionsProcessor.enabled }}
+            - metricstransform/nrConventions
+            {{- end }}
+            {{- range $processor, $_ := .extraProcessors }}
+            - {{ $processor }}
+            {{- end }}
+          exporters:
+            {{- if .otlpExporter.enabled }}
+            - otlp
+            {{- end }}
+            {{- if .loggingExporter.enabled }}
+            - logging
+            {{- end }}
+            {{- if $.Values.service.prometheusDebug.enabled }}
+            - prometheus
+            {{- end }}
+            {{- range $exporter, $_ := .extraExporters }}
+            - {{ $exporter }}
+            {{- end }}
+  {{- end }}

--- a/charts/otel-k8s-prometheus/templates/configmap.yaml
+++ b/charts/otel-k8s-prometheus/templates/configmap.yaml
@@ -61,6 +61,13 @@ data:
             from_attribute: service.name
           - action: delete
             key: service.name
+          # Instrumentation meta
+          - action: insert
+            key: instrumentation.name
+            value: {{$.Chart.Name}}
+          - action: insert
+            key: instrumentation.version
+            value: {{$.Chart.Version}}
           # Cluster name
           - action: insert
             key: k8s.cluster.name

--- a/charts/otel-k8s-prometheus/templates/configmap.yaml
+++ b/charts/otel-k8s-prometheus/templates/configmap.yaml
@@ -24,6 +24,27 @@ data:
               relabel_configs:
                 # K8s scrape labels and transformations
                 {{- include "newrelic.prometheusOtelRelabel" $.Values.config | nindent 16 }}
+                # Use replace labels to support prometheus.io/port and prometheus.io/path annotations.
+                - source_labels: [ __address__, __meta_kubernetes_pod_annotation_prometheus_io_port ]
+                  action: replace
+                  target_label: __address__
+                  # Matched against labels concatenated with `;`:
+                  # First group (captured in $1) gets everything before `:`.
+                  # Second group (non-captured) matches the original group.
+                  # Third group (captured in $2) matches the port from the port label.
+                  # TODO: This will not work with v6.
+                  regex: ([^:]+)(?::\d+)?;(\d+)
+                  # Just concatenate both captured groups separated by a colon.
+                  replacement: $$1:$$2
+                - source_labels: [ __address__, __meta_kubernetes_pod_annotation_prometheus_io_path ]
+                  action: replace
+                  target_label: __address__
+                  # Matched against labels concatenated with `;`:
+                  # First group (captured in $1) gets the current target.
+                  # Second group (captured in $2) matches the path from the path label.
+                  regex: (.+);(/.+)
+                  # Just concatenate both captured groups.
+                  replacement: $$1$$2
           {{- end }}
           {{- end }}
 

--- a/charts/otel-k8s-prometheus/templates/configmap_helper.tpl
+++ b/charts/otel-k8s-prometheus/templates/configmap_helper.tpl
@@ -54,4 +54,8 @@ Return the name key for the License Key inside the secret
 - source_labels: [__meta_kubernetes_service_name]
   action: replace
   target_label: kubernetes_service_name
+
+{{- with .extraPrometheusRelabelConfigs }}
+{{ . | toYaml }}
+{{- end }}
 {{- end -}}

--- a/charts/otel-k8s-prometheus/templates/configmap_helper.tpl
+++ b/charts/otel-k8s-prometheus/templates/configmap_helper.tpl
@@ -1,0 +1,57 @@
+{{/*
+Return the name key for the License Key inside the secret
+*/}}
+{{/*# TODO: Investigate if more characters commonly found in labels are not allowed in prometheus job names */}}
+{{- define "toPrometheus" -}}
+{{ . | replace "." "_" | replace "/" "_" | replace "-" "_" }}
+{{- end -}}
+
+{{- define "newrelic.prometheusOtelRelabel" -}}
+# Multiple instances of `relabel_configs` are applied sequentially. If with action:keep does not match
+# a target, it will be dropped immediately and subsequent configs will be noop.
+- source_labels:
+    # Multiple source_labels are concatenated together with `;` before checking if regex matches
+    # By specifying a permissive regex we achieve a hacky OR, matching e.g `;;true;`
+    {{- range .annotations }}
+    - __meta_kubernetes_pod_annotation_{{ include "toPrometheus" . }}
+    - __meta_kubernetes_service_annotation_{{ include "toPrometheus" . }}
+    {{- end }}
+    {{- range .labels }}
+    - __meta_kubernetes_pod_label_{{ include "toPrometheus" . }}
+    - __meta_kubernetes_service_label_{{ include "toPrometheus" . }}
+    {{- end }}
+  # We need to add .* in both ends to get the hacky ORing because prometheus wraps this regex
+  # with ^ $ automatically. With this, it will result in ^.*true.*$
+  regex: ".*true.*"
+  separator: ";"
+  action: keep
+{{/*# TODO: Honor path and port labels somehow */}}
+{{/*# read the port from "prometheus.io/port: <port>" annotation and update scraping address accordingly*/}}
+{{/*# TODO: Do the same with /scheme and /path?*/}}
+{{/*- source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]*/}}
+{{/*  action: replace*/}}
+{{/*  target_label: __address__*/}}
+{{/*  regex: ([^:]+)(?::\d+)?;(\d+)*/}}
+{{/*  # escaped $1:$2*/}}
+{{/*  replacement: $$1:$$2*/}}
+# Keep meta labels regarding k8s objects
+- source_labels: [__meta_kubernetes_namespace]
+  action: replace
+  target_label: kubernetes_namespace
+
+- source_labels: [__meta_kubernetes_pod_name]
+  action: replace
+  target_label: kubernetes_pod_name
+
+- source_labels: [__meta_kubernetes_pod_container_name]
+  action: replace
+  target_label: kubernetes_pod_container_name
+
+- source_labels: [__meta_kubernetes_pod_node_name]
+  action: replace
+  target_label: kubernetes_pod_node_name
+
+- source_labels: [__meta_kubernetes_service_name]
+  action: replace
+  target_label: kubernetes_service_name
+{{- end -}}

--- a/charts/otel-k8s-prometheus/templates/configmap_helper.tpl
+++ b/charts/otel-k8s-prometheus/templates/configmap_helper.tpl
@@ -25,15 +25,7 @@ Return the name key for the License Key inside the secret
   regex: ".*true.*"
   separator: ";"
   action: keep
-{{/*# TODO: Honor path and port labels somehow */}}
-{{/*# read the port from "prometheus.io/port: <port>" annotation and update scraping address accordingly*/}}
-{{/*# TODO: Do the same with /scheme and /path?*/}}
-{{/*- source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]*/}}
-{{/*  action: replace*/}}
-{{/*  target_label: __address__*/}}
-{{/*  regex: ([^:]+)(?::\d+)?;(\d+)*/}}
-{{/*  # escaped $1:$2*/}}
-{{/*  replacement: $$1:$$2*/}}
+
 # Keep meta labels regarding k8s objects
 - source_labels: [__meta_kubernetes_namespace]
   action: replace

--- a/charts/otel-k8s-prometheus/templates/deployment.yaml
+++ b/charts/otel-k8s-prometheus/templates/deployment.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "otel-k8s-prometheus.labels" . | nindent 4 }}
 spec:
+  {{- if eq .Values.kind "Deployment" }}
   replicas: 1  # Multiple replicas are not supported, as they would lead to duplicate data
+  {{- end }}
   selector:
     matchLabels:
       {{- include "otel-k8s-prometheus.selectorLabels" . | nindent 6 }}
@@ -45,6 +47,10 @@ spec:
                   key: {{ include "newrelic.licenseSecretKey" . }}
             - name: NR_CLUSTER_NAME
               value: {{ include "newrelic.cluster" . }}
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           {{- if .Values.service.prometheusDebug.enabled }}
           ports:
             - name: prometheus

--- a/charts/otel-k8s-prometheus/templates/deployment.yaml
+++ b/charts/otel-k8s-prometheus/templates/deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "otel-k8s-prometheus.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "otel-k8s-prometheus.labels" . | nindent 4 }}
+spec:
+  replicas: 1  # Multiple replicas are not supported, as they would lead to duplicate data
+  selector:
+    matchLabels:
+      {{- include "otel-k8s-prometheus.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "otel-k8s-prometheus.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "otel-k8s-prometheus.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - "/otelcontribcol"
+            - "--config=/conf/otel-prometheus-config.yaml"
+          env:
+            - name: NR_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  optional: true
+                  name: {{ include "newrelic.licenseSecretName" . }}
+                  key: {{ include "newrelic.licenseSecretKey" . }}
+            - name: NR_CLUSTER_NAME
+              value: {{ include "newrelic.cluster" . }}
+          {{- if .Values.service.prometheusDebug.enabled }}
+          ports:
+            - name: prometheus
+              containerPort: 9000
+              protocol: TCP
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133  # Health Check extension default port.
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133  # Health Check extension default port.
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: otel-prometheus-config
+              mountPath: /conf
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: otel-prometheus-config
+          configMap:
+            name: {{ include "otel-k8s-prometheus.fullname" . }}-config
+            items:
+              - key: otel-prometheus-config.yaml
+                path: otel-prometheus-config.yaml

--- a/charts/otel-k8s-prometheus/templates/rbac.yaml
+++ b/charts/otel-k8s-prometheus/templates/rbac.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.rbac.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "otel-k8s-prometheus.fullname" . }}-cr
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - pods
+      - services
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "otel-k8s-prometheus.fullname" . }}-crb
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "otel-k8s-prometheus.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "otel-k8s-prometheus.fullname" . }}-cr
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/otel-k8s-prometheus/templates/secret.yaml
+++ b/charts/otel-k8s-prometheus/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if not (include "newrelic.licenseCustomSecretName" .) | and (include "newrelic.licenseKey" .) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "otel-k8s-prometheus.fullname" . }}-license
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "otel-k8s-prometheus.labels" . | nindent 4 }}
+data:
+  licenseKey: {{ include "newrelic.licenseKey" . | b64enc }}
+{{- end }}

--- a/charts/otel-k8s-prometheus/templates/service.yaml
+++ b/charts/otel-k8s-prometheus/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "otel-k8s-prometheus.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "otel-k8s-prometheus.labels" . | nindent 4 }}
+  {{- with .Values.service.prometheusDebug.annotations }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.prometheusDebug.type }}
+  ports:
+    - port: {{ .Values.service.prometheusDebug.port }}
+      targetPort: prometheus
+      protocol: TCP
+      name: prometheus
+  selector:
+    {{- include "otel-k8s-prometheus.selectorLabels" . | nindent 4 }}

--- a/charts/otel-k8s-prometheus/templates/serviceaccount.yaml
+++ b/charts/otel-k8s-prometheus/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "otel-k8s-prometheus.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "otel-k8s-prometheus.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/otel-k8s-prometheus/templates/tests/test-connection.yaml
+++ b/charts/otel-k8s-prometheus/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "otel-k8s-prometheus.fullname" . }}-test-connection"
+  labels:
+    {{- include "otel-k8s-prometheus.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "otel-k8s-prometheus.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/otel-k8s-prometheus/values.yaml
+++ b/charts/otel-k8s-prometheus/values.yaml
@@ -29,16 +29,18 @@ config:
   batchProcessor:
     enabled: true
 
-  # This pre-configured processor will apply some transformations to labels and values to match the conventions used by
-  # New Relic. It should be enabled if you are sending data to New Relic.
-  nrConventionsProcessor:
+  # If enabled, this flag will add two pre-configured processors which apply some transformations to labels and
+  # attributes to match the conventions used by New Relic.
+  # It MUST be enabled if you are sending data to New Relic.
+  nrConventionsProcessors:
     enabled: false
 
   # Extra configs to use as processors for the otel collector.
-  # By adding more processors here, metrics can be filtered or transformed with a high degree of flexibility:
+  # By adding more processors here, metrics can be filtered or transformed with a high degree of flexibility, e.g.:
   # - Filter: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor
   # - Transform: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/metricstransformprocessor
   # More: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor
+  # Processors defined here will be automatically added at the end of the metrics pipeline.
   extraProcessors: {}
     #filter/kube:
     #  metrics:
@@ -54,7 +56,7 @@ config:
     loglevel: info
 
   # Configure the OTLP exporter, which would typically hit an in-cluster gateway collector.
-  # Env var NR_LICENSE_KEY is available containing the license key.
+  # Env var NR_LICENSE_KEY is available containing the New Relic license key, if it has been provided.
   # See: https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter
   otlpExporter:
     enabled: false

--- a/charts/otel-k8s-prometheus/values.yaml
+++ b/charts/otel-k8s-prometheus/values.yaml
@@ -1,0 +1,137 @@
+config:
+  # Labels and annotations to look for when scraping.
+  labels:
+    - prometheus.io/scrape
+    - newrelic.com/scrape
+  annotations:
+    - prometheus.io/scrape
+    - newrelic.com/scrape
+
+  # How often to pull metrics from discovered targets.
+  interval: 30s
+
+  jobs:
+    # Scrape pods annotated or labeled with the specified annotations, as well as endpoints behind annotated services.
+    # All endpoints behind the service will be scraped individually.
+    podsEndpoints:
+      enabled: true
+    # Scrape externalName services, which may point to exporters outside the Kubernetes cluster.
+    # Keep in mind that for this job, the scraper needs to hit the load-balanced server IP directly, which can lead to
+    # unexpected results if the service has multiple endpoints.
+    external:
+      enabled: false
+
+  # Prometheus scrape configs to add to the prometheus receiver.
+  # See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config
+  extraScrapeConfigs: []
+
+  # Enable the OTEL batch processor.
+  batchProcessor:
+    enabled: true
+
+  # This pre-configured processor will apply some transformations to labels and values to match the conventions used by
+  # New Relic. It should be enabled if you are sending data to New Relic.
+  nrConventionsProcessor:
+    enabled: false
+
+  # Extra configs to use as processors for the otel collector.
+  # By adding more processors here, metrics can be filtered or transformed with a high degree of flexibility:
+  # - Filter: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor
+  # - Transform: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/metricstransformprocessor
+  # More: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor
+  extraProcessors: {}
+    #filter/kube:
+    #  metrics:
+    #    exclude:
+    #      match_type: regexp
+    #      metric_names:
+    #        - kube_.*
+
+  # Configure the logging exporter, which can log to stderr all the metrics received by the collector.
+  # See: https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/loggingexporter
+  loggingExporter:
+    enabled: false
+    loglevel: info
+
+  # Configure the OTLP exporter, which would typically hit an in-cluster gateway collector.
+  # Env var NR_LICENSE_KEY is available containing the license key.
+  # See: https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter
+  otlpExporter:
+    enabled: false
+    endpoint: otlp.nr-data.net:4317
+    headers:
+      api-key: "${NR_LICENSE_KEY}"  # Added to the deployment's env by the chart automatically
+
+  # Extra configs to use as exporters for the otel collector.
+  # See: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter
+  extraExporters: {}
+
+service:
+  # prometheusDebug exposes a port where you can query this collector for all the metrics it has gathered in the
+  # OpenMetrics format. It is useful for troubleshooting and seeing what the collector is scraping.
+  prometheusDebug:
+    enabled: false
+    type: ClusterIP
+    port: 9000
+    annotations: {}
+
+# ---
+
+image:
+  repository: otel/opentelemetry-collector-contrib
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# Whether to automatically create RBAC rules.
+# This chart requires (and by default will create on its own) RBAC granting read-only (get, list, watch) permission to:
+#  - nodes
+#  - pods
+#  - services
+#  - endpoints
+rbac:
+  create: true
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/otel-k8s-prometheus/values.yaml
+++ b/charts/otel-k8s-prometheus/values.yaml
@@ -21,6 +21,14 @@ config:
     external:
       enabled: false
 
+  # Extra relabel_configs entries for prometheus scrape jobs.
+  # This can be used to add, drop or rename labels, metrics, and targets. Will be used for podsEndpoints and external jobs.
+  extraPrometheusRelabelConfigs: []
+    #- source_labels: [ __meta_kubernetes_pod_container_name ]
+    #  action: replace
+    #  target_label: kubernetes_pod_container_name
+
+
   # Prometheus scrape configs to add to the prometheus receiver.
   # See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config
   extraScrapeConfigs: []

--- a/charts/otel-k8s-prometheus/values.yaml
+++ b/charts/otel-k8s-prometheus/values.yaml
@@ -85,6 +85,11 @@ service:
     port: 9000
     annotations: {}
 
+# Either Deployment or DaemonSet.
+# If DaemonSet is in use, sharding will be applied so each pod will scrape only targets it shares a node with.
+# TODO: Sharding logic is currently untested.
+kind: Deployment
+
 # ---
 
 image:


### PR DESCRIPTION
#### Is this a new chart

HECK YES!

#### What this PR does / why we need it:

Adds the `otel-k8s-prometheus` chart, which is an easy to configure deployment of the OpenTelemetry collector that gathers metrics from prometheus endpoints running in a Kubernetes Cluster and sends them to the New Relic OTLP endpoint. Out of the box.

This chart should be functionally comparable with the `nri-prometheus` chart, as they achieve the same thing.

Focus has been put in:

- **Simplicity**: Users can override many aspects of the discovery and scraping process without having to write a Prometheus Server config.

- **Extendability**: Through the use of `extraProcessors` and `extraExporters`, users can add custom filters and transformations and send the output to wherever they want. Out of the box, the chart will send metrics to New Relic's OTLP endpoint.

- **Performance**: By using the OpenTelemetry collector, which is known to be performant, we aim to lower the performance impact `nri-prometheus` had on large clusters. `// TODO: Run some benchmarks and put some numbers`

#### Limitations

- ~Metrics lack some k8s-specific labels (e.g. `pod.name`, `service.name`, `namespace`, etc.)~ (Fixed)
- `service.name` label is present and set to a seemingly unrelated value, which will cause the entity synthesis pipeline to render everything as a service entity.
  - It would seem that getting rid of this label is harder than expected, as processors do not seem to be able to see it

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
