### PR TITLE
[newrelic-infrastructure-v3] Adding needed variable for autodiscovery

### DIFF
--- a/charts/newrelic-infrastructure-v3/Chart.yaml
+++ b/charts/newrelic-infrastructure-v3/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: newrelic-infrastructure-v3
 description: A Helm chart to deploy the New Relic Kubernetes monitoring solution
-version: 3.0.9
-appVersion: 3.0.1-pre
+version: 3.0.10
+appVersion: 3.0.2-pre
 kubeVersion: ">=1.16.0-0"
 home: https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration/
 sources:

--- a/charts/newrelic-infrastructure-v3/README.md
+++ b/charts/newrelic-infrastructure-v3/README.md
@@ -2,7 +2,7 @@
 
 # newrelic-infrastructure-v3
 
-![Version: 3.0.8](https://img.shields.io/badge/Version-3.0.8-informational?style=flat-square) ![AppVersion: 3.0.1-pre](https://img.shields.io/badge/AppVersion-3.0.1--pre-informational?style=flat-square)
+![Version: 3.0.10](https://img.shields.io/badge/Version-3.0.10-informational?style=flat-square) ![AppVersion: 3.0.2-pre](https://img.shields.io/badge/AppVersion-3.0.2--pre-informational?style=flat-square)
 
 A Helm chart to deploy the New Relic Kubernetes monitoring solution
 
@@ -46,7 +46,7 @@ Kubernetes: `>=1.16.0-0`
 | images.forwarder.repository | string | `"newrelic/k8s-events-forwarder"` | Image for the agent sidecar. |
 | images.forwarder.tag | string | `"1.22.0"` | Tag for the agent sidecar. |
 | images.integration.repository | string | `"newrelic/nri-kubernetes"` | Image for the kubernetes integration. |
-| images.integration.tag | string | `"3.0.1-pre"` | Tag for the kubernetes integration. |
+| images.integration.tag | string | `"3.0.2-pre"` | Tag for the kubernetes integration. |
 | integrations | object | `{}` | Config files for other New Relic integrations that should run in this cluster. |
 | ksm | object | See `values.yaml` | Configuration for the Deployment that collects state metrics from KSM (kube-state-metrics). |
 | ksm.config.retries | int | `3` | Number of retries after timeout expired |

--- a/charts/newrelic-infrastructure-v3/ci/test-cplane-kind-deployment-values.yaml
+++ b/charts/newrelic-infrastructure-v3/ci/test-cplane-kind-deployment-values.yaml
@@ -8,7 +8,9 @@ common:
     # not valid, the Identity Api doesn't return an AgentID and the server from the Agent takes to long to respond
     is_forward_only: true
   config:
-    timeout: 180s
+    sink:
+      http:
+        timeout: 180s
 
 customAttributes: '{"new":"relic","loren":"ipsum"}'
 

--- a/charts/newrelic-infrastructure-v3/ci/test-values.yaml
+++ b/charts/newrelic-infrastructure-v3/ci/test-values.yaml
@@ -8,7 +8,9 @@ common:
     # not valid, the Identity Api doesn't return an AgentID and the server from the Agent takes to long to respond
     is_forward_only: true
   config:
-    timeout: 180s
+    sink:
+      http:
+        timeout: 180s
 
 customAttributes: '{"new":"relic","loren":"ipsum"}'
 

--- a/charts/newrelic-infrastructure-v3/templates/kubelet/daemonset.yaml
+++ b/charts/newrelic-infrastructure-v3/templates/kubelet/daemonset.yaml
@@ -161,6 +161,17 @@ spec:
             {{- with .Values.kubelet.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- /* Needed to populate clustername in integration metrics */}}
+            - name: "CLUSTER_NAME"
+              value: {{ include "newrelic.cluster" . | required "cluster name must be set" }}
+            - name: "NRIA_PASSTHROUGH_ENVIRONMENT"
+              value: "CLUSTER_NAME"
+            {{- /* Needed for autodiscovery since hostNetwork=false */}}
+            - name: "NRIA_HOST"
+              valueFrom:
+                fieldRef:
+                  apiVersion: "v1"
+                  fieldPath: "status.hostIP"
           {{- with .Values.kubelet.extraEnvFrom }}
           envFrom: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/newrelic-infrastructure-v3/values.yaml
+++ b/charts/newrelic-infrastructure-v3/values.yaml
@@ -25,7 +25,7 @@ images:
   integration:
     pullPolicy: IfNotPresent
     # -- Tag for the kubernetes integration.
-    tag: 3.0.1-pre
+    tag: 3.0.2-pre
     # -- Image for the kubernetes integration.
     repository: newrelic/nri-kubernetes
     registry: docker.io


### PR DESCRIPTION
#### Is this a new chart
no
#### What this PR does / why we need it:
Since hostnetwork is false now NRIA_HOST is needed. (read by the the discovery binary)
We removed the Cluster_name env var and the passthrough to the integration but it was still needed  

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
