### PR TITLE
newrelic-infrastructure-v3: restrict interval to [10, 45]s

### DIFF
--- a/charts/newrelic-infrastructure-v3/Chart.yaml
+++ b/charts/newrelic-infrastructure-v3/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: newrelic-infrastructure-v3
 description: A Helm chart to deploy the New Relic Kubernetes monitoring solution
-version: 3.0.12
+version: 3.0.13
 appVersion: 3.0.2-pre
 kubeVersion: ">=1.16.0-0"
 home: https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration/

--- a/charts/newrelic-infrastructure-v3/templates/NOTES.txt
+++ b/charts/newrelic-infrastructure-v3/templates/NOTES.txt
@@ -1,3 +1,14 @@
+{{- if not .Values.forceUnsupportedInterval }}
+{{- $max := 45 }}
+{{- $min := 10 }}
+{{- if gt ( .Values.common.config.interval | trimSuffix "s" | int64 ) $max }}
+{{ fail (printf "Intervals larger than %ds are not supported" $max) }}
+{{- end }}
+{{- if lt ( .Values.common.config.interval | trimSuffix "s" | int64 ) $min }}
+{{ fail (printf "Intervals smaller than %ds are not supported" $min) }}
+{{- end }}
+{{- end }}
+
 {{- if or (not .Values.ksm.enabled) (not .Values.kubelet.enabled) }}
 Warning:
 ========

--- a/charts/newrelic-infrastructure-v3/templates/NOTES.txt
+++ b/charts/newrelic-infrastructure-v3/templates/NOTES.txt
@@ -1,6 +1,9 @@
 {{- if not .Values.forceUnsupportedInterval }}
 {{- $max := 45 }}
 {{- $min := 10 }}
+{{- if not (.Values.common.config.interval | hasSuffix "s") }}
+{{ fail (printf "Interval must be between %ds and %ds" $min $max ) }}
+{{- end }}
 {{- if gt ( .Values.common.config.interval | trimSuffix "s" | int64 ) $max }}
 {{ fail (printf "Intervals larger than %ds are not supported" $max) }}
 {{- end }}

--- a/charts/newrelic-infrastructure-v3/tests/interval_override_test.yaml
+++ b/charts/newrelic-infrastructure-v3/tests/interval_override_test.yaml
@@ -1,0 +1,18 @@
+suite: test interval
+templates:
+  - templates/controlplane/configmap.yaml
+  - templates/ksm/configmap.yaml
+  - templates/kubelet/configmap.yaml
+tests:
+  - it: Does not fail with override
+    set:
+      licenseKey: test
+      cluster: test
+      common:
+        config:
+          interval: 1s
+      forceUnsupportedInterval: true
+    asserts:
+      - matchRegex:
+          path: data.nri-kubernetes\.yml
+          pattern: 'interval: 1s'

--- a/charts/newrelic-infrastructure-v3/tests/interval_test.yaml
+++ b/charts/newrelic-infrastructure-v3/tests/interval_test.yaml
@@ -1,4 +1,4 @@
-suite: test configmap
+suite: test interval
 templates:
   - templates/NOTES.txt
 tests:
@@ -22,11 +22,3 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "raw: Intervals smaller than 10s are not supported"
-  - it: Does not fail with override
-    set:
-      licenseKey: test
-      cluster: test
-      common:
-        config:
-          interval: 1s
-      forceUnsupportedInterval: true

--- a/charts/newrelic-infrastructure-v3/tests/interval_test.yaml
+++ b/charts/newrelic-infrastructure-v3/tests/interval_test.yaml
@@ -22,3 +22,13 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "raw: Intervals smaller than 10s are not supported"
+  - it: Non-seconds intervals are rejected
+    set:
+      licenseKey: test
+      cluster: test
+      common:
+        config:
+          interval: 1m
+    asserts:
+      - failedTemplate:
+          errorMessage: "raw: Interval must be between 10s and 45s"

--- a/charts/newrelic-infrastructure-v3/tests/interval_test.yaml
+++ b/charts/newrelic-infrastructure-v3/tests/interval_test.yaml
@@ -1,0 +1,32 @@
+suite: test configmap
+templates:
+  - templates/NOTES.txt
+tests:
+  - it: Fails to render with large intervals
+    set:
+      licenseKey: test
+      cluster: test
+      common:
+        config:
+          interval: 46s
+    asserts:
+      - failedTemplate:
+          errorMessage: "raw: Intervals larger than 45s are not supported"
+  - it: Fails to render with small intervals
+    set:
+      licenseKey: test
+      cluster: test
+      common:
+        config:
+          interval: 1s
+    asserts:
+      - failedTemplate:
+          errorMessage: "raw: Intervals smaller than 10s are not supported"
+  - it: Does not fail with override
+    set:
+      licenseKey: test
+      cluster: test
+      common:
+        config:
+          interval: 1s
+      forceUnsupportedInterval: true


### PR DESCRIPTION
#### What this PR does / why we need it:

Causes the chart to fail to render if `common.config.interval` is not in the `[10, 45]s` range.

This check can be overridden by setting the undocumented and unsupported flag `forceUnsupportedInterval` to `true`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
