### PR TITLE
[newrelic-infrastructure-v3] Change `hostNetwork` depending if their kind is `DaemonSet` or `Deployment`

### DIFF
--- a/charts/newrelic-infrastructure-v3/Chart.yaml
+++ b/charts/newrelic-infrastructure-v3/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: newrelic-infrastructure-v3
 description: A Helm chart to deploy the New Relic Kubernetes monitoring solution
-version: 3.0.17
+version: 3.1.0
 appVersion: 3.0.0
 kubeVersion: ">=1.16.0-0"
 home: https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration/

--- a/charts/newrelic-infrastructure-v3/README.md
+++ b/charts/newrelic-infrastructure-v3/README.md
@@ -38,7 +38,7 @@ Kubernetes: `>=1.16.0-0`
 | controlPlane.config.timeout | string | `"10s"` | Timeout for the Kubernetes APIs contacted by the integration |
 | controlPlane.enabled | bool | `true` | Deploy control plane monitoring component. |
 | controlPlane.kind | string | `"DaemonSet"` | How to deploy the control plane scraper. If autodiscovery is in use, it should be `DaemonSet`. Advanced users using static endpoints set this to `Deployment` to avoid reporting metrics twice. |
-| controlPlane.unprivilegedHostNetwork | bool | `false` | Run Control Plane scraper with `hostNetwork` even if `privileged` is set to false. `hostNetwork` is required for most control plane configurations, as they only accept connections from localhost. |
+| controlPlane.unprivilegedHostNetwork | bool | `false` | Run Control Plane scraper with `hostNetwork` even if `privileged` is set to false. `hostNetwork` is required for most control plane configurations, as they only accept connections from localhost. This is meant to be used with DaemonSets over on-premise clusters. |
 | customAttributes | object | `{}` | Custom attributes to be added to the data reported by all integrations reporting in the cluster. |
 | images | object | See `values.yaml` | Images used by the chart for the integration and agents. |
 | images.agent.repository | string | `"newrelic/infrastructure-bundle"` | Image for the agent and integrations bundle. |

--- a/charts/newrelic-infrastructure-v3/README.md
+++ b/charts/newrelic-infrastructure-v3/README.md
@@ -2,7 +2,7 @@
 
 # newrelic-infrastructure-v3
 
