### PR TITLE
[nri-bundle] Added additional configuration flexibility to newrelic-logging

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.10.0
+version: 1.20.0
 appVersion: 1.10.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/static/lowdatamodedefaults.yaml
+++ b/charts/newrelic-logging/static/lowdatamodedefaults.yaml
@@ -7,7 +7,6 @@ fluent-bit.conf: |
         HTTP_Server   On
         HTTP_Listen   0.0.0.0
         HTTP_Port     2020
-        lowDataDefault true
 
     [INPUT]
         Name              tail

--- a/charts/newrelic-logging/static/lowdatamodedefaults.yaml
+++ b/charts/newrelic-logging/static/lowdatamodedefaults.yaml
@@ -1,0 +1,53 @@
+fluent-bit.conf: |
+    [SERVICE]
+        Flush         1
+        Log_Level     ${LOG_LEVEL}
+        Daemon        off
+        Parsers_File  parsers.conf
+        HTTP_Server   On
+        HTTP_Listen   0.0.0.0
+        HTTP_Port     2020
+        lowDataDefault true
+
+    [INPUT]
+        Name              tail
+        Tag               kube.*
+        Path              ${PATH}
+        Parser            ${LOG_PARSER}
+        DB                ${FB_DB}
+        Mem_Buf_Limit     7MB
+        Skip_Long_Lines   On
+        Refresh_Interval  10
+
+    [FILTER]
+        Name           kubernetes
+        Match          kube.*
+        # We need the full DNS suffix as Windows only supports resolving names with this suffix
+        # See: https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#dns-limitations
+        Kube_URL       https://kubernetes.default.svc.cluster.local:443
+        K8S-Logging.Exclude ${K8S_LOGGING_EXCLUDE}
+        Labels         Off
+        Annotations    Off
+
+    [FILTER]
+        Name           nest
+        Match          *
+        Operation      lift
+        Nested_under   kubernetes
+
+    [FILTER]
+        Name           record_modifier
+        Match          *
+        Record         cluster_name ${CLUSTER_NAME}
+        Allowlist_key  container_name
+        Allowlist_key  namespace_name
+        Allowlist_key  pod_name
+        Allowlist_key  stream
+        Allowlist_key  log
+
+    [OUTPUT]
+        Name           newrelic
+        Match          *
+        licenseKey     ${LICENSE_KEY}
+        endpoint       ${ENDPOINT}
+        lowDataMode    ${LOW_DATA_MODE}

--- a/charts/newrelic-logging/templates/_helpers.tpl
+++ b/charts/newrelic-logging/templates/_helpers.tpl
@@ -152,7 +152,7 @@ Returns fargate
 {{/*
 Returns lowDataMode
 */}}
-{{- define "newrelic.lowDataMode" -}}
+{{- define "newrelic-logging.lowDataMode" -}}
 {{- if .Values.global }}
   {{- if .Values.global.lowDataMode }}
     {{- .Values.global.lowDataMode -}}

--- a/charts/newrelic-logging/templates/configmap.yaml
+++ b/charts/newrelic-logging/templates/configmap.yaml
@@ -13,4 +13,5 @@ data:
     {{ .Values.config.service }}
     {{ .Values.config.inputs }}
     {{ .Values.config.filters }}
+    {{ .Values.config.outputs }}
   {{- end }}

--- a/charts/newrelic-logging/templates/configmap.yaml
+++ b/charts/newrelic-logging/templates/configmap.yaml
@@ -5,77 +5,12 @@ metadata:
   labels: {{ include "newrelic-logging.labels" . | indent 4 }}
   name: {{ template "newrelic-logging.fluentBitConfig" . }}
 data:
-  # Configuration files: server, input, filters and output
-  # ======================================================
+  {{- if (include "newrelic-logging.lowDataMode" .) }}
+  {{ $lowDataDefault := .Files.Get "static/lowdatamodedefaults.yaml" }}
+    {{- $lowDataDefault }}
+  {{- else }}
   fluent-bit.conf: |
