### PR TITLE
[nri-prometheus] bump appVersion to v2.11.0

### DIFF
--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to deploy New Relic integrations bundled together
 name: nri-bundle
-version: 3.2.11
+version: 3.2.12
 home: https://github.com/newrelic/helm-charts
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:

--- a/charts/nri-bundle/requirements.lock
+++ b/charts/nri-bundle/requirements.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 2.7.3
 - name: nri-prometheus
   repository: file://../nri-prometheus
-  version: 1.11.0
+  version: 1.12.0
 - name: nri-metadata-injection
   repository: file://../nri-metadata-injection
   version: 2.1.1
@@ -29,5 +29,5 @@ dependencies:
 - name: newrelic-infra-operator
   repository: file://../newrelic-infra-operator
   version: 0.4.0
-digest: sha256:2232ad080415de40a345bfd1cc2003c190dc5581bfd5f3719d0242753e9d5085
-generated: "2021-11-24T13:43:00.367446+01:00"
+digest: sha256:cf82045ee315450c67743ad2135b8b50093bae44720948b74c8e375b74241166
+generated: "2021-11-30T23:00:04.9032928-05:00"

--- a/charts/nri-bundle/requirements.yaml
+++ b/charts/nri-bundle/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   - name: nri-prometheus
     repository: file://../nri-prometheus
     condition: prometheus.enabled
-    version: 1.11.0
+    version: 1.12.0
 
   - name: nri-metadata-injection
     repository: file://../nri-metadata-injection

--- a/charts/nri-prometheus/Chart.yaml
+++ b/charts/nri-prometheus/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 2.10.0
+appVersion: 2.11.0
 description: A Helm chart to deploy the New Relic Prometheus OpenMetrics integration
 name: nri-prometheus
-version: 1.11.0
+version: 1.12.0
 engine: gotpl
 home: https://github.com/newrelic/nri-prometheus
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

#### What this PR does / why we need it:
Adds the ability to filter prometheus metrics by metric type
https://github.com/newrelic/nri-prometheus/releases/tag/v2.11.0

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
