### PR TITLE
[gh-pages] update manually index to include beta release

### DIFF
--- a/.github/workflows/pr_index_integrity.yaml
+++ b/.github/workflows/pr_index_integrity.yaml
@@ -1,0 +1,18 @@
+name: GH Pages Integrity
+
+on:
+  pull_request:
+    branches:
+      - gh-pages
+
+jobs:
+  gh-pages-integrity:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: check index.yaml
+        run: |
+          helm repo add test https://raw.githubusercontent.com/newrelic/helm-charts/${{ github.event.pull_request.base.ref }}
+          helm search repo newrelic -l --devel | grep test

--- a/index.yaml
+++ b/index.yaml
@@ -3373,6 +3373,67 @@ entries:
     version: 3.3.5
   - apiVersion: v1
     appVersion: "1.0"
+    created: "2022-01-26T16:45:16.232750923Z"
+    dependencies:
+      - alias: newrelic-infrastructure
+        condition: infrastructure.enabled
+        name: newrelic-infrastructure-v3
+        repository: file://../newrelic-infrastructure-v3
+        version: 3.0.14
+      - condition: prometheus.enabled
+        name: nri-prometheus
+        repository: file://../nri-prometheus
+        version: 1.13.1
+      - condition: webhook.enabled
+        name: nri-metadata-injection
+        repository: file://../nri-metadata-injection
+        version: 2.2.0
+      - condition: metrics-adapter.enabled
+        name: newrelic-k8s-metrics-adapter
+        repository: file://../newrelic-k8s-metrics-adapter
+        version: 0.2.0
+      - condition: ksm.enabled
+        name: kube-state-metrics
+        repository: https://kubernetes.github.io/kube-state-metrics
+        version: 2.13.2
+      - condition: kubeEvents.enabled
+        name: nri-kube-events
+        repository: file://../nri-kube-events
+        version: 1.12.1
+      - condition: logging.enabled
+        name: newrelic-logging
+        repository: file://../newrelic-logging
+        version: 1.10.8
+      - condition: newrelic-pixie.enabled
+        name: newrelic-pixie
+        repository: file://../newrelic-pixie
+        version: 1.4.3
+      - alias: pixie-chart
+        condition: pixie-chart.enabled
+        name: pixie-operator-helm2-chart
+        repository: https://pixie-operator-charts.storage.googleapis.com
+        version: 0.0.16
+      - condition: newrelic-infra-operator.enabled
+        name: newrelic-infra-operator
+        repository: file://../newrelic-infra-operator
+        version: 0.4.0
+    description: A Helm chart to deploy New Relic integrations bundled together
+    digest: 46961539795236ae56414412bfa00a3a4f9dc74894a284097dabc82ec8195a6f
+    home: https://github.com/newrelic/helm-charts
+    icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
+    maintainers:
+      - name: alvarocabanas
+      - name: carlossscastro
+      - name: gsanchezgavier
+      - name: kang-makes
+      - name: paologallinaharbur
+      - name: roobre
+    name: nri-bundle
+    urls:
+      - https://github.com/newrelic-forks/helm-charts/releases/download/nri-bundle-4.0.4-beta/nri-bundle-4.0.4-beta.tgz
+    version: 4.0.4-beta
+  - apiVersion: v1
+    appVersion: "1.0"
     created: "2022-01-27T08:40:15.356308021Z"
     dependencies:
     - condition: infrastructure.enabled
@@ -10516,4 +10577,4 @@ entries:
     urls:
     - https://github.com/newrelic/helm-charts/releases/download/synthetics-minion-1.0.17/synthetics-minion-1.0.17.tgz
     version: 1.0.17
-generated: "2022-01-27T20:37:46.677937292Z"
+generated: "2022-01-27T20:37:47.677937292Z"


### PR DESCRIPTION
Publishing new release currently available in fork repo only.

To test that:
```
helm repo add newrelic-beta https://newrelic-forks.github.io/helm-charts
helm upgrade --install newrelic-bundle-beta newrelic-beta/nri-bundle --devel
helm search repo newrelic --devel
```