-    [SERVICE]
-        Flush         1
-        Log_Level     ${LOG_LEVEL}
-        Daemon        off
-        Parsers_File  parsers.conf
-        HTTP_Server   On
-        HTTP_Listen   0.0.0.0
-        HTTP_Port     2020
-
-    [INPUT]
-        Name              tail
-        Tag               kube.*
-        Path              ${PATH}
-        Parser            ${LOG_PARSER}
-        DB                ${FB_DB}
-        Mem_Buf_Limit     7MB
-        Skip_Long_Lines   On
-        Refresh_Interval  10
-
-    [FILTER]
-        Name           kubernetes
-        Match          kube.*
-        # We need the full DNS suffix as Windows only supports resolving names with this suffix
-        # See: https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#dns-limitations
-        Kube_URL       https://kubernetes.default.svc.cluster.local:443
-        K8S-Logging.Exclude ${K8S_LOGGING_EXCLUDE}
-{{- if (include "newrelic.lowDataMode" .) }}
-        Labels         Off
-        Annotations    Off
-
-    [FILTER]
-        Name           nest
-        Match          *
-        Operation      lift
-        Nested_under   kubernetes
-{{- end }}
-
-    [FILTER]
-        Name           record_modifier
-        Match          *
-        Record         cluster_name ${CLUSTER_NAME}
-{{- if (include "newrelic.lowDataMode" .) }}
-        Allowlist_key  container_name
-        Allowlist_key  namespace_name
-        Allowlist_key  pod_name
-        Allowlist_key  stream
-        Allowlist_key  log
-{{- end }}
-
-    [OUTPUT]
-        Name           newrelic
-        Match          *
-        licenseKey     ${LICENSE_KEY}
-        endpoint       ${ENDPOINT}
-        lowDataMode    ${LOW_DATA_MODE}
-
-  parsers.conf: |
-    # Relevant parsers retrieved from: https://github.com/fluent/fluent-bit/blob/master/conf/parsers.conf
-    [PARSER]
-        Name         docker
-        Format       json
-        Time_Key     time
-        Time_Format  %Y-%m-%dT%H:%M:%S.%L
-        Time_Keep    On
-
-    [PARSER]
-        Name cri
-        Format regex
-        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+    {{ .Values.config.service }}
+    {{ .Values.config.inputs }}
+    {{ .Values.config.filters }}
+  {{- end }}

--- a/charts/newrelic-logging/templates/configmap.yaml
+++ b/charts/newrelic-logging/templates/configmap.yaml
@@ -10,8 +10,36 @@ data:
     {{- $lowDataDefault }}
   {{- else }}
   fluent-bit.conf: |
-    {{ .Values.config.service }}
-    {{ .Values.config.inputs }}
-    {{ .Values.config.filters }}
-    {{ .Values.config.outputs }}
-  {{- end }}
+    {{- if .Values.config.service }}
+      {{- .Values.config.service | nindent 4 }}
+    {{ end }}
+    {{- if .Values.config.inputs }}
+      {{- .Values.config.inputs | nindent 4 }}
+    {{ end }}
+    {{- if .Values.config.filters }}
+      {{- .Values.config.filters | nindent 4 }}
+    {{ end }}
+    {{- if .Values.config.outputs }}
+      {{- .Values.config.outputs | nindent 4 }}
+    {{- end }}
+  {{ end }}
+  parsers.conf: |
+  {{- if .Values.config.parsers }}
+    {{- .Values.config.parsers | nindent 4}}
+  {{- else }}
+    # Relevant parsers retrieved from: https://github.com/fluent/fluent-bit/blob/master/conf/parsers.conf
+    [PARSER]
+        Name         docker
+        Format       json
+        Time_Key     time
+        Time_Format  %Y-%m-%dT%H:%M:%S.%L
+        Time_Keep    On
+
+    [PARSER]
+        Name cri
+        Format regex
+        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
+        Time_Key    time
+        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+    {{- end }}
+    

--- a/charts/newrelic-logging/templates/daemonset.yaml
+++ b/charts/newrelic-logging/templates/daemonset.yaml
@@ -55,7 +55,7 @@ spec:
               value: "https://log-api.newrelic.com/log/v1"
               {{- end }}
             - name: SOURCE
-              value: {{ if (include "newrelic.lowDataMode" .) }} "k8s" {{- else }} "kubernetes" {{- end }}
+              value: {{ if (include "newrelic-logging.lowDataMode" .) }} "k8s" {{- else }} "kubernetes" {{- end }}
             - name: LICENSE_KEY
               valueFrom:
                 secretKeyRef:
