### PR TITLE
newrelic-infrastructure-v3: add a separate hostNetwork toggle for control plane monitoring

### DIFF
--- a/charts/newrelic-infrastructure-v3/Chart.yaml
+++ b/charts/newrelic-infrastructure-v3/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: newrelic-infrastructure-v3
 description: A Helm chart to deploy the New Relic Kubernetes monitoring solution
-version: 3.0.4
+version: 3.0.5
 appVersion: 3.0.0
 kubeVersion: ">=1.16.0-0"
 home: https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration/

--- a/charts/newrelic-infrastructure-v3/README.md
+++ b/charts/newrelic-infrastructure-v3/README.md
@@ -23,8 +23,8 @@ Kubernetes: `>=1.16.0-0`
 |-----|------|---------|-------------|
 | common | object | See `values.yaml` | Config that applies to all instances of the solution: kubelet, ksm, control plane and sidecars. |
 | common.agentConfig | object | `{}` | Config for the Infrastructure agent. Will be used by the forwarder sidecars and the agent running integrations. See: https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/ |
-| common.config.interval | duration | `15s` if `lowDataMode == false`, `30s` otherwise. | Intervals larger than 40s are not supported and will cause the NR UI to not behave properly. |
-| controlPlane | object | See `values.yaml` | Configuration for the DaemonSet that collects metrics from the control plane. |
+| common.config.interval | duration | `15s` if `lowDataMode == false`, `30s` otherwise. | Intervals larger than 40s are not supported and will cause the NR UI to not behave properly. Any non-nil value will override the `lowDataMode` default. |
+| controlPlane | object | See `values.yaml` | Configuration for the control plane scraper. |
 | controlPlane.affinity | object | Deployed only in master nodes. | Affinity for the control plane DaemonSet. |
 | controlPlane.config.apiServer | object | Common settings for most K8s distributions. | API Server monitoring configuration |
 | controlPlane.config.apiServer.enabled | bool | `true` | Enable API Server monitoring |
@@ -34,9 +34,9 @@ Kubernetes: `>=1.16.0-0`
 | controlPlane.config.etcd.enabled | bool | `true` | Enable etcd monitoring. Might require manual configuration in some environments. |
 | controlPlane.config.scheduler | object | Common settings for most K8s distributions. | Scheduler monitoring configuration |
 | controlPlane.config.scheduler.enabled | bool | `true` | Enable scheduler monitoring. |
-| controlPlane.enabled | bool | `true` | Deploy control plane monitoring DaemonSet. |
+| controlPlane.enabled | bool | `true` | Deploy control plane monitoring component. |
 | controlPlane.kind | string | `"DaemonSet"` | How to deploy the control plane scraper. If autodiscovery is in use, it should be `DaemonSet`. Advanced users using static endpoints set this to `Deployment` to avoid reporting metrics twice. |
-| controlPlane.unprivilegedHostNetwork | bool | `false` | Run Control Plane scraper with hostNetwork even if privileged is set to false. hostNetwork is required for most control plane configuration, as they only accept connections from localhost. |
+| controlPlane.unprivilegedHostNetwork | bool | `false` | Run Control Plane scraper with `hostNetwork` even if `privileged` is set to false. `hostNetwork` is required for most control plane configurations, as they only accept connections from localhost. |
 | customAttributes | object | `{}` | Custom attributes to be added to the data reported by all integrations reporting in the cluster. |
 | images | object | See `values.yaml` | Images used by the chart for the integration and agents. |
 | images.agent.repository | string | `"newrelic/infrastructure-bundle"` | Image for the agent and integrations bundle. |
@@ -51,7 +51,7 @@ Kubernetes: `>=1.16.0-0`
 | ksm.resources | object | 100m/150M -/850M | Resources for the KSM scraper pod. Keep in mind that sharding is not supported at the moment, so memory usage for this component ramps up quickly on large clusters. |
 | kubelet | object | See `values.yaml` | Configuration for the DaemonSet that collects metrics from the Kubelet. |
 | kubelet.enabled | bool | `true` | Enable kubelet monitoring. Advanced users only. Setting this to `false` is not supported and will break the New Relic experience. |
