### PR TITLE
[newrelic-logging] allow metadata env vars

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.11.4
+version: 1.11.5
 appVersion: 1.14.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/templates/_helpers.tpl
+++ b/charts/newrelic-logging/templates/_helpers.tpl
@@ -172,3 +172,16 @@ Returns if the template should render, it checks if the required values are set.
 {{- $customSecretKey := include "newrelic-logging.customSecretKey" . -}}
 {{- and (or $licenseKey (and $customSecretName $customSecretKey))}}
 {{- end -}}
+
+{{/*
+If additionalEnvVariables is set, renames to extraEnv. Returns extraEnv.
+*/}}
+{{- define "newrelic-logging.extraEnv" -}}
+{{- if .Values.fluentBit }}
+  {{- if .Values.fluentBit.additionalEnvVariables }}
+    {{- toYaml .Values.fluentBit.additionalEnvVariables -}}
+  {{- else if .Values.fluentBit.extraEnv }}
+    {{- toYaml .Values.fluentBit.extraEnv  -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/newrelic-logging/templates/daemonset-windows.yaml
+++ b/charts/newrelic-logging/templates/daemonset-windows.yaml
@@ -91,10 +91,7 @@ spec:
               value: {{ $.Values.fluentBit.k8sLoggingExclude | quote }}
             - name: LOW_DATA_MODE
               value: {{ include "newrelic-logging.lowDataMode" $ | default "false" | quote }}
-            {{- range $.Values.fluentBit.additionalEnvVariables }}
-            - name: {{ .name }}
-              value: {{ .value }}
-            {{- end }}
+            {{- include "newrelic-logging.extraEnv" . | nindent 12 }}
           command:
             - C:\fluent-bit\bin\fluent-bit.exe
             - -c

--- a/charts/newrelic-logging/templates/daemonset.yaml
+++ b/charts/newrelic-logging/templates/daemonset.yaml
@@ -98,10 +98,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            {{- range .Values.fluentBit.additionalEnvVariables }}
-            - name: {{ .name }}
-              value: {{ .value }}
-            {{- end }}
+            {{- include "newrelic-logging.extraEnv" . | nindent 12 }}
           command:
             - /fluent-bit/bin/fluent-bit
             - -c

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -37,6 +37,10 @@ fluentBit:
   # additionalEnvVariables:
   # - name: HTTPS_PROXY
   #   value: http://example.com:3128
+  # - name: METADATA_NAME
+  #   valueFrom:
+  #     fieldRef:
+  #       fieldPath: metadata.name
 
   # New Relic default configuration for fluent-bit.conf (service, inputs, filters, outputs)
   # and parsers.conf (parsers). The configuration below is not configured for lowDataMode and will

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -33,8 +33,8 @@ fluentBit:
   criEnabled: false
   k8sBufferSize: "32k"
   k8sLoggingExclude: "Off"
-  additionalEnvVariables: []
-  # additionalEnvVariables:
+  extraEnv: []
+  # extraEnv:
   # - name: HTTPS_PROXY
   #   value: http://example.com:3128
   # - name: METADATA_NAME


### PR DESCRIPTION
Problem: [Issue #613][1]. We cannot use `valueFrom` in
`additionalEnvVariables` to add metadata like the pod id as an
environment variable. The code only passes through the `name` and
`value` fields, not `valueFrom`.

Solution: Don't destructure the additionalEnvVariables list at all. Just
emit the whole thing in place.

#### Is this a new chart

No.

#### What this PR does / why we need it:

Allows the use of `valueFrom` in `additionalEnvVars` provided to Fluent Bit containers.

#### Which issue this PR fixes
* fixes #613 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