@@ -83,7 +83,7 @@ spec:
             - name: K8S_LOGGING_EXCLUDE
               value: {{ .Values.fluentBit.k8sLoggingExclude | quote }}
             - name: LOW_DATA_MODE
-              value: {{ include "newrelic.lowDataMode" . | default "false" | quote }}
+              value: {{ include "newrelic-logging.lowDataMode" . | default "false" | quote }}
             {{- range .Values.fluentBit.additionalEnvVariables }}
             - name: {{ .name }}
               value: {{ .value }}

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -143,50 +143,37 @@ lowDataMode: false
 
 config:
   service: |
+    # This is the first line
     [SERVICE]
-        Flush         1
-        Log_Level     ${LOG_LEVEL}
-        Daemon        off
-        Parsers_File  parsers.conf
-        HTTP_Server   On
-        HTTP_Listen   0.0.0.0
-        HTTP_Port     2020
-        lowDataDefault true
+      Flush         1
+      Log_Level     ${LOG_LEVEL}
+      Daemon        off
+      Parsers_File  parsers.conf
+      HTTP_Server   On
+      HTTP_Listen   0.0.0.0
+      HTTP_Port     2020
+      lowDataDefault true
 
   inputs: |
+    # This is the first line
     [INPUT]
-        Name              tail
-        Tag               kube.*
-        Path              ${PATH}
-        Parser            ${LOG_PARSER}
-        DB                ${FB_DB}
-        Mem_Buf_Limit     7MB
-        Skip_Long_Lines   On
-        Refresh_Interval  10
+      Name              tail
+      Tag               kube.*
+      Path              ${PATH}
+      Parser            ${LOG_PARSER}
+      DB                ${FB_DB}
+      Mem_Buf_Limit     7MB
+      Skip_Long_Lines   On
+      Refresh_Interval  10
 
   filters: |
+    # This is the first line
     [FILTER]
-        Name           kubernetes
-        Match          kube.*
-        # We need the full DNS suffix as Windows only supports resolving names with this suffix
-        # See: https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#dns-limitations
-        Kube_URL       https://kubernetes.default.svc.cluster.local:443
-        K8S-Logging.Exclude ${K8S_LOGGING_EXCLUDE}
-        Labels         Off
-        Annotations    Off
-
-    [FILTER]
-        Name           nest
-        Match          *
-        Operation      lift
-        Nested_under   kubernetes
-
-    [FILTER]
-        Name           record_modifier
-        Match          *
-        Record         cluster_name ${CLUSTER_NAME}
-        Allowlist_key  container_name
-        Allowlist_key  namespace_name
-        Allowlist_key  pod_name
-        Allowlist_key  stream
-        Allowlist_key  log
+      Name           kubernetes
+      Match          kube.*
+      # We need the full DNS suffix as Windows only supports resolving names with this suffix
+      # See: https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#dns-limitations
+      Kube_URL       https://kubernetes.default.svc.cluster.local:443
+      K8S-Logging.Exclude ${K8S_LOGGING_EXCLUDE}
+      Labels         Off
+      Annotations    Off

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -141,6 +141,9 @@ daemonSet:
 # Can be set as a global: global.lowDataMode
 lowDataMode: false
 
+# New Relic default configuration for fluent-bit.conf (service, inputs, filters, outputs) 
+# and parsers.conf (parsers). The configuration below is not configured for lowDataMode and will
+# send all attributes.  If custom configuration is required, update these variables.
 config:
   service: |
     [SERVICE]
@@ -185,17 +188,17 @@ config:
         endpoint       ${ENDPOINT}
         lowDataMode    ${LOW_DATA_MODE}
   
-  # parsers: |
-  #   [PARSER]
-  #       Name         docker
-  #       Format       json
-  #       Time_Key     time
-  #       Time_Format  %Y-%m-%dT%H:%M:%S.%L
-  #       Time_Keep    On
+  parsers: |
+    [PARSER]
+        Name         docker
+        Format       json
+        Time_Key     time
+        Time_Format  %Y-%m-%dT%H:%M:%S.%L
+        Time_Keep    On
 
-  #   [PARSER]
-  #       Name cri
-  #       Format regex
-  #       Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
-  #       Time_Key    time
-  #       Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+    [PARSER]
+        Name cri
+        Format regex
+        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
+        Time_Key    time
+        Time_Format %Y-%m-%dT%H:%M:%S.%L%z

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -140,3 +140,53 @@ daemonSet:
 # into the plugin.source attribute.
 # Can be set as a global: global.lowDataMode
 lowDataMode: false
