### PR TITLE
[newrelic-logging] Made fluent-bit.conf and parsers.conf ConfigMap configurable from values.yaml file

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.10.4
+version: 1.10.5
 appVersion: 1.10.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/README.md
+++ b/charts/newrelic-logging/README.md
@@ -68,11 +68,11 @@ Since Fluent Bit Kubernetes plugin is using [newrelic-fluent-bit-output](https:/
         ...
      ```
  3. Continue to the next steps
- 
+
  ##### Custom proxy
- 
+
  If you want to set up a custom proxy (eg. using self-signed certificate):
- 
+
   1. Complete the step 1 in [Install the Kubernetes manifests manually](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging#install-the-kubernetes-manifests-manually)
   2. Modify the `fluent-conf.yml` and define in the ConfigMap a `caBundle.pem` file with the self-signed certificate:
       ```yaml
@@ -84,7 +84,7 @@ Since Fluent Bit Kubernetes plugin is using [newrelic-fluent-bit-output](https:/
                 endpoint ${ENDPOINT}
                 proxy https://https-proxy-hostname:PORT
                 caBundleFile ${CA_BUNDLE_FILE}
-            
+
             caBundle.pem: |
                 -----BEGIN CERTIFICATE-----
                 MIIB+zCCAWSgAwIBAgIQTiHC/d/NhpHFptZCIoCbNzANBgkrhtiG9w0BAQsFADAS
@@ -107,7 +107,7 @@ Since Fluent Bit Kubernetes plugin is using [newrelic-fluent-bit-output](https:/
           ...
        ```
   4. Continue to the next steps
- 
+
 ## Configuration
 
 See [values.yaml](values.yaml) for the default values
@@ -142,6 +142,12 @@ See [values.yaml](values.yaml) for the default values
 | `daemonSet.annotations`                                    | The annotations to add to the `DaemonSet`.                                                                                                                                                                                                                                   |                                      |
 | `enableLinux`                                              | Enable log collection from Linux containers. This is the default behavior. In case you are only interested of collecting logs from Windows containers, set this to `false`.                                                                                                  | `true`                               |
 | `enableWindows`                                            | Enable log collection from Windows containers. Please refer to the [Windows support](#windows-support) section for more details.                                                                                                                                             | `false`                              |
+| `fluentBit.config.service` | Contains fluent-bit.conf Service config                                                                                             |    |
+| `fluentBit.config.inputs` | Contains fluent-bit.conf Inputs config                                                                                             |    |
+| `fluentBit.config.filters` | Contains fluent-bit.conf Filters config
+| `fluentBit.config.lowDataModeFilters` | Contains fluent-bit.conf Filters config for lowDataMode                                                                                              |    |
+| `fluentBit.config.outputs` | Contains fluent-bit.conf Outputs config                                                                                             |    |
+| `fluentBit.config.parsers` | Contains parsers.conf Parsers config                                                                                             |    |
 
 
 ## Uninstall the Kubernetes plugin

--- a/charts/newrelic-logging/templates/_helpers.tpl
+++ b/charts/newrelic-logging/templates/_helpers.tpl
@@ -152,11 +152,9 @@ Returns fargate
 {{/*
 Returns lowDataMode
 */}}
-{{- define "newrelic.lowDataMode" -}}
-{{- if .Values.global }}
-  {{- if .Values.global.lowDataMode }}
-    {{- .Values.global.lowDataMode -}}
-  {{- end -}}
+{{- define "newrelic-logging.lowDataMode" -}}
+{{- if and (.Values.global) (.Values.global.lowDataMode) }}
+  {{- .Values.global.lowDataMode -}}
 {{- else if .Values.lowDataMode }}
   {{- .Values.lowDataMode -}}
 {{- end -}}

--- a/charts/newrelic-logging/templates/_helpers.tpl
+++ b/charts/newrelic-logging/templates/_helpers.tpl
@@ -153,8 +153,10 @@ Returns fargate
 Returns lowDataMode
 */}}
 {{- define "newrelic-logging.lowDataMode" -}}
-{{- if and (.Values.global) (.Values.global.lowDataMode) }}
-  {{- .Values.global.lowDataMode -}}
+{{- if .Values.global }}
+  {{- if .Values.global.lowDataMode }}
+    {{- .Values.global.lowDataMode -}}
+  {{- end -}}
 {{- else if .Values.lowDataMode }}
   {{- .Values.lowDataMode -}}
 {{- end -}}

--- a/charts/newrelic-logging/templates/configmap.yaml
+++ b/charts/newrelic-logging/templates/configmap.yaml
@@ -5,78 +5,22 @@ metadata:
   labels: {{ include "newrelic-logging.labels" . | indent 4 }}
   name: {{ template "newrelic-logging.fluentBitConfig" . }}
 data:
-  # Configuration files: server, input, filters and output
-  # ======================================================
   fluent-bit.conf: |
-    [SERVICE]
-        Flush         1
-        Log_Level     ${LOG_LEVEL}
-        Daemon        off
-        Parsers_File  parsers.conf
-        HTTP_Server   On
-        HTTP_Listen   0.0.0.0
-        HTTP_Port     2020
-
-    [INPUT]
-        Name              tail
-        Tag               kube.*
-        Path              ${PATH}
-        Parser            ${LOG_PARSER}
-        DB                ${FB_DB}
-        Mem_Buf_Limit     7MB
-        Skip_Long_Lines   On
-        Refresh_Interval  10
-
-    [FILTER]
-        Name           kubernetes
-        Match          kube.*
-        # We need the full DNS suffix as Windows only supports resolving names with this suffix
-        # See: https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#dns-limitations
-        Kube_URL       https://kubernetes.default.svc.cluster.local:443
-        K8S-Logging.Exclude ${K8S_LOGGING_EXCLUDE}
-{{- if (include "newrelic.lowDataMode" .) }}
-        Labels         Off
-        Annotations    Off
-
-    [FILTER]
-        Name           nest
-        Match          *
-        Operation      lift
-        Nested_under   kubernetes
-{{- end }}
-
-    [FILTER]
-        Name           record_modifier
-        Match          *
-        Record         cluster_name ${CLUSTER_NAME}
-{{- if (include "newrelic.lowDataMode" .) }}
-        Allowlist_key  container_name
-        Allowlist_key  namespace_name
-        Allowlist_key  pod_name
-        Allowlist_key  stream
-        Allowlist_key  message
-        Allowlist_key  log
-{{- end }}
-
-    [OUTPUT]
-        Name           newrelic
-        Match          *
-        licenseKey     ${LICENSE_KEY}
-        endpoint       ${ENDPOINT}
-        lowDataMode    ${LOW_DATA_MODE}
-
+    {{- if .Values.fluentBit.config.service }}
+      {{- .Values.fluentBit.config.service | nindent 4 }}
+    {{- end }}
+    {{- if .Values.fluentBit.config.inputs }}
+      {{- .Values.fluentBit.config.inputs | nindent 4 }}
+    {{- end }}
+    {{- if and (include "newrelic-logging.lowDataMode" .) (.Values.fluentBit.config.lowDataModeFilters) }}
+      {{- .Values.fluentBit.config.lowDataModeFilters | nindent 4 }}
+    {{- else }}
+      {{- .Values.fluentBit.config.filters | nindent 4 }}
+    {{- end }}
+    {{- if .Values.fluentBit.config.outputs }}
+      {{- .Values.fluentBit.config.outputs | nindent 4 }}
+    {{- end }}
   parsers.conf: |
-    # Relevant parsers retrieved from: https://github.com/fluent/fluent-bit/blob/master/conf/parsers.conf
-    [PARSER]
-        Name         docker
-        Format       json
-        Time_Key     time
-        Time_Format  %Y-%m-%dT%H:%M:%S.%L
-        Time_Keep    On
-
-    [PARSER]
-        Name cri
-        Format regex
-        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+  {{- if .Values.fluentBit.config.parsers }}
+    {{- .Values.fluentBit.config.parsers | nindent 4}}
+  {{- end }}

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -37,6 +37,95 @@ fluentBit:
   # - name: HTTPS_PROXY
   #   value: http://example.com:3128
 
+  # New Relic default configuration for fluent-bit.conf (service, inputs, filters, outputs)
+  # and parsers.conf (parsers). The configuration below is not configured for lowDataMode and will
+  # send all attributes.  If custom configuration is required, update these variables.
+  config:
+    service: |
+      [SERVICE]
+          Flush         1
+          Log_Level     ${LOG_LEVEL}
+          Daemon        off
+          Parsers_File  parsers.conf
+          HTTP_Server   On
+          HTTP_Listen   0.0.0.0
+          HTTP_Port     2020
+
+    inputs: |
+      [INPUT]
+          Name              tail
+          Tag               kube.*
+          Path              ${PATH}
+          Parser            ${LOG_PARSER}
+          DB                ${FB_DB}
+          Mem_Buf_Limit     7MB
+          Skip_Long_Lines   On
+          Refresh_Interval  10
+
+    filters: |
+      [FILTER]
+          Name                kubernetes
+          Match               kube.*
+          # We need the full DNS suffix as Windows only supports resolving names with this suffix
+          # See: https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#dns-limitations
+          Kube_URL            https://kubernetes.default.svc.cluster.local:443
+          K8S-Logging.Exclude ${K8S_LOGGING_EXCLUDE}
+
+      [FILTER]
+          Name           record_modifier
+          Match          *
+          Record         cluster_name ${CLUSTER_NAME}
+
+    lowDataModeFilters: |
+      [FILTER]
+          Name           kubernetes
+          Match          kube.*
+          # We need the full DNS suffix as Windows only supports resolving names with this suffix
+          # See: https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#dns-limitations
+          Kube_URL       https://kubernetes.default.svc.cluster.local:443
+          K8S-Logging.Exclude ${K8S_LOGGING_EXCLUDE}
+          Labels         Off
+          Annotations    Off
+
+      [FILTER]
+          Name           nest
+          Match          *
+          Operation      lift
+          Nested_under   kubernetes
+
+      [FILTER]
+          Name           record_modifier
+          Match          *
+          Record         cluster_name ${CLUSTER_NAME}
+          Allowlist_key  container_name
+          Allowlist_key  namespace_name
+          Allowlist_key  pod_name
+          Allowlist_key  stream
+          Allowlist_key  log
+
+    outputs: |
+      [OUTPUT]
+          Name           newrelic
+          Match          *
+          licenseKey     ${LICENSE_KEY}
+          endpoint       ${ENDPOINT}
+          lowDataMode    ${LOW_DATA_MODE}
+
+    parsers: |
+      [PARSER]
+          Name         docker
+          Format       json
+          Time_Key     time
+          Time_Format  %Y-%m-%dT%H:%M:%S.%L
+          Time_Keep    On
+
+      [PARSER]
+          Name cri
+          Format regex
+          Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
+          Time_Key    time
+          Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+
 image:
   repository: newrelic/newrelic-fluentbit-output
   tag: ""


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

The changes in this PR provide users the ability to customize the fluent-bit.conf and parsers.conf files using the values.yaml file. Previously, this was statically set in the configmap.yaml file. This will provide much better flexibility for custom fluent-bit configurations.

#### Which issue this PR fixes

A cleanup and continuation of https://github.com/newrelic/helm-charts/pull/551 (previously closed by me).

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
