### PR TITLE
newrelic-infrastructure-v3: render integrations and agent configmaps unconditionally

### DIFF
--- a/charts/newrelic-infrastructure-v3/Chart.yaml
+++ b/charts/newrelic-infrastructure-v3/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: newrelic-infrastructure-v3
 description: A Helm chart to deploy the New Relic Kubernetes monitoring solution
-version: 3.0.13
+version: 3.0.14
 appVersion: 3.0.2-pre
 kubeVersion: ">=1.16.0-0"
 home: https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration/

--- a/charts/newrelic-infrastructure-v3/templates/agent-configmap.yaml
+++ b/charts/newrelic-infrastructure-v3/templates/agent-configmap.yaml
@@ -1,4 +1,3 @@
-{{- if (include "newrelic.compatibility.agentConfig" . ) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,5 +7,6 @@ metadata:
   name: {{ template "newrelic.fullname" . }}-agent
 data:
   newrelic-infra.yml: |-
+    # This is the configuration file for the infrastructure agent. See:
+    # https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/
     {{- include "newrelic.compatibility.agentConfig" . | nindent 4 -}}
-{{- end -}}

--- a/charts/newrelic-infrastructure-v3/templates/controlplane/daemonset.yaml
+++ b/charts/newrelic-infrastructure-v3/templates/controlplane/daemonset.yaml
@@ -27,9 +27,7 @@ spec:
         {{- if not (include "newrelic.licenseCustomSecretName" .) }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
-        {{- if (include "newrelic.compatibility.agentConfig" . ) }}
         checksum/agent-config: {{ include (print $.Template.BasePath "/agent-configmap.yaml") . | sha256sum }}
-        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -155,11 +153,9 @@ spec:
               name: forwarder-tmpfs-user-data
             - mountPath: /tmp
               name: forwarder-tmpfs-tmp
-            {{- if (include "newrelic.compatibility.agentConfig" . ) }}
             - name: config
               mountPath: /etc/newrelic-infra.yml
               subPath: newrelic-infra.yml
-            {{- end }}
             {{- with .Values.controlPlane.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -179,14 +175,12 @@ spec:
           emptyDir: {}
         - name: forwarder-tmpfs-tmp
           emptyDir: {}
-        {{- if (include "newrelic.compatibility.agentConfig" . ) }}
         - name: config
           configMap:
             name: {{ template "newrelic.fullname" . }}-agent
             items:
               - key: newrelic-infra.yml
                 path: newrelic-infra.yml
-        {{- end }}
         {{- with .Values.controlPlane.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/newrelic-infrastructure-v3/templates/ksm/deployment.yaml
+++ b/charts/newrelic-infrastructure-v3/templates/ksm/deployment.yaml
@@ -22,9 +22,7 @@ spec:
         {{- if not (include "newrelic.licenseCustomSecretName" .) }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
-        {{- if (include "newrelic.compatibility.agentConfig" . ) }}
         checksum/agent-config: {{ include (print $.Template.BasePath "/agent-configmap.yaml") . | sha256sum }}
-        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -141,11 +139,9 @@ spec:
               name: forwarder-tmpfs-user-data
             - mountPath: /tmp
               name: forwarder-tmpfs-tmp
-            {{- if (include "newrelic.compatibility.agentConfig" . ) }}
             - name: config
               mountPath: /etc/newrelic-infra.yml
               subPath: newrelic-infra.yml
-            {{- end }}
             {{- with .Values.ksm.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -165,14 +161,12 @@ spec:
           emptyDir: {}
         - name: forwarder-tmpfs-tmp
           emptyDir: {}
-        {{- if (include "newrelic.compatibility.agentConfig" . ) }}
         - name: config
           configMap:
             name: {{ template "newrelic.fullname" . }}-agent
             items:
               - key: newrelic-infra.yml
                 path: newrelic-infra.yml
-        {{- end }}
         {{- with .Values.ksm.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/newrelic-infrastructure-v3/templates/kubelet/daemonset.yaml
+++ b/charts/newrelic-infrastructure-v3/templates/kubelet/daemonset.yaml
@@ -28,9 +28,7 @@ spec:
         {{- if (include "newrelic.compatibility.agentConfig" . ) }}
         checksum/agent-config: {{ include (print $.Template.BasePath "/agent-configmap.yaml") . | sha256sum }}
         {{- end }}
-        {{- if .Values.integrations_config }}
         checksum/integrations_config: {{ include (print $.Template.BasePath "/kubelet/integrations-configmap.yaml") . | sha256sum }}
-        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -182,10 +180,8 @@ spec:
               mountPath: /etc/newrelic-infra.yml
               subPath: newrelic-infra.yml
             {{- end }}
-            {{- if or .Values.integrations (include "newrelic.compatibility.integrations" .)}}
             - name: nri-integrations-cfg-volume
               mountPath: /etc/newrelic-infra/integrations.d/
-            {{- end }}
             {{- if .Values.privileged }}
             - name: dev
               mountPath: /dev
@@ -244,11 +240,9 @@ spec:
               - key: newrelic-infra.yml
                 path: newrelic-infra.yml
         {{- end }}
-        {{- if or .Values.integrations (include "newrelic.compatibility.integrations" .) }}
         - name: nri-integrations-cfg-volume
           configMap:
             name: {{ template "newrelic.fullname" . }}-integrations-cfg
-        {{- end }}
         {{- with .Values.kubelet.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/newrelic-infrastructure-v3/templates/kubelet/daemonset.yaml
+++ b/charts/newrelic-infrastructure-v3/templates/kubelet/daemonset.yaml
@@ -25,9 +25,7 @@ spec:
         {{- if not (include "newrelic.licenseCustomSecretName" .) }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
-        {{- if (include "newrelic.compatibility.agentConfig" . ) }}
         checksum/agent-config: {{ include (print $.Template.BasePath "/agent-configmap.yaml") . | sha256sum }}
-        {{- end }}
         checksum/integrations_config: {{ include (print $.Template.BasePath "/kubelet/integrations-configmap.yaml") . | sha256sum }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
@@ -175,11 +173,9 @@ spec:
           envFrom: {{ toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            {{- if (include "newrelic.compatibility.agentConfig" . ) }}
             - name: config
               mountPath: /etc/newrelic-infra.yml
               subPath: newrelic-infra.yml
-            {{- end }}
             - name: nri-integrations-cfg-volume
               mountPath: /etc/newrelic-infra/integrations.d/
             {{- if .Values.privileged }}
@@ -232,14 +228,12 @@ spec:
             items:
               - key: nri-kubernetes.yml
                 path: nri-kubernetes.yml
-        {{- if (include "newrelic.compatibility.agentConfig" . ) }}
         - name: config
           configMap:
             name: {{ template "newrelic.fullname" . }}-agent
             items:
               - key: newrelic-infra.yml
                 path: newrelic-infra.yml
-        {{- end }}
         - name: nri-integrations-cfg-volume
           configMap:
             name: {{ template "newrelic.fullname" . }}-integrations-cfg

--- a/charts/newrelic-infrastructure-v3/templates/kubelet/integrations-configmap.yaml
+++ b/charts/newrelic-infrastructure-v3/templates/kubelet/integrations-configmap.yaml
@@ -1,4 +1,3 @@
-{{ if or .Values.integrations (include "newrelic.compatibility.integrations" .)}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,11 +6,32 @@ metadata:
     {{- include "newrelic.labels" . | nindent 4 }}
   name: {{ template "newrelic.fullname" . }}-integrations-cfg
 data:
+  # This ConfigMap holds config files for integrations. They should have the following format:
+  #redis-config.yml: |
+  #  # Run auto discovery to find pods with label "app=redis"
+  #  discovery:
+  #    command:
+  #      # Run discovery for Kubernetes. Use the following optional arguments:
+  #      # --namespaces: Comma separated list of namespaces to discover pods on
+  #      # --tls: Use secure (TLS) connection
+  #      # --port: Port used to connect to the kubelet. Default is 10255
+  #      exec: /var/db/newrelic-infra/nri-discovery-kubernetes --port PORT --tls
+  #      match:
+  #        label.app: redis
+  #  integrations:
+  #    - name: nri-redis
+  #      env:
+  #        # using the discovered IP as the hostname address
+  #        HOSTNAME: ${discovery.ip}
+  #        PORT: 6379
+  #        KEYS: '{"0":["<KEY_1>"],"1":["<KEY_2>"]}'
+  #        REMOTE_MONITORING: true
+  #      labels:
+  #        env: production
   {{- if .Values.integrations -}}
   {{- range $k, $v := .Values.integrations -}}
   {{- $k | trimSuffix ".yaml" | trimSuffix ".yml" | nindent 2 -}}.yaml: |-
   {{- tpl ($v | toYaml) $ | nindent 4 -}}
-  {{- end -}}
-  {{- end -}}
-  {{- include "newrelic.compatibility.integrations" . | nindent 2 -}}
-{{- end -}}
+  {{- end }}
+  {{- end }}
+  {{- include "newrelic.compatibility.integrations" . | nindent 2 }}

--- a/charts/newrelic-infrastructure-v3/tests/annotations_test.yaml
+++ b/charts/newrelic-infrastructure-v3/tests/annotations_test.yaml
@@ -4,6 +4,7 @@ templates:
   - templates/controlplane/configmap.yaml
   - templates/kubelet/daemonset.yaml
   - templates/kubelet/configmap.yaml
+  - templates/kubelet/integrations-configmap.yaml
   - templates/ksm/deployment.yaml
   - templates/ksm/configmap.yaml
   - templates/agent-configmap.yaml

--- a/charts/newrelic-infrastructure-v3/tests/configmap_agent_test.yaml
+++ b/charts/newrelic-infrastructure-v3/tests/configmap_agent_test.yaml
@@ -13,6 +13,8 @@ tests:
       - equal:
           path: data.newrelic-infra\.yml
           value: |-
+            # This is the configuration file for the infrastructure agent. See:
+            # https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/
             test1: one
             test2: two
   - it: agent configMap is created and configured from common.agentConfig
@@ -26,6 +28,8 @@ tests:
       - equal:
           path: data.newrelic-infra\.yml
           value: |-
+            # This is the configuration file for the infrastructure agent. See:
+            # https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/
             test1: one
             test2: two
   - it: common.agentConfig takes precedence
@@ -41,6 +45,8 @@ tests:
       - equal:
           path: data.newrelic-infra\.yml
           value: |-
+            # This is the configuration file for the infrastructure agent. See:
+            # https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/
             test1: one
             test2: two
   - it: eventQueueDepth is taken into account
@@ -57,6 +63,8 @@ tests:
       - equal:
           path: data.newrelic-infra\.yml
           value: |-
+            # This is the configuration file for the infrastructure agent. See:
+            # https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/
             event_queue_depth: 1000
             test1: one
             test2: two

--- a/charts/newrelic-infrastructure-v3/tests/configmap_integrations_test.yaml
+++ b/charts/newrelic-infrastructure-v3/tests/configmap_integrations_test.yaml
@@ -193,10 +193,10 @@ tests:
               labels:
                 env: test2
               name: nri-redis
-  - it: without any option the file is not rendered
+  - it: without any option the file is still rendered
     set:
       licenseKey: test
       cluster: test
     asserts:
       - hasDocuments:
-          count: 0
+          count: 1

--- a/charts/newrelic-infrastructure-v3/tests/nodeAffinity_test.yaml
+++ b/charts/newrelic-infrastructure-v3/tests/nodeAffinity_test.yaml
@@ -4,6 +4,7 @@ templates:
   - templates/controlplane/configmap.yaml
   - templates/kubelet/daemonset.yaml
   - templates/kubelet/configmap.yaml
+  - templates/kubelet/integrations-configmap.yaml
   - templates/ksm/deployment.yaml
   - templates/ksm/configmap.yaml
   - templates/agent-configmap.yaml

--- a/charts/newrelic-infrastructure-v3/tests/nodeSelectors_test.yaml
+++ b/charts/newrelic-infrastructure-v3/tests/nodeSelectors_test.yaml
@@ -4,6 +4,7 @@ templates:
   - templates/controlplane/configmap.yaml
   - templates/kubelet/daemonset.yaml
   - templates/kubelet/configmap.yaml
+  - templates/kubelet/integrations-configmap.yaml
   - templates/ksm/deployment.yaml
   - templates/ksm/configmap.yaml
   - templates/agent-configmap.yaml

--- a/charts/newrelic-infrastructure-v3/tests/podName_test.yaml
+++ b/charts/newrelic-infrastructure-v3/tests/podName_test.yaml
@@ -4,6 +4,7 @@ templates:
   - templates/controlplane/configmap.yaml
   - templates/kubelet/daemonset.yaml
   - templates/kubelet/configmap.yaml
+  - templates/kubelet/integrations-configmap.yaml
   - templates/ksm/deployment.yaml
   - templates/ksm/configmap.yaml
   - templates/agent-configmap.yaml

--- a/charts/newrelic-infrastructure-v3/tests/securityContext_test.yaml
+++ b/charts/newrelic-infrastructure-v3/tests/securityContext_test.yaml
@@ -4,6 +4,7 @@ templates:
   - templates/controlplane/configmap.yaml
   - templates/kubelet/daemonset.yaml
   - templates/kubelet/configmap.yaml
+  - templates/kubelet/integrations-configmap.yaml
   - templates/ksm/deployment.yaml
   - templates/ksm/configmap.yaml
   - templates/agent-configmap.yaml


### PR DESCRIPTION
#### What this PR does / why we need it:

Previously, we completely skipped config maps and their respective mounts if the agent config or the integrations config was empty. This was done to reduce clutter and unnecessary objects in the clusters where the chart is deployed.

However, while working on the docs (https://github.com/newrelic/docs-website/pull/5742), I realized that for installations using the generated manifests (which we support) we point users to modify or add items to these configmaps. If the configmaps do not exist, it would be hard for users  to create them and mount them in the correct places.

For this reason, this PR makes these manifests to render unconditionally, and adds some comments and examples on them.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