+
+config:
+  service: |
+    [SERVICE]
+        Flush         1
+        Log_Level     ${LOG_LEVEL}
+        Daemon        off
+        Parsers_File  parsers.conf
+        HTTP_Server   On
+        HTTP_Listen   0.0.0.0
+        HTTP_Port     2020
+        lowDataDefault true
+
+  inputs: |
+    [INPUT]
+        Name              tail
+        Tag               kube.*
+        Path              ${PATH}
+        Parser            ${LOG_PARSER}
+        DB                ${FB_DB}
+        Mem_Buf_Limit     7MB
+        Skip_Long_Lines   On
+        Refresh_Interval  10
+
+  filters: |
+    [FILTER]
+        Name           kubernetes
+        Match          kube.*
+        # We need the full DNS suffix as Windows only supports resolving names with this suffix
+        # See: https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#dns-limitations
+        Kube_URL       https://kubernetes.default.svc.cluster.local:443
+        K8S-Logging.Exclude ${K8S_LOGGING_EXCLUDE}
+        Labels         Off
+        Annotations    Off
+
+    [FILTER]
+        Name           nest
+        Match          *
+        Operation      lift
+        Nested_under   kubernetes
+
+    [FILTER]
+        Name           record_modifier
+        Match          *
+        Record         cluster_name ${CLUSTER_NAME}
+        Allowlist_key  container_name
+        Allowlist_key  namespace_name
+        Allowlist_key  pod_name
+        Allowlist_key  stream
+        Allowlist_key  log

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -143,37 +143,59 @@ lowDataMode: false
 
 config:
   service: |
-    # This is the first line
     [SERVICE]
-      Flush         1
-      Log_Level     ${LOG_LEVEL}
-      Daemon        off
-      Parsers_File  parsers.conf
-      HTTP_Server   On
-      HTTP_Listen   0.0.0.0
-      HTTP_Port     2020
-      lowDataDefault true
+        Flush         1
+        Log_Level     ${LOG_LEVEL}
+        Daemon        off
+        Parsers_File  parsers.conf
+        HTTP_Server   On
+        HTTP_Listen   0.0.0.0
+        HTTP_Port     2020
 
   inputs: |
-    # This is the first line
     [INPUT]
-      Name              tail
-      Tag               kube.*
-      Path              ${PATH}
-      Parser            ${LOG_PARSER}
-      DB                ${FB_DB}
-      Mem_Buf_Limit     7MB
-      Skip_Long_Lines   On
-      Refresh_Interval  10
+        Name              tail
+        Tag               kube.*
+        Path              ${PATH}
+        Parser            ${LOG_PARSER}
+        DB                ${FB_DB}
+        Mem_Buf_Limit     7MB
+        Skip_Long_Lines   On
+        Refresh_Interval  10
 
   filters: |
-    # This is the first line
     [FILTER]
-      Name           kubernetes
-      Match          kube.*
-      # We need the full DNS suffix as Windows only supports resolving names with this suffix
-      # See: https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#dns-limitations
-      Kube_URL       https://kubernetes.default.svc.cluster.local:443
-      K8S-Logging.Exclude ${K8S_LOGGING_EXCLUDE}
-      Labels         Off
-      Annotations    Off
+        Name           kubernetes
+        Match          kube.*
+        # We need the full DNS suffix as Windows only supports resolving names with this suffix
+        # See: https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#dns-limitations
+        Kube_URL       https://kubernetes.default.svc.cluster.local:443
+        K8S-Logging.Exclude ${K8S_LOGGING_EXCLUDE}
+
+    [FILTER]
+        Name           record_modifier
+        Match          *
+        Record         cluster_name ${CLUSTER_NAME}
+
+  outputs: |
+    [OUTPUT]
+        Name           newrelic
+        Match          *
+        licenseKey     ${LICENSE_KEY}
+        endpoint       ${ENDPOINT}
+        lowDataMode    ${LOW_DATA_MODE}
+  
+  # parsers: |
+  #   [PARSER]
+  #       Name         docker
+  #       Format       json
+  #       Time_Key     time
+  #       Time_Format  %Y-%m-%dT%H:%M:%S.%L
+  #       Time_Keep    On
+
+  #   [PARSER]
+  #       Name cri
+  #       Format regex
+  #       Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
+  #       Time_Key    time
+  #       Time_Format %Y-%m-%dT%H:%M:%S.%L%z

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to deploy New Relic integrations bundled together
 name: nri-bundle
