### PR TITLE
[newrelic-logging] Fix regression in lowDataMode

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.10.8
+version: 1.10.9
 appVersion: 1.10.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -104,6 +104,7 @@ fluentBit:
           Allowlist_key  namespace_name
           Allowlist_key  pod_name
           Allowlist_key  stream
+          Allowlist_key  message
           Allowlist_key  log
 
     outputs: |


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Fixes a regression in `lowDataMode` introduced in [this PR](https://github.com/newrelic/helm-charts/pull/593). Specifically, when `lowDataMode=true`, we must allow logs captured either using the `docker` parser (this one places it under the `log` attribute) or the `cri` parser (this one places it under the `message` attribute). We already fixed this problem in [this PR](https://github.com/newrelic/helm-charts/pull/567/files), but [in this other PR](https://github.com/newrelic/helm-charts/pull/593/files) we moved the configuration of Fluent Bit into the `values.yml` file, to make it configurable. Nevertheless, during this copy&paste, the line `Allowlist_key  message` was omitted accidentally.

#### Which issue this PR fixes
  - fixes #699 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
