### PR TITLE
[newrelic-logging] fix empty messages with CRI

### DIFF
--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -125,7 +125,7 @@ fluentBit:
       [PARSER]
           Name cri
           Format regex
-          Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
+          Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<log>.*)$
           Time_Key    time
           Time_Format %Y-%m-%dT%H:%M:%S.%L%z
 


### PR DESCRIPTION
When running containerd, the log message was being dropped due 'message'
not being in the record_modifier allowlist. The cri parser now
unmarshals the field as 'log' instead of 'message'. 'log' is the
preferred field name as the Kubernetes filter checks that key for JSON
when Merge_Log is set to true.

#### Is this a new chart

No.

#### What this PR does / why we need it:

Fixes lowDataMode when using `criEnabled: true`. See #699 

#### Which issue this PR fixes

Fixes #699 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
