### PR TITLE
[nri-kube-events] added custom attributes feature

### DIFF
--- a/charts/nri-kube-events/Chart.yaml
+++ b/charts/nri-kube-events/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Kube Events
 name: nri-kube-events
-version: 1.11.0
+version: 1.12.0
 appVersion: 1.6.0
 engine: gotpl
 home: https://docs.newrelic.com/docs/integrations/kubernetes-integration/kubernetes-events/install-kubernetes-events-integration

--- a/charts/nri-kube-events/README.md
+++ b/charts/nri-kube-events/README.md
@@ -37,6 +37,7 @@ This chart will deploy the New Relic Events Routers as a Deployment.
 | `proxy`                                                    | Set proxy if you required as Kube-events-forwarder / infra-agent needs to send metrics to New Relic One.                                                                                                                                       |                                 |
 | `config`                                                    | Set config option in order to pass any configuration to the agent running as a sidecar. This object is map as a configuration map mounted in /etc/newrelic-infra.yml.                                                                                                                                        |                                 |
 | `deployment.annotations`   | The annotations to add to the `Deployment`.
+| `custom_attributes.*`   | Custom attributes to be added to the Kube events.  Queryable in New Relic.
 
 ## Example
 

--- a/charts/nri-kube-events/templates/deployment.yaml
+++ b/charts/nri-kube-events/templates/deployment.yaml
@@ -47,6 +47,13 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /app/config
+          {{- if .Values.custom_attributes }}
+          env:
+            {{- range $key, $val := .Values.custom_attributes }}
+            - name: NRI_KUBE_EVENTS_{{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
+          {{- end }}
         - name: infra-agent
           image: {{ .Values.image.infraAgent.repository }}:{{ .Values.image.infraAgent.tag }}
           imagePullPolicy: {{ .Values.image.infraAgent.pullPolicy }}

--- a/charts/nri-kube-events/templates/deployment.yaml
+++ b/charts/nri-kube-events/templates/deployment.yaml
@@ -47,9 +47,9 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /app/config
-          {{- if .Values.custom_attributes }}
+          {{- if .Values.customAttributes }}
           env:
-            {{- range $key, $val := .Values.custom_attributes }}
+            {{- range $key, $val := .Values.customAttributes }}
             - name: NRI_KUBE_EVENTS_{{ $key }}
               value: {{ $val | quote }}
             {{- end }}

--- a/charts/nri-kube-events/values.yaml
+++ b/charts/nri-kube-events/values.yaml
@@ -122,6 +122,6 @@ deployment:
 # Add custom attributes to each Kube event being shipped to New Relic
 # Ref: https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/kubernetes-events/install-kubernetes-events-integration/#custom-attributes
 #
-# custom_attributes:
+# customAttributes:
 #  environment: dev
 #  team: alpha-team

--- a/charts/nri-kube-events/values.yaml
+++ b/charts/nri-kube-events/values.yaml
@@ -118,3 +118,10 @@ nrStaging: false
 deployment:
   # Annotations to add to the Deployment.
   annotations: {}
+
+# Add custom attributes to each Kube event being shipped to New Relic
+# Ref: https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/kubernetes-events/install-kubernetes-events-integration/#custom-attributes
+#
+# custom_attributes:
+#  environment: dev
+#  team: alpha-team


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

Allows user-provided custom attributes to be associated with Kube events.  We outline this capability in our docs but it was not previously available in our Helm chart.

https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/kubernetes-events/install-kubernetes-events-integration/#custom-attributes

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
