### PR TITLE
[newrelic-infrastructure] Adding nri-flex config for Pixie cloud connector health and status checks

### DIFF
--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 2.8.1
+version: 2.9.0
 appVersion: 2.10.0
 home: https://hub.docker.com/r/newrelic/infrastructure-k8s/
 sources:

--- a/charts/newrelic-infrastructure/flex/nri-pixie-check.yaml
+++ b/charts/newrelic-infrastructure/flex/nri-pixie-check.yaml
@@ -1,0 +1,22 @@
+---
+discovery:
+  command:
+    exec: /var/db/newrelic-infra/nri-discovery-kubernetes
+    match:
+      label.name: vizier-cloud-connector
+integrations:
+  - name: nri-flex
+    interval: 60s
+    config:
+      name: pixie-health-check
+      apis:
+        - event_type: pixieHealth
+          commands:
+            - run: curl --insecure -s https://${discovery.ip}:50800/healthz | xargs | awk '{print "cloud_connector_health:"$1}'
+              split_by: ":"
+          merge: pixieHealthCheck
+        - event_type: pixieStatus
+          commands:
+            - run: curl --insecure -s https://${discovery.ip}:50800/statusz | awk '{if($1 == ""){ print "cloud_connector_status:OK" } else { print "cloud_connector_status:"$1 }}'
+              split_by: ":"
+          merge: pixieHealthCheck

--- a/charts/newrelic-infrastructure/flex/nri-pixie-check.yaml
+++ b/charts/newrelic-infrastructure/flex/nri-pixie-check.yaml
@@ -1,9 +1,10 @@
 ---
 # This Flex config performs periodic checks of the Pixie
-# healthz and statusz endpoints.  A status for each endpoint
-# is sent to New Relic in a pixieHealthCheck event.
+# /healthz and /statusz endpoints exposed by the Pixie Cloud Connector.
+# A status for each endpoint is sent to New Relic in a pixieHealthCheck event.
 #
 # If Pixie is not installed in the cluster, no events will be generated.
+# This can also be disabled with enablePixieHealthCheck: false in the values.yaml file.
 discovery:
   command:
     exec: /var/db/newrelic-infra/nri-discovery-kubernetes

--- a/charts/newrelic-infrastructure/flex/nri-pixie-check.yaml
+++ b/charts/newrelic-infrastructure/flex/nri-pixie-check.yaml
@@ -1,4 +1,9 @@
 ---
+# This Flex config performs periodic checks of the Pixie
+# healthz and statusz endpoints.  A status for each endpoint
+# is sent to New Relic in a pixieHealthCheck event.
+#
+# If Pixie is not installed in the cluster, no events will be generated.
 discovery:
   command:
     exec: /var/db/newrelic-infra/nri-discovery-kubernetes

--- a/charts/newrelic-infrastructure/templates/configmap.yaml
+++ b/charts/newrelic-infrastructure/templates/configmap.yaml
@@ -9,7 +9,6 @@ data:
     newrelic-infra.yml: |
 {{ toYaml .Values.config | indent 6 }}
 {{ end }}
-{{ if .Values.integrations_config }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -18,6 +17,8 @@ metadata:
   labels: {{ include "newrelic.labels" . | indent 4 }}
   name: {{ template "newrelic.fullname" . }}-integrations-cfg
 data:
+{{ (.Files.Glob "flex/**.yaml").AsConfig | indent 2 }} # include Flex configs
+{{ if .Values.integrations_config }}
 {{ range .Values.integrations_config -}}
 {{ .name | indent 2 }}: |
     ---

--- a/charts/newrelic-infrastructure/templates/configmap.yaml
+++ b/charts/newrelic-infrastructure/templates/configmap.yaml
@@ -17,7 +17,9 @@ metadata:
   labels: {{ include "newrelic.labels" . | indent 4 }}
   name: {{ template "newrelic.fullname" . }}-integrations-cfg
 data:
-{{ (.Files.Glob "flex/**.yaml").AsConfig | indent 2 }} # include Flex configs
+{{ if .Values.selfMonitoring.pixie.enabled }}
+{{ (.Files.Glob "flex/nri-pixie-check.yaml").AsConfig | indent 2 }} # include Pixie Health Check
+{{ end }}
 {{ if .Values.integrations_config }}
 {{ range .Values.integrations_config -}}
 {{ .name | indent 2 }}: |

--- a/charts/newrelic-infrastructure/templates/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/daemonset.yaml
@@ -190,10 +190,8 @@ spec:
               mountPath: /etc/newrelic-infra.yml
               subPath: newrelic-infra.yml
             {{- end }}
-            {{- if .Values.integrations_config }}
             - name: nri-integrations-cfg-volume
               mountPath: /etc/newrelic-infra/integrations.d/
-            {{- end }}
             {{- if .Values.privileged }}
             - name: dev
               mountPath: /dev
@@ -261,11 +259,9 @@ spec:
             - key: newrelic-infra.yml
               path: newrelic-infra.yml
         {{- end }}
-        {{- if .Values.integrations_config }}
         - name: nri-integrations-cfg-volume
           configMap:
             name: {{ template "newrelic.fullname" . }}-integrations-cfg
-        {{- end }}
       {{- if $.Values.priorityClassName }}
       priorityClassName: {{ $.Values.priorityClassName }}
       {{- end }}

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -39,6 +39,16 @@ windowsOsList:
     buildNumber: 10.0.19041
 
 
+selfMonitoring:
+  # Enables the Pixie Health Check nri-flex config.
+  # This Flex config performs periodic checks of the Pixie
+  # /healthz and /statusz endpoints exposed by the Pixie Cloud Connector.
+  # A status for each endpoint is sent to New Relic in a pixieHealthCheck event.
+  pixie:
+    enabled: true
+
+enablePixieHealthCheck: true
+
 verboseLog: false
 
 # Accounts and subaccounts created before July 20, 2020 will report, by default, process metrics unless this config option is explicitly set to "false"

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -47,6 +47,8 @@ selfMonitoring:
   pixie:
     enabled: true
 
+enablePixieHealthCheck: true
+
 verboseLog: false
 
 # Accounts and subaccounts created before July 20, 2020 will report, by default, process metrics unless this config option is explicitly set to "false"

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -47,8 +47,6 @@ selfMonitoring:
   pixie:
     enabled: true
 
-enablePixieHealthCheck: true
-
 verboseLog: false
 
 # Accounts and subaccounts created before July 20, 2020 will report, by default, process metrics unless this config option is explicitly set to "false"


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

Adds the `flex/nri-pixie-check.yaml` flex config to the `newrelic-infra-integrations-cfg` configMap.  This provides users the ability to query the status of Pixie health check endpoints using `pixieHealthCheck` custom events.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
