### PR TITLE
newrelic-infrastructure-v3: default to recreate strategy for controlPlane Deployment

### DIFF
--- a/charts/newrelic-infrastructure-v3/Chart.yaml
+++ b/charts/newrelic-infrastructure-v3/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: newrelic-infrastructure-v3
 description: A Helm chart to deploy the New Relic Kubernetes monitoring solution
-version: 3.0.18
+version: 3.1.1
 appVersion: 3.0.0
 kubeVersion: ">=1.16.0-0"
 home: https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration/

--- a/charts/newrelic-infrastructure-v3/README.md
+++ b/charts/newrelic-infrastructure-v3/README.md
@@ -2,7 +2,7 @@
 
 # newrelic-infrastructure-v3
 
-![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 3.1.1](https://img.shields.io/badge/Version-3.1.1-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 A Helm chart to deploy the New Relic Kubernetes monitoring solution
 
@@ -38,7 +38,6 @@ Kubernetes: `>=1.16.0-0`
 | controlPlane.config.timeout | string | `"10s"` | Timeout for the Kubernetes APIs contacted by the integration |
 | controlPlane.enabled | bool | `true` | Deploy control plane monitoring component. |
 | controlPlane.kind | string | `"DaemonSet"` | How to deploy the control plane scraper. If autodiscovery is in use, it should be `DaemonSet`. Advanced users using static endpoints set this to `Deployment` to avoid reporting metrics twice. |
-| controlPlane.strategy | object | `type: Recreate` | Deployment strategy when `kind` is set to `Deployment`. |
 | controlPlane.unprivilegedHostNetwork | bool | `false` | Run Control Plane scraper with `hostNetwork` even if `privileged` is set to false. `hostNetwork` is required for most control plane configurations, as they only accept connections from localhost. |
 | customAttributes | object | `{}` | Custom attributes to be added to the data reported by all integrations reporting in the cluster. |
 | images | object | See `values.yaml` | Images used by the chart for the integration and agents. |
@@ -69,7 +68,8 @@ Kubernetes: `>=1.16.0-0`
 | securityContext | object | See `values.yaml` | Security context used in all the containers of the pods When `privileged == true`, the Kubelet scraper will run as root and ignore these settings. |
 | serviceAccount | object | See `values.yaml` | Settings controlling ServiceAccount creation. |
 | serviceAccount.create | bool | `true` | Whether the chart should automatically create the ServiceAccount objects required to run. |
-| updateStrategy | object | See `values.yaml` | Update strategy for the DaemonSets deployed. |
+| strategy | object | `type: Recreate` | Update strategy for the deployed Deployments. |
+| updateStrategy | object | See `values.yaml` | Update strategy for the deployed DaemonSets. |
 | verboseLog | bool | `false` | Enable verbose logging for all components. |
 
 ## Maintainers

--- a/charts/newrelic-infrastructure-v3/README.md
+++ b/charts/newrelic-infrastructure-v3/README.md
@@ -2,7 +2,7 @@
 
 # newrelic-infrastructure-v3
 
-![Version: 3.0.16](https://img.shields.io/badge/Version-3.0.16-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 A Helm chart to deploy the New Relic Kubernetes monitoring solution
 
@@ -38,6 +38,7 @@ Kubernetes: `>=1.16.0-0`
 | controlPlane.config.timeout | string | `"10s"` | Timeout for the Kubernetes APIs contacted by the integration |
 | controlPlane.enabled | bool | `true` | Deploy control plane monitoring component. |
 | controlPlane.kind | string | `"DaemonSet"` | How to deploy the control plane scraper. If autodiscovery is in use, it should be `DaemonSet`. Advanced users using static endpoints set this to `Deployment` to avoid reporting metrics twice. |
+| controlPlane.strategy | object | `type: Recreate` | Deployment strategy when `kind` is set to `Deployment`. |
 | controlPlane.unprivilegedHostNetwork | bool | `false` | Run Control Plane scraper with `hostNetwork` even if `privileged` is set to false. `hostNetwork` is required for most control plane configurations, as they only accept connections from localhost. |
 | customAttributes | object | `{}` | Custom attributes to be added to the data reported by all integrations reporting in the cluster. |
 | images | object | See `values.yaml` | Images used by the chart for the integration and agents. |

--- a/charts/newrelic-infrastructure-v3/templates/controlplane/daemonset.yaml
+++ b/charts/newrelic-infrastructure-v3/templates/controlplane/daemonset.yaml
@@ -11,9 +11,13 @@ metadata:
   annotations: {{ . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if eq .Values.controlPlane.kind "DaemonSet"}}
+  {{- if eq .Values.controlPlane.kind "DaemonSet" }}
   {{- with .Values.updateStrategy }}
   updateStrategy: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- else if eq .Values.controlPlane.kind "Deployment" }}
