### PR TITLE
[newrelic-bundle] adding new v3 chart

### DIFF
--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -1,8 +1,7 @@
 apiVersion: v1
-appVersion: "1.0"
 description: A Helm chart to deploy New Relic integrations bundled together
 name: nri-bundle
-version: 3.2.11
+version: 4.0.0
 home: https://github.com/newrelic/helm-charts
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:

--- a/charts/nri-bundle/requirements.lock
+++ b/charts/nri-bundle/requirements.lock
@@ -2,9 +2,12 @@ dependencies:
 - name: newrelic-infrastructure
   repository: file://../newrelic-infrastructure
   version: 2.7.3
+- name: newrelic-infrastructure-v3
+  repository: file://../newrelic-infrastructure-v3
+  version: 3.0.3
 - name: nri-prometheus
   repository: file://../nri-prometheus
-  version: 1.11.0
+  version: 1.12.0
 - name: nri-metadata-injection
   repository: file://../nri-metadata-injection
   version: 2.1.1
@@ -29,5 +32,5 @@ dependencies:
 - name: newrelic-infra-operator
   repository: file://../newrelic-infra-operator
   version: 0.4.0
-digest: sha256:2232ad080415de40a345bfd1cc2003c190dc5581bfd5f3719d0242753e9d5085
-generated: "2021-11-24T13:43:00.367446+01:00"
+digest: sha256:842a45827b0508e140d0f7614c21f74c36402e0f4e832d62f974c1abaf88f281
+generated: "2022-01-04T19:07:36.524776+01:00"

--- a/charts/nri-bundle/requirements.yaml
+++ b/charts/nri-bundle/requirements.yaml
@@ -1,13 +1,21 @@
 dependencies:
+  # Old newrelic-infrastructure chart, now deprecated.
   - name: newrelic-infrastructure
     repository: file://../newrelic-infrastructure
     condition: infrastructure.enabled
     version: 2.7.3
 
+  # New newrelic-infrastructure chart.
+  - name: newrelic-infrastructure-v3
+    alias: newrelic-infrastructure
+    repository: file://../newrelic-infrastructure-v3
+    condition: newrelic-infrastructure-v3.enabled
+    version: 3.0.3
+
   - name: nri-prometheus
     repository: file://../nri-prometheus
     condition: prometheus.enabled
-    version: 1.11.0
+    version: 1.12.0
 
   - name: nri-metadata-injection
     repository: file://../nri-metadata-injection

--- a/charts/nri-bundle/templates/NOTES.txt
+++ b/charts/nri-bundle/templates/NOTES.txt
@@ -1,0 +1,48 @@
+{{- if and .Values.infrastructure.enabled (index .Values "newrelic-infrastructure-beta").enabled }}
+ _________________________________________
+/ You cannot enable the legacy and the v3 \
+| infrastructure charts at the same time. |
+| Please set infrastructure.enabled to    |
+\ false in your values.                   /
+ -----------------------------------------
+    \
+     \
+      \
+                    ##        .
+              ## ## ##       ==
+           ## ## ## ##      ===
+       /""""""""""""""""___/ ===
+  ~~~ {~~ ~~~~ ~~~ ~~~~ ~~ ~ /  ===- ~~~
+       \______ o          __/
+        \    \        __/
+          \____\______/
+{{- fail "You cannot enable the legacy and the v3 infrastructure charts at the same time." }}
+{{- end }}
+
+{{- if and (index .Values "newrelic-infrastructure-beta").enabled .Release.IsUpgrade }}
+Congratulations!
+You just upgraded to:
+
+             _        _          _                          _
+            (_)      | |        | |                        | |
+  _ __  _ __ _ ______| | ___   _| |__   ___ _ __ _ __   ___| |_ ___  ___
+ | '_ \| '__| |______| |/ / | | | '_ \ / _ \ '__| '_ \ / _ \ __/ _ \/ __|
+ | | | | |  | |      |   <| |_| | |_) |  __/ |  | | | |  __/ ||  __/\__ \
+ |_| |_|_|_ |_|      |_|\_\\__,_|_.__/ \___|_|  |_| |_|\___|\__\___||___/
+      |___ \
+ __   ____) |
+ \ \ / /__ <
+  \ V /___) |
+   \_/|____/
+
+In this major release we have changed quite a few things:
+* Our monolithic DaemonSet has been split into several, more lightweight
+  components allowing for better resource tuning.
+* Enabling monitoring of the control plane, including out-of-cluster control
+  planes is now easier to do.
+* Logs and error messages have been strongly revamped, providing more
+  actionable and less noisy messages.
+
+And much more! Please check the full release notes below:
+https://placeholder.link # TODO
+{{- end }}

--- a/charts/nri-bundle/values.yaml
+++ b/charts/nri-bundle/values.yaml
@@ -3,8 +3,13 @@
 # Declare variables to be passed into your templates.
 
 # enables newrelic-infrastructure
+# Legacy nri-kubernetes chart, disabled by default
 infrastructure:
   enabled: true
+
+# Latest nri-kubernetes chart
+newrelic-infrastructure-v3:
+  enabled: false
 
 # enables nri-prometheus
 prometheus:


### PR DESCRIPTION

#### Is this a new chart
no
#### What this PR does / why we need it:
adds the new v3 infra chart to the nri-budle

#### Which issue this PR fixes
This PR allow installing the PR being developed in #624 from the nri-bundle, by flipping newrelic-infrastructure-beta.enabled to true and infrastructure to false.

#### Special notes for your reviewer:
Basically the code from https://github.com/newrelic/helm-charts/pull/631, created a new PR since I was facing too many conflicts rebasing

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