-version: 3.1.1
+version: 3.2.0
 home: https://github.com/newrelic/helm-charts
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:

--- a/charts/nri-bundle/requirements.yaml
+++ b/charts/nri-bundle/requirements.yaml
@@ -27,7 +27,7 @@ dependencies:
   - name: newrelic-logging
     repository: file://../newrelic-logging
     condition: logging.enabled
-    version: 1.10.0
+    version: 1.20.0
 
   - name: newrelic-pixie
     repository: file://../newrelic-pixie

--- a/charts/nri-bundle/values.yaml
+++ b/charts/nri-bundle/values.yaml
@@ -101,65 +101,66 @@ newrelic-infra-operator:
 #             labels:
 #               env: test
 
+# New Relic default configuration for fluent-bit.conf (service, inputs, filters, outputs)
+# and parsers.conf (parsers). The configuration below is not configured for lowDataMode and will
+# send all attributes.  If custom configuration is required, update these variables.
 # newrelic-logging:
-#   # New Relic default configuration for fluent-bit.conf (service, inputs, filters, outputs) 
-#   # and parsers.conf (parsers). The configuration below is not configured for lowDataMode and will
-#   # send all attributes.  If custom configuration is required, update these variables.
-#   config:
-#     service: |
-#       [SERVICE]
-#           Flush         1
-#           Log_Level     ${LOG_LEVEL}
-#           Daemon        off
-#           Parsers_File  parsers.conf
-#           HTTP_Server   On
-#           HTTP_Listen   0.0.0.0
-#           HTTP_Port     2020
+#   fluentBit:
+#     config:
+#       service: |
+#         [SERVICE]
+#             Flush         1
+#             Log_Level     ${LOG_LEVEL}
+#             Daemon        off
+#             Parsers_File  parsers.conf
+#             HTTP_Server   On
+#             HTTP_Listen   0.0.0.0
+#             HTTP_Port     2020
 
-#     inputs: |
-#       [INPUT]
-#           Name              tail
-#           Tag               kube.*
-#           Path              ${PATH}
-#           Parser            ${LOG_PARSER}
-#           DB                ${FB_DB}
-#           Mem_Buf_Limit     7MB
-#           Skip_Long_Lines   On
-#           Refresh_Interval  10
+#       inputs: |
+#         [INPUT]
+#             Name              tail
+#             Tag               kube.*
+#             Path              ${PATH}
+#             Parser            ${LOG_PARSER}
+#             DB                ${FB_DB}
+#             Mem_Buf_Limit     7MB
+#             Skip_Long_Lines   On
+#             Refresh_Interval  10
 
-#     filters: |
-#       [FILTER]
-#           Name           kubernetes
-#           Match          kube.*
-#           # We need the full DNS suffix as Windows only supports resolving names with this suffix
-#           # See: https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#dns-limitations
-#           Kube_URL       https://kubernetes.default.svc.cluster.local:443
-#           K8S-Logging.Exclude ${K8S_LOGGING_EXCLUDE}
+#       filters: |
+#         [FILTER]
+#             Name           kubernetes
+#             Match          kube.*
+#             # We need the full DNS suffix as Windows only supports resolving names with this suffix
+#             # See: https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#dns-limitations
+#             Kube_URL       https://kubernetes.default.svc.cluster.local:443
+#             K8S-Logging.Exclude ${K8S_LOGGING_EXCLUDE}
 
-#       [FILTER]
-#           Name           record_modifier
-#           Match          *
-#           Record         cluster_name ${CLUSTER_NAME}
+#         [FILTER]
+#             Name           record_modifier
+#             Match          *
+#             Record         cluster_name ${CLUSTER_NAME}
 
