### PR TITLE
[nri-bundle] Bump nri-prometheus version in nri-bundle

### DIFF
--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to deploy New Relic integrations bundled together
 name: nri-bundle
-version: 3.3.0
+version: 3.3.1
 home: https://github.com/newrelic/helm-charts
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:

--- a/charts/nri-bundle/requirements.lock
+++ b/charts/nri-bundle/requirements.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 2.8.0
 - name: nri-prometheus
   repository: file://../nri-prometheus
-  version: 1.13.0
+  version: 1.13.1
 - name: nri-metadata-injection
   repository: file://../nri-metadata-injection
   version: 2.2.0
@@ -29,5 +29,5 @@ dependencies:
 - name: newrelic-infra-operator
   repository: file://../newrelic-infra-operator
   version: 0.4.0
-digest: sha256:97dac54e4238a9237987a2013c5d8f6cf68c1ef1f22bf5d0791c568199dfbd19
-generated: "2022-01-19T15:05:37.489082+01:00"
+digest: sha256:8de6f536c91daac3d9de53383ca00c3727759455091917269164b8c13bc5ae8f
+generated: "2022-01-19T11:49:35.373351-08:00"

--- a/charts/nri-bundle/requirements.yaml
+++ b/charts/nri-bundle/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   - name: nri-prometheus
     repository: file://../nri-prometheus
     condition: prometheus.enabled
-    version: 1.13.0
+    version: 1.13.1
 
   - name: nri-metadata-injection
     repository: file://../nri-metadata-injection


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
Updates the `nri-bundle` with the most recent `nri-prometheus` chart version.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
