### PR TITLE
newrelic-infrastructure-v3: document values, generate README.md

### DIFF
--- a/charts/newrelic-infrastructure-v3/Chart.yaml
+++ b/charts/newrelic-infrastructure-v3/Chart.yaml
@@ -1,19 +1,27 @@
 apiVersion: v2
 name: newrelic-infrastructure-v3
 description: A Helm chart to deploy the New Relic Kubernetes monitoring solution
-version: 3.0.0
+version: 3.0.1
 appVersion: 3.0.0
-home: https://hub.docker.com/r/newrelic/nri-kubernetes/
+kubeVersion: ">=1.16.0-0"
+home: https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration/
 sources:
+  - https://github.com/newrelic/nri-kubernetes/
   - https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-infrastructure
 icon: https://newrelic.com/themes/custom/curio/assets/mediakit/NR_logo_Horizontal.svg
 maintainers:
   - name: alvarocabanas
+    url: https://github.com/alvarocabanas
   - name: carlossscastro
+    url: https://github.com/carlossscastro
   - name: gsanchezgavier
+    url: https://github.com/gsanchezgavier
   - name: kang-makes
+    url: https://github.com/kang-makes
   - name: paologallinaharbur
+    url: https://github.com/paologallinaharbur
   - name: roobre
+    url: https://github.com/roobre
 keywords:
   - infrastructure
   - newrelic

--- a/charts/newrelic-infrastructure-v3/Chart.yaml
+++ b/charts/newrelic-infrastructure-v3/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: newrelic-infrastructure-v3
 description: A Helm chart to deploy the New Relic Kubernetes monitoring solution
-version: 3.0.1
+version: 3.0.2
 appVersion: 3.0.0
 kubeVersion: ">=1.16.0-0"
 home: https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration/

