### PR TITLE
[nri-bundle] Bump version to 3.2.7 including newrelic-logging 1.10.3

### DIFF
--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to deploy New Relic integrations bundled together
 name: nri-bundle
-version: 3.2.6
+version: 3.2.7
 home: https://github.com/newrelic/helm-charts
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:

--- a/charts/nri-bundle/requirements.lock
+++ b/charts/nri-bundle/requirements.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 1.11.0
 - name: newrelic-logging
   repository: file://../newrelic-logging
-  version: 1.10.2
+  version: 1.10.3
 - name: newrelic-pixie
   repository: file://../newrelic-pixie
   version: 1.4.2
@@ -29,5 +29,5 @@ dependencies:
 - name: newrelic-infra-operator
   repository: file://../newrelic-infra-operator
   version: 0.4.0
-digest: sha256:8f4276460bd311ce433348ff63ff406b54248db04027ac317dede748069d2cd4
-generated: "2021-11-09T11:42:01.396393+01:00"
+digest: sha256:1ae3c45e3f0f8595eddc40ebdd7fd2ed0e6204d56ef0e5e5ede316da3b2d554d
+generated: "2021-11-11T11:22:18.246987+01:00"

--- a/charts/nri-bundle/requirements.yaml
+++ b/charts/nri-bundle/requirements.yaml
@@ -32,7 +32,7 @@ dependencies:
   - name: newrelic-logging
     repository: file://../newrelic-logging
     condition: logging.enabled
-    version: 1.10.2
+    version: 1.10.3
 
   - name: newrelic-pixie
     repository: file://../newrelic-pixie


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

Bump version of nri-bundle

#### Special notes for your reviewer:

the bundle includes now newrelic-logging 1.10.3

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
