### PR TITLE
[nri-bundle] bump newrelic-logging version to 1.10.1

### DIFF
--- a/charts/nri-bundle/requirements.lock
+++ b/charts/nri-bundle/requirements.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 1.11.0
 - name: newrelic-logging
   repository: file://../newrelic-logging
-  version: 1.10.0
+  version: 1.10.1
 - name: newrelic-pixie
   repository: file://../newrelic-pixie
   version: 1.4.2
@@ -29,5 +29,5 @@ dependencies:
 - name: newrelic-infra-operator
   repository: file://../newrelic-infra-operator
   version: 0.3.0
-digest: sha256:0e0d2547dc009ceab163b14d88c97315997e4d7c5a44ee89a2396cbaba37ef6a
-generated: "2021-10-28T12:01:10.447486+02:00"
+digest: sha256:815bd5c519626e029cc43a2adf1e5e8fbca1d860e8f5ca0de3740ab5ae44e675
+generated: "2021-10-29T20:34:54.416068+02:00"

--- a/charts/nri-bundle/requirements.yaml
+++ b/charts/nri-bundle/requirements.yaml
@@ -32,7 +32,7 @@ dependencies:
   - name: newrelic-logging
     repository: file://../newrelic-logging
     condition: logging.enabled
-    version: 1.10.0
+    version: 1.10.1
 
   - name: newrelic-pixie
     repository: file://../newrelic-pixie


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

Bump the newrelic-logging chart to latest version on nri-bundle

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