--- a/charts/newrelic-infrastructure-v3/README.md
+++ b/charts/newrelic-infrastructure-v3/README.md
@@ -1,5 +1,95 @@
 [![New Relic Experimental header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Experimental.png)](https://opensource.newrelic.com/oss-category/#new-relic-experimental)
 
-# Helm chart for `nri-kubernetes` v3
+# newrelic-infrastructure-v3
 
-> This chart is not Generally Available yet.
+![Version: 3.0.1](https://img.shields.io/badge/Version-3.0.1-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+
+A Helm chart to deploy the New Relic Kubernetes monitoring solution
+
+**Homepage:** <https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration/>
+
+## Source Code
+
+* <https://github.com/newrelic/nri-kubernetes/>
+* <https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-infrastructure>
+
+## Requirements
+
+Kubernetes: `>=1.16.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| common | object | See `values.yaml` | Config that applies to all instances of the solution: kubelet, ksm, control plane and sidecars. |
+| common.agentConfig | object | `{}` | Config for the Infrastructure agent. Will be used by the forwarder sidecars and the agent running integrations. See: https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/ |
+| common.config.interval | string | `"15s"` | How often the integration should collect and report data. Intervals larger than 40s are not supported and will cause the NR UI to not behave properly. |
+| common.config.timeout | string | `"30s"` | Timeout for the different APIs contacted by the integration: Kubernetes, KSM, Kubelet, etc. |
+| controlPlane | object | See `values.yaml` | Configuration for the DaemonSet that collects metrics from the control plane. |
+| controlPlane.affinity | object | Deployed only in master nodes. | Affinity for the control plane DaemonSet. |
+| controlPlane.config.apiServer | object | Common settings for most K8s distributions. | API Server monitoring configuration |
+| controlPlane.config.apiServer.enabled | bool | `true` | Enable API Server monitoring |
+| controlPlane.config.controllerManager | object | Common settings for most K8s distributions. | Controller manager monitoring configuration |
+| controlPlane.config.controllerManager.enabled | bool | `true` | Enable controller manager monitoring. |
+| controlPlane.config.etcd | object | Common settings for most K8s distributions. | ETCD monitoring configuration |
+| controlPlane.config.etcd.enabled | bool | `true` | Enable etcd monitoring. Might require manual configuration in some environments. |
+| controlPlane.config.scheduler | object | Common settings for most K8s distributions. | Scheduler monitoring configuration |
+| controlPlane.config.scheduler.enabled | bool | `true` | Enable scheduler monitoring. |
+| controlPlane.enabled | bool | `true` | Deploy control plane monitoring DaemonSet. Requires `privileged` mode to be enabled. |
+| controlPlane.kind | string | `"DaemonSet"` | How to deploy the control plane scraper. If autodiscovery is in use, it should be `DaemonSet`. Advanced users using static endpoints set this to `Deployment` to avoid reporting metrics twice. |
+| customAttributes | object | `{}` | Custom attributes to be added to the data reported by all integrations reporting in the cluster. |
+| images | object | See `values.yaml` | Images used by the chart for the integration and agents. |
+| images.agent.repository | string | `"newrelic/infrastructure-bundle"` | Image for the agent and integrations bundle. |
+| images.agent.tag | string | `"2.7.6"` | Tag for the agent and integrations bundle. |
+| images.forwarder.repository | string | `"newrelic/k8s-events-forwarder"` | Image for the agent sidecar. |
+| images.forwarder.tag | string | `"1.20.5"` | Tag for the agent sidecar. |
+| images.integration.repository | string | `"newrelic/nri-kubernetes"` | Image for the kubernetes integration. |
+| images.integration.tag | string | `"0.1.2"` | Tag for the kubernetes integration. |
+| integrations | object | `{}` | Config files for other New Relic integrations that should run in this cluster. |
+| ksm | object | See `values.yaml` | Configuration for the Deployment that collects state metrics from KSM (kube-state-metrics). |
+| ksm.enabled | bool | `true` | Enable cluster state monitoring. Advanced users only. Setting this to `false` is not supported and will break the New Relic experience. |
+| ksm.resources | object | 100m/150M -/850M | Resources for the KSM scraper pod. Keep in mind that sharding is not supported at the moment, so memory usage for this component ramps up quickly on large clusters. |
+| kubelet | object | See `values.yaml` | Configuration for the DaemonSet that collects metrics from the Kubelet |
+| kubelet.enabled | bool | `true` | Enable kubelet monitoring. Advanced users only. Setting this to `false` is not supported and will break the New Relic experience. |
+| podAnnotations | object | `{}` | Annotations to be added to all pods created by the integration. |
+| podLabels | object | `{}` | Labels to be added to all pods created by the integration. |
+| priorityClassName | string | `""` | Pod scheduling priority Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/ |
+| privileged | bool | `true` | Run the integration with full access to the host filesystem and network. Running in this mode allows reporting fine-grained cpu, memory, process and network metrics for your nodes. Additionally, it allows control plane monitoring, which requires hostNetwork to work. |
+| rbac | object | `{"create":true,"pspEnabled":false}` | Settings controlling RBAC objects creation. |
+| rbac.create | bool | `true` | Whether the chart should automatically create the RBAC objects required to run. |
+| rbac.pspEnabled | bool | `false` | Whether the chart should create Pod Security Policy objects. |
+| securityContext | object | See `values.yaml` | Security context used in all the containers of the pods When `privileged == true`, the Kubelet scraper will run as root and ignore these settings. |
+| serviceAccount | object | See `values.yaml` | Settings controlling ServiceAccount creation. |
+| serviceAccount.create | bool | `true` | Whether the chart should automatically create the ServiceAccount objects required to run. |
+| updateStrategy | object | See `values.yaml` | Update strategy for the DaemonSets deployed. |
+| verboseLog | bool | `false` | Enable verbose logging for all components. |
+
+## Maintainers
+
+* [alvarocabanas](https://github.com/alvarocabanas)
+* [carlossscastro](https://github.com/carlossscastro)
+* [gsanchezgavier](https://github.com/gsanchezgavier)
+* [kang-makes](https://github.com/kang-makes)
+* [paologallinaharbur](https://github.com/paologallinaharbur)
+* [roobre](https://github.com/roobre)
+
+## Past Contributors
+
+Previous iterations of this chart started as a community project in the [stable Helm chart repository](github.com/helm/charts/). New Relic is very thankful for all the 15+ community members that contributed and helped maintain the chart there over the years:
+
+* coreypobrien
+* sstarcher
+* jmccarty3
+* slayerjain
+* ryanhope2
+* rk295
+* michaelajr
+* isindir
+* idirouhab
+* ismferd
+* enver
+* diclophis
+* jeffdesc
+* costimuraru
+* verwilst
+* ezelenka

--- a/charts/newrelic-infrastructure-v3/README.md.gotmpl
+++ b/charts/newrelic-infrastructure-v3/README.md.gotmpl
@@ -1,0 +1,50 @@
+[![New Relic Experimental header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Experimental.png)](https://opensource.newrelic.com/oss-category/#new-relic-experimental)
+
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ if .Maintainers }}
+## Maintainers
+{{ range .Maintainers }}
+{{- if .Name }}
+{{- if .Url }}
+* [{{ .Name }}]({{ .Url }})
+{{- else }}
+* {{ .Name }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+## Past Contributors
+
+Previous iterations of this chart started as a community project in the [stable Helm chart repository](github.com/helm/charts/). New Relic is very thankful for all the 15+ community members that contributed and helped maintain the chart there over the years:
+
+* coreypobrien
+* sstarcher
+* jmccarty3
+* slayerjain
+* ryanhope2
+* rk295
+* michaelajr
+* isindir
+* idirouhab
+* ismferd
+* enver
+* diclophis
+* jeffdesc
+* costimuraru
+* verwilst
+* ezelenka

--- a/charts/newrelic-infrastructure-v3/templates/control-plane/configmap.yaml
+++ b/charts/newrelic-infrastructure-v3/templates/control-plane/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "newrelic.labels" . | nindent 4 }}
   name: {{ template "newrelic.fullname" . }}-control-plane
 data:
-  nri-kubernetes-config.yml: |
+  nri-kubernetes.yml: |
     {{- .Values.common.config | toYaml | nindent 4 }}
     controlPlane:
       enabled: true

--- a/charts/newrelic-infrastructure-v3/templates/control-plane/daemonset.yaml
+++ b/charts/newrelic-infrastructure-v3/templates/control-plane/daemonset.yaml
@@ -82,8 +82,8 @@ spec:
           {{- end }}
           volumeMounts:
             - name: nri-kubernetes-config
-              mountPath: /etc/newrelic-infra/integrations.d/nri-kubernetes-config.yml
-              subPath: nri-kubernetes-config.yml
+              mountPath: /etc/newrelic-infra/nri-kubernetes.yml
+              subPath: nri-kubernetes.yml
             - mountPath: /tmp
               name: control-plane-tmpfs-tmp
             {{- with .Values.controlPlane.extraVolumeMounts }}
@@ -172,8 +172,8 @@ spec:
           configMap:
             name: {{ template "newrelic.fullname" . }}-control-plane
             items:
-              - key: nri-kubernetes-config.yml
-                path: nri-kubernetes-config.yml
+              - key: nri-kubernetes.yml
+                path: nri-kubernetes.yml
         - name: forwarder-tmpfs-data
           emptyDir: {}
         - name: forwarder-tmpfs-user-data

--- a/charts/newrelic-infrastructure-v3/templates/ksm/configmap.yaml
+++ b/charts/newrelic-infrastructure-v3/templates/ksm/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "newrelic.labels" . | nindent 4 }}
   name: {{ template "newrelic.fullname" . }}-ksm
 data:
-  nri-kubernetes-config.yml: |
+  nri-kubernetes.yml: |
     {{- .Values.common.config | toYaml | nindent 4 }}
     ksm:
       enabled: true

--- a/charts/newrelic-infrastructure-v3/templates/ksm/deployment.yaml
+++ b/charts/newrelic-infrastructure-v3/templates/ksm/deployment.yaml
@@ -68,8 +68,8 @@ spec:
           {{- end }}
           volumeMounts:
             - name: nri-kubernetes-config
-              mountPath: /etc/newrelic-infra/integrations.d/nri-kubernetes-config.yml
-              subPath: nri-kubernetes-config.yml
+              mountPath: /etc/newrelic-infra/nri-kubernetes.yml
+              subPath: nri-kubernetes.yml
             - mountPath: /tmp
               name: ksm-tmpfs-tmp
             {{- with .Values.ksm.extraVolumeMounts }}
@@ -158,8 +158,8 @@ spec:
           configMap:
             name: {{ template "newrelic.fullname" . }}-ksm
             items:
-              - key: nri-kubernetes-config.yml
-                path: nri-kubernetes-config.yml
+              - key: nri-kubernetes.yml
+                path: nri-kubernetes.yml
         - name: forwarder-tmpfs-data
           emptyDir: {}
         - name: forwarder-tmpfs-user-data

--- a/charts/newrelic-infrastructure-v3/templates/kubelet/configmap.yaml
+++ b/charts/newrelic-infrastructure-v3/templates/kubelet/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "newrelic.labels" . | nindent 4 }}
   name: {{ template "newrelic.fullname" . }}-kubelet
 data:
-  nri-kubernetes-config.yml: |
+  nri-kubernetes.yml: |
     {{- .Values.common.config | toYaml | nindent 4 }}
     kubelet:
       enabled: true

--- a/charts/newrelic-infrastructure-v3/templates/kubelet/daemonset.yaml
+++ b/charts/newrelic-infrastructure-v3/templates/kubelet/daemonset.yaml
@@ -80,8 +80,8 @@ spec:
           {{- end }}
           volumeMounts:
             - name: nri-kubernetes-config
-              mountPath: /etc/newrelic-infra/integrations.d/nri-kubernetes-config.yml
-              subPath: nri-kubernetes-config.yml
+              mountPath: /etc/newrelic-infra/nri-kubernetes.yml
+              subPath: nri-kubernetes.yml
             - mountPath: /tmp
               name: kubelet-tmpfs-tmp
             {{- with .Values.kubelet.extraVolumeMounts }}
@@ -230,8 +230,8 @@ spec:
           configMap:
             name: {{ template "newrelic.fullname" . }}-kubelet
             items:
-              - key: nri-kubernetes-config.yml
-                path: nri-kubernetes-config.yml
+              - key: nri-kubernetes.yml
+                path: nri-kubernetes.yml
         {{- if .Values.common.agentConfig }}
         - name: config
           configMap:

--- a/charts/newrelic-infrastructure-v3/values.yaml
+++ b/charts/newrelic-infrastructure-v3/values.yaml
@@ -1,32 +1,55 @@
-# Default values for newrelic-infrastructure.
-nameOverride: ""
-fullnameOverride: ""
+# nameOverride: ""
+# fullnameOverride: ""
 
+# -- Images used by the chart for the integration and agents.
+# @default -- See `values.yaml`
 images:
   pullSecrets: []
+  # Image for the New Relic Infrastructure Agent sidecar.
   forwarder:
     pullPolicy: IfNotPresent
+    # -- Tag for the agent sidecar.
     tag: 1.20.5
+    # -- Image for the agent sidecar.
     repository: newrelic/k8s-events-forwarder
     registry: docker.io
+  # Image for the New Relic Infrastructure Agent plus integrations.
   agent:
     pullPolicy: IfNotPresent
+    # -- Tag for the agent and integrations bundle.
     tag: 2.7.6
+    # -- Image for the agent and integrations bundle.
     repository: newrelic/infrastructure-bundle
     registry: docker.io
+  # Image for the New Relic Kubernetes integration.
   integration:
     pullPolicy: IfNotPresent
+    # -- Tag for the kubernetes integration.
     tag: 0.1.2
+    # -- Image for the kubernetes integration.
     repository: newrelic/nri-kubernetes
     registry: docker.io
 
+# -- Config that applies to all instances of the solution: kubelet, ksm, control plane and sidecars.
+# @default -- See `values.yaml`
 common:
+  # Configuration entries that apply to all instances of the integration: kubelet, ksm and control plane.
   config:
+    # -- How often the integration should collect and report data.
+    # Intervals larger than 40s are not supported and will cause the NR UI to not behave properly.
     interval: 15s
+    # -- Timeout for the different APIs contacted by the integration: Kubernetes, KSM, Kubelet, etc.
     timeout: 30s
+  # -- Config for the Infrastructure agent.
+  # Will be used by the forwarder sidecars and the agent running integrations.
+  # See: https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/
   agentConfig: {}
 
+# -- Configuration for the DaemonSet that collects metrics from the Kubelet
+# @default -- See `values.yaml`
 kubelet:
+  # -- Enable kubelet monitoring.
+  # Advanced users only. Setting this to `false` is not supported and will break the New Relic experience.
   enabled: true
   annotations: {}
   tolerations:
@@ -37,21 +60,9 @@ kubelet:
   nodeSelector: {}
   affinity:
     nodeAffinity: {}
-  # Extra env ‘items’ that will be added to the definition of the containers; a string is expected (can be templated).
-  # extraEnv:
-  #  - name: ENV_VAR1
-  #    value: "var1"
-  #  - name: ENV_VAR2
-  #    value: "var2"
   extraEnv: []
-  # Extra envFrom ‘items’ that will be added to the definition of the containers; a string is expected (can be templated).
-  # extraEnvFrom:
-  #  - configMapRef:
-  #      name: 'another-config-map'
   extraEnvFrom: []
-  # Mount additional volumes into the pod.
   extraVolumes: []
-  # Mount additional volume Mounts into the pod.
   extraVolumeMounts: []
   resources:
     limits:
@@ -61,7 +72,11 @@ kubelet:
       memory: 150M
   config: {}
 
+# -- Configuration for the Deployment that collects state metrics from KSM (kube-state-metrics).
+# @default -- See `values.yaml`
 ksm:
+  # -- Enable cluster state monitoring.
+  # Advanced users only. Setting this to `false` is not supported and will break the New Relic experience.
   enabled: true
   annotations: {}
   tolerations:
@@ -80,31 +95,26 @@ ksm:
                 app.kubernetes.io/name: kube-state-metrics
           weight: 100
     nodeAffinity: {}
-  # Extra env ‘items’ that will be added to the definition of the containers; a string is expected (can be templated).
-  # extraEnv:
-  #  - name: ENV_VAR1
-  #    value: "var1"
-  #  - name: ENV_VAR2
-  #    value: "var2"
   extraEnv: []
-  # Extra envFrom ‘items’ that will be added to the definition of the containers; a string is expected (can be templated).
-  # extraEnvFrom:
-  #  - configMapRef:
-  #      name: 'another-config-map'
   extraEnvFrom: []
-  # Mount additional volumes into the pod.
   extraVolumes: []
-  # Mount additional volume Mounts into the pod.
   extraVolumeMounts: []
+  # -- Resources for the KSM scraper pod.
+  # Keep in mind that sharding is not supported at the moment, so memory usage for this component ramps up quickly on
+  # large clusters.
+  # @default -- 100m/150M -/850M
   resources:
     limits:
-      memory: 300M
+      memory: 850M  # Bump me up if KSM pod shows restarts.
     requests:
       cpu: 100m
       memory: 150M
   config: {}
 
+# -- Configuration for the DaemonSet that collects metrics from the control plane.
+# @default -- See `values.yaml`
 controlPlane:
+  # -- Deploy control plane monitoring DaemonSet. Requires `privileged` mode to be enabled.
   enabled: true
   annotations: {}
   tolerations:
@@ -113,6 +123,8 @@ controlPlane:
     - operator: "Exists"
       effect: "NoExecute"
   nodeSelector: {}
+  # -- Affinity for the control plane DaemonSet.
+  # @default -- Deployed only in master nodes.
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -129,22 +141,12 @@ controlPlane:
           - matchExpressions:
               - key: node-role.kubernetes.io/master
                 operator: Exists
+  # -- How to deploy the control plane scraper. If autodiscovery is in use, it should be `DaemonSet`.
+  # Advanced users using static endpoints set this to `Deployment` to avoid reporting metrics twice.
   kind: DaemonSet
-  # Extra env ‘items’ that will be added to the definition of the containers; a string is expected (can be templated).
-  # extraEnv:
-  #  - name: ENV_VAR1
-  #    value: "var1"
-  #  - name: ENV_VAR2
-  #    value: "var2"
   extraEnv: []
-  # Extra envFrom ‘items’ that will be added to the definition of the containers; a string is expected (can be templated).
-  # extraEnvFrom:
-  #  - configMapRef:
-  #      name: 'another-config-map'
   extraEnvFrom: []
-  # Mount additional volumes into the pod.
   extraVolumes: []
-  # Mount additional volume Mounts into the pod.
   extraVolumeMounts: []
   resources:
     limits:
@@ -153,12 +155,20 @@ controlPlane:
       cpu: 100m
       memory: 150M
   config:
+    # -- ETCD monitoring configuration
+    # @default -- Common settings for most K8s distributions.
     etcd:
+      # -- Enable etcd monitoring. Might require manual configuration in some environments.
       enabled: true
+      # Discover etcd pods using the following namespaces and selectors.
+      # If a pod matches the selectors, the scraper will attempt to reach it through the `endpoints` defined below.
       autodiscover:
         - selector: "tier=control-plane,component=etcd"
           namespace: kube-system
+          # Set to true to consider only pods sharing the node with the scraper pod.
+          # This should be set to `true` if Kind is Daemonset, `false` otherwise.
           matchNode: true
+          # Try to reach etcd using the following endpoints.
           endpoints:
             - url: https://localhost:4001
               insecureSkipVerify: true
@@ -181,7 +191,8 @@ controlPlane:
               insecureSkipVerify: true
               auth:
                 type: bearer
-      ## OpenShift
+      # Openshift users might want to remove previous autodiscover entries and add this one instead.
+      # Manual steps are required to create a secret containing the required TLS certificates to connect to etcd.
       # - selector: "k8s-app=etcd"
       #   namespace: kube-system
       #   matchNode: true
@@ -193,7 +204,10 @@ controlPlane:
       #         mtls:
       #           secretName: secret-name
       #           secretNamespace: secret-namespace
+    # -- Scheduler monitoring configuration
+    # @default -- Common settings for most K8s distributions.
     scheduler:
+      # -- Enable scheduler monitoring.
       enabled: true
       autodiscover:
         - selector: "tier=control-plane,component=kube-scheduler"
@@ -220,7 +234,10 @@ controlPlane:
               insecureSkipVerify: true
               auth:
                 type: bearer
+    # -- Controller manager monitoring configuration
+    # @default -- Common settings for most K8s distributions.
     controllerManager:
+      # -- Enable controller manager monitoring.
       enabled: true
       autodiscover:
         - selector: "tier=control-plane,component=kube-controller-manager"
@@ -258,7 +275,10 @@ controlPlane:
               insecureSkipVerify: true
               auth:
                 type: bearer
+    # -- API Server monitoring configuration
+    # @default -- Common settings for most K8s distributions.
     apiServer:
+      # -- Enable API Server monitoring
       enabled: true
       autodiscover:
         - selector: "tier=control-plane,component=kube-apiserver"
@@ -288,70 +308,61 @@ controlPlane:
               auth:
                 type: bearer
 
-# K8s DaemonSets update strategy.
+# -- Update strategy for the DaemonSets deployed.
+# @default -- See `values.yaml`
 updateStrategy:
   type: RollingUpdate
   rollingUpdate:
     maxUnavailable: 1
 
-# Kubelet's agent envs
-# Custom attributes to be passed to the New Relic agent
+# -- Custom attributes to be added to the data reported by all integrations reporting in the cluster.
 customAttributes: {}
 
-# Accounts and subaccounts created before July 20, 2020 will report, by default, process metrics unless this config option is explicitly set to "false"
-# On the other hand New Relic accounts created after July 20, 2020 will **not** send, by default, any process metrics unless this config option is explicitly set to "true",
-# https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1120
-# enableProcessMetrics: "false"
-
-# This can be set, the default is shown below
-# logFile: /var/log/nr-infra.log
-
+# -- Enable verbose logging for all components.
 verboseLog: false
 
+# -- Settings controlling ServiceAccount creation.
+# @default -- See `values.yaml`
 serviceAccount:
+  # -- Whether the chart should automatically create the ServiceAccount objects required to run.
   create: true
   annotations: {}
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# -- Annotations to be added to all pods created by the integration.
 podAnnotations: {}
+# -- Labels to be added to all pods created by the integration.
 podLabels: {}
 
-# Pod scheduling priority
+# -- Pod scheduling priority
 # Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
-# priorityClassName: high-priority
 priorityClassName: ""
 
-# Used in all the containers of the pods except the kubelet agent on privileged mode
-# The default user may be restricted on OpenShift clusters where the runAsUser range
-# is restricted.  See OpenShift docs for more information.
-# https://www.openshift.com/blog/a-guide-to-openshift-and-uids
+# -- Security context used in all the containers of the pods
+# When `privileged == true`, the Kubelet scraper will run as root and ignore these settings.
+# @default -- See `values.yaml`
 securityContext:
+  # OpenShift users might want to change the default UID:GID to be inside the allowed range.
   runAsUser: 1000
   runAsGroup: 2000
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
 
+# -- Run the integration with full access to the host filesystem and network.
+# Running in this mode allows reporting fine-grained cpu, memory, process and network metrics for your nodes.
+# Additionally, it allows control plane monitoring, which requires hostNetwork to work.
 privileged: true
 
+# -- Settings controlling RBAC objects creation.
 rbac:
-  # Specifies whether RBAC resources should be created
+  # -- Whether the chart should automatically create the RBAC objects required to run.
   create: true
+  # -- Whether the chart should create Pod Security Policy objects.
   pspEnabled: false
 
-# Sends data to staging, can be set as a global.
-# global.nrStaging
-# nrStaging: false
-
-# prefix nodes display name with cluster to reduce chances of collisions
-prefixDisplayNameWithCluster: false
-
-# 'true' will use the node name as the name for the "host",
-#  note that it may cause data collision if the node name is the same in different clusters
-#  and prefixDisplayNameWithCluster is not set to true.
-# 'false' will use the host name as the name for the "host".
-useNodeNameAsDisplayName: true
-
+# -- Config files for other New Relic integrations that should run in this cluster.
+integrations: {}
 # If you wish to monitor services running on Kubernetes you can provide integrations
 # configuration under `integrations`. You just need to create a new entry where
 # the key is the filename of the configuration file and the value is the content of
@@ -361,7 +372,6 @@ useNodeNameAsDisplayName: true
 # https://docs.newrelic.com/docs/integrations/integrations-sdk/file-specifications/integration-configuration-file-specifications-agent-v180
 # For example, if you wanted to monitor a Redis instance that has a label "app=sampleapp"
 # you could do so by adding following entry:
-integrations:
 #  nri-redis-sampleapp:
 #    discovery:
 #      command:
@@ -378,3 +388,19 @@ integrations:
 #          PORT: 6379
 #        labels:
 #          env: test
+
+# Collect detailed metrics from processes running in the host.
+# @default -- [True only for accounts created before July 20, 2020.](https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1120)
+# enableProcessMetrics: false
+
+# Send data to New Relic Staging. Requires an staging-specific License Key.
+# nrStaging: false
+
+# Prefix nodes display name with cluster to reduce chances of collisions
+# prefixDisplayNameWithCluster: false
+
+# 'true' will use the node name as the name for the "host",
+#  note that it may cause data collision if the node name is the same in different clusters
+#  and prefixDisplayNameWithCluster is not set to true.
+# 'false' will use the host name as the name for the "host".
+# useNodeNameAsDisplayName: true


### PR DESCRIPTION
This PR adds some documentation to the values.yml file, and makes use of https://github.com/norwoodj/helm-docs to autogenerate a README.md file with documentation from the same `values.yml` file and `README.md.gotmpl`.

To regenerate this README.md again, just run `helm-docs`:
- `go run github.com/norwoodj/helm-docs/cmd/helm-docs`
- `docker run --rm --volume "$(pwd):/helm-docs" -u $(id -u) jnorwood/helm-docs:latest`

Closes #635