-![Version: 3.0.16](https://img.shields.io/badge/Version-3.0.16-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 A Helm chart to deploy the New Relic Kubernetes monitoring solution
 
@@ -37,8 +37,8 @@ Kubernetes: `>=1.16.0-0`
 | controlPlane.config.scheduler.enabled | bool | `true` | Enable scheduler monitoring. |
 | controlPlane.config.timeout | string | `"10s"` | Timeout for the Kubernetes APIs contacted by the integration |
 | controlPlane.enabled | bool | `true` | Deploy control plane monitoring component. |
+| controlPlane.hostNetwork | bool | true if `Kind` is `DaemonSet` and `privileged` is `true`. false in all the other cases | Run Control Plane scraper with `hostNetwork`. In case this scraper is run as a Deployment or in unprivileged mode this defaults to false to allow the pod to be scheduled properly. See "Control plane `hostNetwork`" in the README.md for more information. |
 | controlPlane.kind | string | `"DaemonSet"` | How to deploy the control plane scraper. If autodiscovery is in use, it should be `DaemonSet`. Advanced users using static endpoints set this to `Deployment` to avoid reporting metrics twice. |
-| controlPlane.unprivilegedHostNetwork | bool | `false` | Run Control Plane scraper with `hostNetwork` even if `privileged` is set to false. `hostNetwork` is required for most control plane configurations, as they only accept connections from localhost. This is meant to be used with DaemonSets over on-premise clusters. |
 | customAttributes | object | `{}` | Custom attributes to be added to the data reported by all integrations reporting in the cluster. |
 | images | object | See `values.yaml` | Images used by the chart for the integration and agents. |
 | images.agent.repository | string | `"newrelic/infrastructure-bundle"` | Image for the agent and integrations bundle. |
@@ -68,8 +68,17 @@ Kubernetes: `>=1.16.0-0`
 | securityContext | object | See `values.yaml` | Security context used in all the containers of the pods When `privileged == true`, the Kubelet scraper will run as root and ignore these settings. |
 | serviceAccount | object | See `values.yaml` | Settings controlling ServiceAccount creation. |
 | serviceAccount.create | bool | `true` | Whether the chart should automatically create the ServiceAccount objects required to run. |
-| updateStrategy | object | See `values.yaml` | Update strategy for the DaemonSets deployed. |
+| updateStrategy | object | {} | Update strategy for the DaemonSets/Deployments deployed. |
 | verboseLog | bool | `false` | Enable verbose logging for all components. |
+
+## Control plane `hostNetwork`
+
+The monitoring pods that are used to monitor the Control Plane could be deployed as a DaemonSet or as a Deployment to cover these use cases:
+- On premise clusters where the Control Plane is inside the cluster as a pod (run as a statics manifest, for example) so we need a DaemonSet
+  with the nodeSelector/affinity to run on the control plane nodes and we could need access to `hostNetwork`.
+- Managed clusters that has the control plane outside the cluster. We simply run as any other pod/deployment and we scrape the URLs configured
+
+`hostNetwork` in the control plane is difficult
 
 ## Maintainers
 

--- a/charts/newrelic-infrastructure-v3/README.md.gotmpl
+++ b/charts/newrelic-infrastructure-v3/README.md.gotmpl
@@ -15,6 +15,20 @@
 
 {{ template "chart.valuesSection" . }}
 
+## Control plane `hostNetwork`
+
+The monitoring pods that are used to monitor the Control Plane could be deployed as a DaemonSet or as a Deployment to cover these use cases:
+- On premise clusters where the Control Plane is inside the cluster as a pod (run as a statics manifest, for example) so we need a DaemonSet
+  with the nodeSelector/affinity to run on the control plane nodes and we could need access to `hostNetwork`.
+- Managed clusters that has the control plane outside the cluster. We simply run as any other pod/deployment and we scrape the URLs configured
+  using `.controlPlane.config.{etcd,scheduler,controllerManager,apiServer}.staticEndpoint`
+
+Because of this complexity, the `hostNetwork` default will change depending on the way you are deploying chart:
+- The value you can set manually in `.controlPlane.hostNetwork` will always be honored and will override any default value this chart sets.
+- `hostNetwork` will be set to true if this is deployed as a `DaemonSet` in `privileged` mode.
+- In the rest of the cases it will be run with `hostNetwork` set to false.
+
+
 {{ if .Maintainers }}
 ## Maintainers
 {{ range .Maintainers }}

--- a/charts/newrelic-infrastructure-v3/templates/_helpers.tpl
+++ b/charts/newrelic-infrastructure-v3/templates/_helpers.tpl
@@ -240,4 +240,3 @@ interval: 30s
 interval: 15s
 {{- end -}}
 {{- end -}}
-

--- a/charts/newrelic-infrastructure-v3/templates/controlplane/_helpers.tpl
+++ b/charts/newrelic-infrastructure-v3/templates/controlplane/_helpers.tpl
@@ -1,8 +1,14 @@
 {{/* Returns whether the controlPlane scraper should run with hostNetwork: true based on the user configuration. */}}
 {{- define "newrelic.controlPlane.hostNetwork" -}}
+{{- if eq .Values.controlPlane.kind "Daemonset" -}}
 {{- if .Values.privileged -}}
 true
 {{- else if .Values.controlPlane.unprivilegedHostNetwork -}}
 true
+{{- end -}}
+{{- end -}}
+{{/* Error handling */}}
+{{- if and (eq .Values.controlPlane.kind "Deployment") .Values.controlPlane.unprivilegedHostNetwork -}}
+{{- fail ".controlPlane.unprivilegedHostNetwork is meant to be used with Daemonsets, not with Deployments" -}}
 {{- end -}}
 {{- end -}}

--- a/charts/newrelic-infrastructure-v3/templates/controlplane/_helpers.tpl
+++ b/charts/newrelic-infrastructure-v3/templates/controlplane/_helpers.tpl
@@ -1,14 +1,39 @@
 {{/* Returns whether the controlPlane scraper should run with hostNetwork: true based on the user configuration. */}}
 {{- define "newrelic.controlPlane.hostNetwork" -}}
-{{- if eq .Values.controlPlane.kind "Daemonset" -}}
-{{- if .Values.privileged -}}
-true
-{{- else if .Values.controlPlane.unprivilegedHostNetwork -}}
-true
+{{- if (get .Values.controlPlane. "hostNetwork" | kindIs "bool") -}}
+    {{- if .Values.controlPlane.hostNetwork -}}
+        {{/*
+            We want only to return when this is true, returning `false` here will template "false" (string) when doing
+            an `(include "newrelic-logging.lowDataMode" .)`, which is not an "empty string" so it is `true` if it is used
+            as an evaluation somewhere else.
+        */}}
+        {{- .Values.controlPlane.hostNetwork -}}
+    {{- end -}}
+{{- else if eq .Values.controlPlane.kind "DaemonSet" -}}
+    {{- if .Values.privileged -}}
+        true
+    {{- end -}}
 {{- end -}}
 {{- end -}}
-{{/* Error handling */}}
-{{- if and (eq .Values.controlPlane.kind "Deployment") .Values.controlPlane.unprivilegedHostNetwork -}}
-{{- fail ".controlPlane.unprivilegedHostNetwork is meant to be used with Daemonsets, not with Deployments" -}}
+
+{{- define "newrelic.controlPlane.computedAffinity" -}}
+{{- if and (not .Values.controlPlane.affinity) (eq .Values.controlPlane.kind "DaemonSet") -}}
+nodeAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+    nodeSelectorTerms:
+      - matchExpressions:
+          - key: node-role.kubernetes.io/control-plane
+            operator: Exists
+      - matchExpressions:
+          - key: node-role.kubernetes.io/controlplane
+            operator: Exists
+      - matchExpressions:
+          - key: node-role.kubernetes.io/etcd
+            operator: Exists
+      - matchExpressions:
+          - key: node-role.kubernetes.io/master
+            operator: Exists
+{{- else -}}
+{{- .Values.controlPlane.affinity | toYaml -}}
 {{- end -}}
 {{- end -}}

--- a/charts/newrelic-infrastructure-v3/templates/controlplane/daemonset.yaml
+++ b/charts/newrelic-infrastructure-v3/templates/controlplane/daemonset.yaml
@@ -190,7 +190,7 @@ spec:
       {{- if .Values.controlPlane.affinity.nodeAffinity }}
       affinity:
         nodeAffinity:
-          {{- .Values.controlPlane.affinity.nodeAffinity | toYaml | nindent 10 }}
+          {{- include "newrelic.controlPlane.computedAffinity" . | nindent 10 }}
       {{- end }}
       {{- with .Values.controlPlane.tolerations }}
       tolerations:

--- a/charts/newrelic-infrastructure-v3/values.yaml
+++ b/charts/newrelic-infrastructure-v3/values.yaml
@@ -142,6 +142,7 @@ controlPlane:
   enabled: true
   # -- Run Control Plane scraper with `hostNetwork` even if `privileged` is set to false.
   # `hostNetwork` is required for most control plane configurations, as they only accept connections from localhost.
+  # This is meant to be used with DaemonSets over on-premise clusters.
   unprivilegedHostNetwork: false
   annotations: {}
   tolerations:

--- a/charts/newrelic-infrastructure-v3/values.yaml
+++ b/charts/newrelic-infrastructure-v3/values.yaml
@@ -62,8 +62,7 @@ kubelet:
     - operator: "Exists"
       effect: "NoExecute"
   nodeSelector: {}
-  affinity:
-    nodeAffinity: {}
+  affinity: {}
   extraEnv: []
   extraEnvFrom: []
   extraVolumes: []
@@ -140,10 +139,12 @@ ksm:
 controlPlane:
   # -- Deploy control plane monitoring component.
   enabled: true
-  # -- Run Control Plane scraper with `hostNetwork` even if `privileged` is set to false.
-  # `hostNetwork` is required for most control plane configurations, as they only accept connections from localhost.
-  # This is meant to be used with DaemonSets over on-premise clusters.
-  unprivilegedHostNetwork: false
+
+  # controlPlane.hostNetwork -- (bool) Run Control Plane scraper with `hostNetwork`. In case this scraper is run as a Deployment or in unprivileged
+  # mode this defaults to false to allow the pod to be scheduled properly. See "Control plane `hostNetwork`" in the README.md for more information.
+  # @default -- true if `Kind` is `DaemonSet` and `privileged` is `true`. false in all the other cases
+  hostNetwork:
+
   annotations: {}
   tolerations:
     - operator: "Exists"
@@ -153,22 +154,7 @@ controlPlane:
   nodeSelector: {}
   # -- Affinity for the control plane DaemonSet.
   # @default -- Deployed only in master nodes.
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: node-role.kubernetes.io/control-plane
-                operator: Exists
-          - matchExpressions:
-              - key: node-role.kubernetes.io/controlplane
-                operator: Exists
-          - matchExpressions:
-              - key: node-role.kubernetes.io/etcd
-                operator: Exists
-          - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
+  affinity: {}
   # -- How to deploy the control plane scraper. If autodiscovery is in use, it should be `DaemonSet`.
   # Advanced users using static endpoints set this to `Deployment` to avoid reporting metrics twice.
   kind: DaemonSet
@@ -198,7 +184,7 @@ controlPlane:
         - selector: "tier=control-plane,component=etcd"
           namespace: kube-system
           # Set to true to consider only pods sharing the node with the scraper pod.
-          # This should be set to `true` if Kind is Daemonset, `false` otherwise.
+          # This should be set to `true` if Kind is DaemonSet, `false` otherwise.
           matchNode: true
           # Try to reach etcd using the following endpoints.
           endpoints:
@@ -240,7 +226,7 @@ controlPlane:
       # -- staticEndpoint configuration.
       # It is possible to specify static endpoint to scrape. If specified 'autodiscover' section is ignored.
       # If set the static endpoint should be reachable, otherwise an error will be returned and the integration stops.
-      # Notice that if deployed as a daemonSet and not as a Deployment setting static URLs could lead to duplicate data
+      # Notice that if deployed as a DaemonSet and not as a Deployment setting static URLs could lead to duplicate data
       # staticEndpoint:
       #   url: https://url:port
       #   insecureSkipVerify: true
@@ -279,7 +265,7 @@ controlPlane:
       # -- staticEndpoint configuration.
       # It is possible to specify static endpoint to scrape. If specified 'autodiscover' section is ignored.
       # If set the static endpoint should be reachable, otherwise an error will be returned and the integration stops.
-      # Notice that if deployed as a daemonSet and not as a Deployment setting static URLs could lead to duplicate data
+      # Notice that if deployed as a DaemonSet and not as a Deployment setting static URLs could lead to duplicate data
       # staticEndpoint:
       #   url: https://url:port
       #   insecureSkipVerify: true
@@ -329,7 +315,7 @@ controlPlane:
       # -- staticEndpoint configuration.
       # It is possible to specify static endpoint to scrape. If specified 'autodiscover' section is ignored.
       # If set the static endpoint should be reachable, otherwise an error will be returned and the integration stops.
-      # Notice that if deployed as a daemonSet and not as a Deployment setting static URLs could lead to duplicate data
+      # Notice that if deployed as a DaemonSet and not as a Deployment setting static URLs could lead to duplicate data
       # staticEndpoint:
       #   url: https://url:port
       #   insecureSkipVerify: true
@@ -375,18 +361,15 @@ controlPlane:
       # -- staticEndpoint configuration.
       # It is possible to specify static endpoint to scrape. If specified 'autodiscover' section is ignored.
       # If set the static endpoint should be reachable, otherwise an error will be returned and the integration stops.
-      # Notice that if deployed as a daemonSet and not as a Deployment setting static URLs could lead to duplicate data
+      # Notice that if deployed as a DaemonSet and not as a Deployment setting static URLs could lead to duplicate data
       # staticEndpoint:
       #   url: https://url:port
       #   insecureSkipVerify: true
       #   auth: {}
 
-# -- Update strategy for the DaemonSets deployed.
-# @default -- See `values.yaml`
-updateStrategy:
-  type: RollingUpdate
-  rollingUpdate:
-    maxUnavailable: 1
+# -- Update strategy for the DaemonSets/Deployments deployed.
+# @default -- {}
+updateStrategy: {}
 
 # -- Custom attributes to be added to the data reported by all integrations reporting in the cluster.
 customAttributes: {}


### PR DESCRIPTION

#### Is this a new chart

No.

#### What this PR does / why we need it:

#### Which issue this PR fixes
There is no use case where `hostNetwork` is used as a `Deployment` because the deployment is meant to be use when the control plane is outside the Cluster.

This approach changes the `hostNetwork` to false the control plane scraper is deployed as a DaemonSet and refuses to render if you try to.

#### Special notes for your reviewer:

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