+  {{- with .Values.controlPlane.strategy }}
+  strategy: {{ toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
   selector:

--- a/charts/newrelic-infrastructure-v3/templates/controlplane/daemonset.yaml
+++ b/charts/newrelic-infrastructure-v3/templates/controlplane/daemonset.yaml
@@ -16,7 +16,7 @@ spec:
   updateStrategy: {{ toYaml . | nindent 4 }}
   {{- end }}
   {{- else if eq .Values.controlPlane.kind "Deployment" }}
-  {{- with .Values.controlPlane.strategy }}
+  {{- with .Values.strategy }}
   strategy: {{ toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}

--- a/charts/newrelic-infrastructure-v3/tests/controlplane_strategy_test.yaml
+++ b/charts/newrelic-infrastructure-v3/tests/controlplane_strategy_test.yaml
@@ -1,0 +1,88 @@
+suite: Control plane strategy
+templates:
+  - templates/controlplane/daemonset.yaml
+  - templates/controlplane/configmap.yaml
+  - templates/secret.yaml
+  - templates/agent-configmap.yaml
+  - templates/_helpers.tpl
+  - templates/_helpers_compatibility.tpl
+tests:
+- it: DaemonSet defaults to global updateStrategy
+  set:
+    licenseKey: test
+    cluster: test
+  asserts:
+    - equal:
+        path: spec.updateStrategy
+        value:
+          type: RollingUpdate
+          rollingUpdate:
+            maxUnavailable: 1
+      template: templates/controlplane/daemonset.yaml
+- it: DaemonSet updateStrategy can be overridden
+  set:
+    licenseKey: test
+    cluster: test
+    controlPlane:
+      kind: Deployment
+  asserts:
+    - equal:
+        path: spec.strategy
+        value:
+          type: Recreate
+      template: templates/controlplane/daemonset.yaml
+    - isNull:
+        path: spec.updateStrategy
+      template: templates/controlplane/daemonset.yaml
+- it: Deployment defaults to recreate
+  set:
+    licenseKey: test
+    cluster: test
+    controlPlane:
+      kind: Deployment
+  asserts:
+    - equal:
+        path: spec.strategy
+        value:
+          type: Recreate
+      template: templates/controlplane/daemonset.yaml
+- it: Deployment strategy can be overridden
+  set:
+    licenseKey: test
+    cluster: test
+    controlPlane:
+      kind: Deployment
+      strategy:
+        type: Foobar
+  asserts:
+    - equal:
+        path: spec.strategy
+        value:
+          type: Foobar
+      template: templates/controlplane/daemonset.yaml
+    - isNull:
+        path: spec.updateStrategy
+      template: templates/controlplane/daemonset.yaml
+- it: Deployment strategy is not rendered on DaemonSet
+  set:
+    licenseKey: test
+    cluster: test
+    controlPlane:
+      strategy:
+        type: Foobar
+  asserts:
+    - isNull:
+        path: spec.strategy
+      template: templates/controlplane/daemonset.yaml
+- it: DaemonSet strategy is not rendered on Deployment
+  set:
+    licenseKey: test
+    cluster: test
+    controlPlane:
+      kind: Deployment
+      updateStrategy:
+        type: Foobar
+  asserts:
+    - isNull:
+        path: spec.updateStrategy
+      template: templates/controlplane/daemonset.yaml

--- a/charts/newrelic-infrastructure-v3/tests/controlplane_strategy_test.yaml
+++ b/charts/newrelic-infrastructure-v3/tests/controlplane_strategy_test.yaml
@@ -50,10 +50,10 @@ tests:
   set:
     licenseKey: test
     cluster: test
+    strategy:
+      type: Foobar
     controlPlane:
       kind: Deployment
-      strategy:
-        type: Foobar
   asserts:
     - equal:
         path: spec.strategy

--- a/charts/newrelic-infrastructure-v3/values.yaml
+++ b/charts/newrelic-infrastructure-v3/values.yaml
@@ -143,10 +143,6 @@ controlPlane:
   # -- Run Control Plane scraper with `hostNetwork` even if `privileged` is set to false.
   # `hostNetwork` is required for most control plane configurations, as they only accept connections from localhost.
   unprivilegedHostNetwork: false
-  # -- Deployment strategy when `kind` is set to `Deployment`.
-  # @default -- `type: Recreate`
-  strategy:
-    type: Recreate
   annotations: {}
   tolerations:
     - operator: "Exists"
@@ -384,12 +380,17 @@ controlPlane:
       #   insecureSkipVerify: true
       #   auth: {}
 
-# -- Update strategy for the DaemonSets deployed.
+# -- Update strategy for the deployed DaemonSets.
 # @default -- See `values.yaml`
 updateStrategy:
   type: RollingUpdate
   rollingUpdate:
     maxUnavailable: 1
+
+# -- Update strategy for the deployed Deployments.
+# @default -- `type: Recreate`
+strategy:
+  type: Recreate
 
 # -- Custom attributes to be added to the data reported by all integrations reporting in the cluster.
 customAttributes: {}

--- a/charts/newrelic-infrastructure-v3/values.yaml
+++ b/charts/newrelic-infrastructure-v3/values.yaml
@@ -143,6 +143,10 @@ controlPlane:
   # -- Run Control Plane scraper with `hostNetwork` even if `privileged` is set to false.
   # `hostNetwork` is required for most control plane configurations, as they only accept connections from localhost.
   unprivilegedHostNetwork: false
+  # -- Deployment strategy when `kind` is set to `Deployment`.
+  # @default -- `type: Recreate`
+  strategy:
+    type: Recreate
   annotations: {}
   tolerations:
     - operator: "Exists"


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

Changes the default `strategy` for the control plane component to `type: Recreate` strategy when `kind` is `Deployment`. This is done to prevent new versions of the deployment from getting stuck in `Pending` state, as the previous version is occupying the same host port in use.

This strategy can be overridden from `values.yaml`.

Opting out of `hostNetwork` when privileged is set to true is not possible at the moment, and is out of the scope of this PR.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