-#     outputs: |
-#       [OUTPUT]
-#           Name           newrelic
-#           Match          *
-#           licenseKey     ${LICENSE_KEY}
-#           endpoint       ${ENDPOINT}
-#           lowDataMode    ${LOW_DATA_MODE}
-    
-#     parsers: |
-#       [PARSER]
-#           Name         docker
-#           Format       json
-#           Time_Key     time
-#           Time_Format  %Y-%m-%dT%H:%M:%S.%L
-#           Time_Keep    On
+#       outputs: |
+#         [OUTPUT]
+#             Name           newrelic
+#             Match          *
+#             licenseKey     ${LICENSE_KEY}
+#             endpoint       ${ENDPOINT}
+#             lowDataMode    ${LOW_DATA_MODE}
 
-#       [PARSER]
-#           Name cri
-#           Format regex
-#           Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
-#           Time_Key    time
-#           Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+#       parsers: |
+#         [PARSER]
+#             Name         docker
+#             Format       json
+#             Time_Key     time
+#             Time_Format  %Y-%m-%dT%H:%M:%S.%L
+#             Time_Keep    On
+
+#         [PARSER]
+#             Name cri
+#             Format regex
+#             Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
+#             Time_Key    time
+#             Time_Format %Y-%m-%dT%H:%M:%S.%L%z

--- a/charts/nri-bundle/values.yaml
+++ b/charts/nri-bundle/values.yaml
@@ -1,4 +1,4 @@
-# Default values for nri-infrastructure.
+# Default values for nri-bundle.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
@@ -16,15 +16,15 @@ webhook:
 
 # enables kube-state-metrics
 ksm:
-  enabled: false
+  enabled: true
 
 # enables nri-kube-events
 kubeEvents:
-  enabled: false
+  enabled: true
 
 # enables newrelic-logging
 logging:
-  enabled: false
+  enabled: true
 
 # enables newrelic-pixie
 newrelic-pixie:
@@ -100,3 +100,66 @@ newrelic-infra-operator:
 #               PORT: 6379
 #             labels:
 #               env: test
+
+# newrelic-logging:
+#   # New Relic default configuration for fluent-bit.conf (service, inputs, filters, outputs) 
+#   # and parsers.conf (parsers). The configuration below is not configured for lowDataMode and will
+#   # send all attributes.  If custom configuration is required, update these variables.
+#   config:
+#     service: |
+#       [SERVICE]
+#           Flush         1
+#           Log_Level     ${LOG_LEVEL}
+#           Daemon        off
+#           Parsers_File  parsers.conf
+#           HTTP_Server   On
+#           HTTP_Listen   0.0.0.0
+#           HTTP_Port     2020
+
+#     inputs: |
+#       [INPUT]
+#           Name              tail
+#           Tag               kube.*
+#           Path              ${PATH}
+#           Parser            ${LOG_PARSER}
+#           DB                ${FB_DB}
+#           Mem_Buf_Limit     7MB
+#           Skip_Long_Lines   On
+#           Refresh_Interval  10
+
+#     filters: |
+#       [FILTER]
+#           Name           kubernetes
+#           Match          kube.*
+#           # We need the full DNS suffix as Windows only supports resolving names with this suffix
+#           # See: https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#dns-limitations
+#           Kube_URL       https://kubernetes.default.svc.cluster.local:443
+#           K8S-Logging.Exclude ${K8S_LOGGING_EXCLUDE}
+
+#       [FILTER]
+#           Name           record_modifier
+#           Match          *
+#           Record         cluster_name ${CLUSTER_NAME}
+
+#     outputs: |
+#       [OUTPUT]
+#           Name           newrelic
+#           Match          *
+#           licenseKey     ${LICENSE_KEY}
+#           endpoint       ${ENDPOINT}
+#           lowDataMode    ${LOW_DATA_MODE}
+    
+#     parsers: |
+#       [PARSER]
+#           Name         docker
+#           Format       json
+#           Time_Key     time
+#           Time_Format  %Y-%m-%dT%H:%M:%S.%L
+#           Time_Keep    On
+
+#       [PARSER]
+#           Name cri
+#           Format regex
+#           Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
+#           Time_Key    time
+#           Time_Format %Y-%m-%dT%H:%M:%S.%L%z


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

The changes in this PR provide users the ability to customize the fluent-bit.conf and parsers.conf files using the values.yaml file. Previously, this was statically set in the configmap.yaml file.  The values.yaml file and README were updated for nri-bundle to include examples explaining how to use the new configuration options.

#### Which issue this PR fixes

See [this PR](https://github.com/newrelic/helm-charts/pull/551) for details.

#### Special notes for your reviewer:

N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