-| lowDataMode | bool | false | Enables low data mode sending less data by incrementing the interval from "15s" (the default when `lowDataMode` is `false` or `nil`) to "30s". Will be ignored if `.common.config.interval` is set. |
+| lowDataMode | bool | `false` | Send less data by incrementing the interval from `15s` (the default when `lowDataMode` is `false` or `nil`) to `30s`. Non-nil values of `common.config.interval` will override this value. |
 | podAnnotations | object | `{}` | Annotations to be added to all pods created by the integration. |
 | podLabels | object | `{}` | Labels to be added to all pods created by the integration. |
 | priorityClassName | string | `""` | Pod scheduling priority Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/ |

--- a/charts/newrelic-infrastructure-v3/README.md
+++ b/charts/newrelic-infrastructure-v3/README.md
@@ -2,7 +2,7 @@
 
 # newrelic-infrastructure-v3
 
-![Version: 3.0.4](https://img.shields.io/badge/Version-3.0.4-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 3.0.5](https://img.shields.io/badge/Version-3.0.5-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 A Helm chart to deploy the New Relic Kubernetes monitoring solution
 
@@ -48,22 +48,8 @@ Kubernetes: `>=1.16.0-0`
 | ksm | object | See `values.yaml` | Configuration for the Deployment that collects state metrics from KSM (kube-state-metrics). |
 | ksm.enabled | bool | `true` | Enable cluster state monitoring. Advanced users only. Setting this to `false` is not supported and will break the New Relic experience. |
 | ksm.resources | object | 100m/150M -/850M | Resources for the KSM scraper pod. Keep in mind that sharding is not supported at the moment, so memory usage for this component ramps up quickly on large clusters. |
-| kubelet.affinity.nodeAffinity | object | `{}` |  |
-| kubelet.annotations | object | `{}` |  |
-| kubelet.config | object | `{}` |  |
+| kubelet | object | See `values.yaml` | Configuration for the DaemonSet that collects metrics from the Kubelet. |
 | kubelet.enabled | bool | `true` | Enable kubelet monitoring. Advanced users only. Setting this to `false` is not supported and will break the New Relic experience. |
-| kubelet.extraEnv | list | `[]` |  |
-| kubelet.extraEnvFrom | list | `[]` |  |
-| kubelet.extraVolumeMounts | list | `[]` |  |
-| kubelet.extraVolumes | list | `[]` |  |
-| kubelet.nodeSelector | object | `{}` |  |
-| kubelet.resources.limits.memory | string | `"300M"` |  |
-| kubelet.resources.requests.cpu | string | `"100m"` |  |
-| kubelet.resources.requests.memory | string | `"150M"` |  |
-| kubelet.tolerations[0].effect | string | `"NoSchedule"` |  |
-| kubelet.tolerations[0].operator | string | `"Exists"` |  |
-| kubelet.tolerations[1].effect | string | `"NoExecute"` |  |
-| kubelet.tolerations[1].operator | string | `"Exists"` |  |
 | podAnnotations | object | `{}` | Annotations to be added to all pods created by the integration. |
 | podLabels | object | `{}` | Labels to be added to all pods created by the integration. |
 | priorityClassName | string | `""` | Pod scheduling priority Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/ |

--- a/charts/newrelic-infrastructure-v3/README.md
+++ b/charts/newrelic-infrastructure-v3/README.md
@@ -2,7 +2,7 @@
 
 # newrelic-infrastructure-v3
 
-![Version: 3.0.1](https://img.shields.io/badge/Version-3.0.1-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 3.0.4](https://img.shields.io/badge/Version-3.0.4-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 A Helm chart to deploy the New Relic Kubernetes monitoring solution
 
@@ -21,11 +21,8 @@ Kubernetes: `>=1.16.0-0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| lowDataMode | bool | `nil` | Enables low data mode sending less data by incrementing the interval from "15s" (the default when `lowDataMode` is `false` or `nil`) to "30s". Can be superseded by `.common.config.interval` |
 | common | object | See `values.yaml` | Config that applies to all instances of the solution: kubelet, ksm, control plane and sidecars. |
 | common.agentConfig | object | `{}` | Config for the Infrastructure agent. Will be used by the forwarder sidecars and the agent running integrations. See: https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/ |
-| common.config.interval | string | `nil` | How often the integration should collect and report data. Intervals larger than 40s are not supported and will cause the NR UI to not behave properly. This value takes precedence over `lowDataMode` but if this value is undefined its default from 15s (without low data mode) to 30s (with low data mode enabled) |
-| common.config.timeout | string | `"30s"` | Timeout for the different APIs contacted by the integration: Kubernetes, KSM, Kubelet, etc. |
 | controlPlane | object | See `values.yaml` | Configuration for the DaemonSet that collects metrics from the control plane. |
 | controlPlane.affinity | object | Deployed only in master nodes. | Affinity for the control plane DaemonSet. |
 | controlPlane.config.apiServer | object | Common settings for most K8s distributions. | API Server monitoring configuration |
@@ -36,8 +33,9 @@ Kubernetes: `>=1.16.0-0`
 | controlPlane.config.etcd.enabled | bool | `true` | Enable etcd monitoring. Might require manual configuration in some environments. |
 | controlPlane.config.scheduler | object | Common settings for most K8s distributions. | Scheduler monitoring configuration |
 | controlPlane.config.scheduler.enabled | bool | `true` | Enable scheduler monitoring. |
-| controlPlane.enabled | bool | `true` | Deploy control plane monitoring DaemonSet. Requires `privileged` mode to be enabled. |
+| controlPlane.enabled | bool | `true` | Deploy control plane monitoring DaemonSet. |
 | controlPlane.kind | string | `"DaemonSet"` | How to deploy the control plane scraper. If autodiscovery is in use, it should be `DaemonSet`. Advanced users using static endpoints set this to `Deployment` to avoid reporting metrics twice. |
+| controlPlane.unprivilegedHostNetwork | bool | `false` | Run Control Plane scraper with hostNetwork even if privileged is set to false. hostNetwork is required for most control plane configuration, as they only accept connections from localhost. |
 | customAttributes | object | `{}` | Custom attributes to be added to the data reported by all integrations reporting in the cluster. |
 | images | object | See `values.yaml` | Images used by the chart for the integration and agents. |
 | images.agent.repository | string | `"newrelic/infrastructure-bundle"` | Image for the agent and integrations bundle. |
@@ -50,8 +48,22 @@ Kubernetes: `>=1.16.0-0`
 | ksm | object | See `values.yaml` | Configuration for the Deployment that collects state metrics from KSM (kube-state-metrics). |
 | ksm.enabled | bool | `true` | Enable cluster state monitoring. Advanced users only. Setting this to `false` is not supported and will break the New Relic experience. |
 | ksm.resources | object | 100m/150M -/850M | Resources for the KSM scraper pod. Keep in mind that sharding is not supported at the moment, so memory usage for this component ramps up quickly on large clusters. |
-| kubelet | object | See `values.yaml` | Configuration for the DaemonSet that collects metrics from the Kubelet |
+| kubelet.affinity.nodeAffinity | object | `{}` |  |
+| kubelet.annotations | object | `{}` |  |
+| kubelet.config | object | `{}` |  |
 | kubelet.enabled | bool | `true` | Enable kubelet monitoring. Advanced users only. Setting this to `false` is not supported and will break the New Relic experience. |
+| kubelet.extraEnv | list | `[]` |  |
+| kubelet.extraEnvFrom | list | `[]` |  |
+| kubelet.extraVolumeMounts | list | `[]` |  |
+| kubelet.extraVolumes | list | `[]` |  |
+| kubelet.nodeSelector | object | `{}` |  |
+| kubelet.resources.limits.memory | string | `"300M"` |  |
+| kubelet.resources.requests.cpu | string | `"100m"` |  |
+| kubelet.resources.requests.memory | string | `"150M"` |  |
+| kubelet.tolerations[0].effect | string | `"NoSchedule"` |  |
+| kubelet.tolerations[0].operator | string | `"Exists"` |  |
+| kubelet.tolerations[1].effect | string | `"NoExecute"` |  |
+| kubelet.tolerations[1].operator | string | `"Exists"` |  |
 | podAnnotations | object | `{}` | Annotations to be added to all pods created by the integration. |
 | podLabels | object | `{}` | Labels to be added to all pods created by the integration. |
 | priorityClassName | string | `""` | Pod scheduling priority Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/ |

--- a/charts/newrelic-infrastructure-v3/README.md
+++ b/charts/newrelic-infrastructure-v3/README.md
@@ -23,6 +23,7 @@ Kubernetes: `>=1.16.0-0`
 |-----|------|---------|-------------|
 | common | object | See `values.yaml` | Config that applies to all instances of the solution: kubelet, ksm, control plane and sidecars. |
 | common.agentConfig | object | `{}` | Config for the Infrastructure agent. Will be used by the forwarder sidecars and the agent running integrations. See: https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/ |
+| common.config.interval | duration | `15s` if `lowDataMode == false`, `30s` otherwise. | Intervals larger than 40s are not supported and will cause the NR UI to not behave properly. |
 | controlPlane | object | See `values.yaml` | Configuration for the DaemonSet that collects metrics from the control plane. |
 | controlPlane.affinity | object | Deployed only in master nodes. | Affinity for the control plane DaemonSet. |
 | controlPlane.config.apiServer | object | Common settings for most K8s distributions. | API Server monitoring configuration |
@@ -50,6 +51,7 @@ Kubernetes: `>=1.16.0-0`
 | ksm.resources | object | 100m/150M -/850M | Resources for the KSM scraper pod. Keep in mind that sharding is not supported at the moment, so memory usage for this component ramps up quickly on large clusters. |
 | kubelet | object | See `values.yaml` | Configuration for the DaemonSet that collects metrics from the Kubelet. |
 | kubelet.enabled | bool | `true` | Enable kubelet monitoring. Advanced users only. Setting this to `false` is not supported and will break the New Relic experience. |
+| lowDataMode | bool | false | Enables low data mode sending less data by incrementing the interval from "15s" (the default when `lowDataMode` is `false` or `nil`) to "30s". Will be ignored if `.common.config.interval` is set. |
 | podAnnotations | object | `{}` | Annotations to be added to all pods created by the integration. |
 | podLabels | object | `{}` | Labels to be added to all pods created by the integration. |
 | priorityClassName | string | `""` | Pod scheduling priority Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/ |

--- a/charts/newrelic-infrastructure-v3/templates/NOTES.txt
+++ b/charts/newrelic-infrastructure-v3/templates/NOTES.txt
@@ -1,19 +1,23 @@
 {{- if or (not .Values.ksm.enabled) (not .Values.kubelet.enabled) }}
-
-###########
-# WARNING #
-###########
+Warning:
+========
 
 You have specified ksm or kubelet integration components as not enabled.
 Those components are needed to have the full experience on NROne kubernetes explorer.
+{{- end }}
 
+{{- if and .Values.controlPlane.enabled (not (include "newrelic.controlPlane.hostNetwork" .)) }}
+Warning:
+========
+
+Most Control Plane components listen in the loopback address only, which is not reachable with `hostNetwork: true`.
+Control plane autodiscovery might not work as expected.
+You can enable hostNetwork for control plane scraper pods only by setting `controlPlane.unprivilegedHostNetwork: true`.
 {{- end }}
 
 {{- if and (include "newrelic.fargate" .) .Values.kubelet.affinity.nodeAffinity }}
-
-###########
-# WARNING #
-###########
+Warning:
+========
 
 You have specified both an EKS Fargate environment (global.fargate) and custom
 nodeAffinity rules, so we couldn't automatically exclude the kubelet daemonSet from

--- a/charts/newrelic-infrastructure-v3/templates/NOTES.txt
+++ b/charts/newrelic-infrastructure-v3/templates/NOTES.txt
@@ -10,7 +10,7 @@ Those components are needed to have the full experience on NROne kubernetes expl
 Warning:
 ========
 
-Most Control Plane components listen in the loopback address only, which is not reachable with `hostNetwork: true`.
+Most Control Plane components listen in the loopback address only, which is not reachable without `hostNetwork: true`.
 Control plane autodiscovery might not work as expected.
 You can enable hostNetwork for control plane scraper pods only by setting `controlPlane.unprivilegedHostNetwork: true`.
 {{- end }}

--- a/charts/newrelic-infrastructure-v3/templates/NOTES.txt
+++ b/charts/newrelic-infrastructure-v3/templates/NOTES.txt
@@ -12,7 +12,8 @@ Warning:
 
 Most Control Plane components listen in the loopback address only, which is not reachable without `hostNetwork: true`.
 Control plane autodiscovery might not work as expected.
-You can enable hostNetwork for control plane scraper pods only by setting `controlPlane.unprivilegedHostNetwork: true`.
+You can enable hostNetwork for control plane scraper pods only by setting `controlPlane.unprivilegedHostNetwork: true`,
+or alternative disable control plane monitoring altogether with `controlPlane.enabled: false`.
 {{- end }}
 
 {{- if and (include "newrelic.fargate" .) .Values.kubelet.affinity.nodeAffinity }}

--- a/charts/newrelic-infrastructure-v3/templates/NOTES.txt
+++ b/charts/newrelic-infrastructure-v3/templates/NOTES.txt
@@ -1,7 +1,3 @@
-Your deployment of the New Relic Infrastructure agent is complete if you have not used --wait during the installation of this helm chart. You can check on the progress of this by running the following command:
-
-    kubectl get daemonset -o wide -w --namespace {{ .Release.Namespace }} {{ template "newrelic.fullname" . }}
-
 {{- if or (not .Values.ksm.enabled) (not .Values.kubelet.enabled) }}
 
 ###########

--- a/charts/newrelic-infrastructure-v3/templates/control-plane/_helpers.tpl
+++ b/charts/newrelic-infrastructure-v3/templates/control-plane/_helpers.tpl
@@ -1,0 +1,8 @@
+{{/* Returns whether the controlPlane component needs needsHostNetwork to work, that is, if they do not have a staticEndpoint configured */}}
+{{- define "newrelic.controlPlane.hostNetwork" -}}
+{{- if .Values.privileged -}}
+true
+{{- else if .Values.controlPlane.unprivilegedHostNetwork -}}
+true
+{{- end -}}
+{{- end -}}

--- a/charts/newrelic-infrastructure-v3/templates/control-plane/_helpers.tpl
+++ b/charts/newrelic-infrastructure-v3/templates/control-plane/_helpers.tpl
@@ -1,4 +1,4 @@
-{{/* Returns whether the controlPlane component needs needsHostNetwork to work, that is, if they do not have a staticEndpoint configured */}}
+{{/* Returns whether the controlPlane scraper should run with hostNetwork: true based on the user configuration. */}}
 {{- define "newrelic.controlPlane.hostNetwork" -}}
 {{- if .Values.privileged -}}
 true

--- a/charts/newrelic-infrastructure-v3/templates/control-plane/daemonset.yaml
+++ b/charts/newrelic-infrastructure-v3/templates/control-plane/daemonset.yaml
@@ -45,7 +45,7 @@ spec:
           {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ template "newrelic.serviceAccountName" . }}-control-plane
-      {{- if .Values.privileged }}
+      {{- if include "newrelic.controlPlane.hostNetwork" . }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       {{- end }}

--- a/charts/newrelic-infrastructure-v3/values.yaml
+++ b/charts/newrelic-infrastructure-v3/values.yaml
@@ -35,10 +35,10 @@ images:
 common:
   # Configuration entries that apply to all instances of the integration: kubelet, ksm and control plane.
   config:
-    # Intervals larger than 40s are not supported and will cause the NR UI to not behave properly.
+    # common.config.interval -- (duration) Intervals larger than 40s are not supported and will cause the NR UI to not behave properly.
     # @default -- `15s` if `lowDataMode == false`, `30s` otherwise.
-    # interval: 15s
-    # -- Timeout for the different APIs contacted by the integration: Kubernetes, KSM, Kubelet, etc.
+    interval:
+    # Timeout for the different APIs contacted by the integration: Kubernetes, KSM, Kubelet, etc.
     timeout: 30s
   # -- Config for the Infrastructure agent.
   # Will be used by the forwarder sidecars and the agent running integrations.
@@ -48,7 +48,7 @@ common:
 # lowDataMode -- (bool) Enables low data mode sending less data by incrementing the interval from "15s" (the default when `lowDataMode` is `false` or `nil`) to "30s".
 # Will be ignored if `.common.config.interval` is set.
 # @default -- false
-# lowDataMode: false
+lowDataMode:
 
 # kubelet -- Configuration for the DaemonSet that collects metrics from the Kubelet.
 # @default -- See `values.yaml`

--- a/charts/newrelic-infrastructure-v3/values.yaml
+++ b/charts/newrelic-infrastructure-v3/values.yaml
@@ -119,8 +119,11 @@ ksm:
 # -- Configuration for the DaemonSet that collects metrics from the control plane.
 # @default -- See `values.yaml`
 controlPlane:
-  # -- Deploy control plane monitoring DaemonSet. Requires `privileged` mode to be enabled.
+  # -- Deploy control plane monitoring DaemonSet.
   enabled: true
+  # -- Run Control Plane scraper with hostNetwork even if privileged is set to false.
+  # hostNetwork is required for most control plane configuration, as they only accept connections from localhost.
+  unprivilegedHostNetwork: false
   annotations: {}
   tolerations:
     - operator: "Exists"

--- a/charts/newrelic-infrastructure-v3/values.yaml
+++ b/charts/newrelic-infrastructure-v3/values.yaml
@@ -50,7 +50,7 @@ common:
 # @default -- false
 # lowDataMode: false
 
-# -- Configuration for the DaemonSet that collects metrics from the Kubelet
+# kubelet -- Configuration for the DaemonSet that collects metrics from the Kubelet.
 # @default -- See `values.yaml`
 kubelet:
   # -- Enable kubelet monitoring.
@@ -77,7 +77,7 @@ kubelet:
       memory: 150M
   config: {}
 
-# -- Configuration for the Deployment that collects state metrics from KSM (kube-state-metrics).
+# ksm -- Configuration for the Deployment that collects state metrics from KSM (kube-state-metrics).
 # @default -- See `values.yaml`
 ksm:
   # -- Enable cluster state monitoring.
@@ -116,7 +116,7 @@ ksm:
       memory: 150M
   config: {}
 
-# -- Configuration for the DaemonSet that collects metrics from the control plane.
+# controlPlane -- Configuration for the DaemonSet that collects metrics from the control plane.
 # @default -- See `values.yaml`
 controlPlane:
   # -- Deploy control plane monitoring DaemonSet.

--- a/charts/newrelic-infrastructure-v3/values.yaml
+++ b/charts/newrelic-infrastructure-v3/values.yaml
@@ -117,10 +117,10 @@ ksm:
       memory: 150M
   config: {}
 
-# controlPlane -- Configuration for the DaemonSet that collects metrics from the control plane.
+# controlPlane -- Configuration for the control plane scraper.
 # @default -- See `values.yaml`
 controlPlane:
-  # -- Deploy control plane monitoring DaemonSet.
+  # -- Deploy control plane monitoring component.
   enabled: true
   # -- Run Control Plane scraper with `hostNetwork` even if `privileged` is set to false.
   # `hostNetwork` is required for most control plane configurations, as they only accept connections from localhost.

--- a/charts/newrelic-infrastructure-v3/values.yaml
+++ b/charts/newrelic-infrastructure-v3/values.yaml
@@ -35,7 +35,8 @@ images:
 common:
   # Configuration entries that apply to all instances of the integration: kubelet, ksm and control plane.
   config:
-    # common.config.interval -- (duration) Intervals larger than 40s are not supported and will cause the NR UI to not behave properly.
+    # common.config.interval -- (duration) Intervals larger than 40s are not supported and will cause the NR UI to not
+    # behave properly. Any non-nil value will override the `lowDataMode` default.
     # @default -- `15s` if `lowDataMode == false`, `30s` otherwise.
     interval:
     # Timeout for the different APIs contacted by the integration: Kubernetes, KSM, Kubelet, etc.
@@ -45,9 +46,9 @@ common:
   # See: https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/
   agentConfig: {}
 
-# lowDataMode -- (bool) Enables low data mode sending less data by incrementing the interval from "15s" (the default when `lowDataMode` is `false` or `nil`) to "30s".
-# Will be ignored if `.common.config.interval` is set.
-# @default -- false
+# lowDataMode -- (bool) Send less data by incrementing the interval from `15s` (the default when `lowDataMode` is `false` or `nil`) to `30s`.
+# Non-nil values of `common.config.interval` will override this value.
+# @default -- `false`
 lowDataMode:
 
 # kubelet -- Configuration for the DaemonSet that collects metrics from the Kubelet.
@@ -121,8 +122,8 @@ ksm:
 controlPlane:
   # -- Deploy control plane monitoring DaemonSet.
   enabled: true
-  # -- Run Control Plane scraper with hostNetwork even if privileged is set to false.
-  # hostNetwork is required for most control plane configuration, as they only accept connections from localhost.
+  # -- Run Control Plane scraper with `hostNetwork` even if `privileged` is set to false.
+  # `hostNetwork` is required for most control plane configurations, as they only accept connections from localhost.
   unprivilegedHostNetwork: false
   annotations: {}
   tolerations:


### PR DESCRIPTION
Previously, if `privileged` was set to `false`, we deployed the control plane DaemonSet with `hostNetwork: false`. However, this will almost certainly cause it not to work as intended.

This PR:
- Adds a way to deploy the DaemonSet with `hostNetwork: true` even when `privileged: false` (disabled by default)
- Warns the user and encourages them to set this flag if control plane monitoring is enabled

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
