### PR TITLE
[newrelic-pixie] Update to v1.4.3 of the integration

### DIFF
--- a/charts/newrelic-pixie/Chart.yaml
+++ b/charts/newrelic-pixie/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart for the New Relic Pixie integration.
 name: newrelic-pixie
-version: 1.4.2
-appVersion: 1.4.2
+version: 1.4.3
+appVersion: 1.4.3
 home: https://hub.docker.com/u/newrelic
 sources:
   - https://github.com/newrelic/


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
It updates the Pixie integration to v1.4.3 that uses port 443 for the New Relic OTel endpoint

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
