### PR TITLE
newrelic-infrastructure-v3: rename `nrk8s-kubelet` DS to `nrk8s-node`

### DIFF
--- a/charts/newrelic-infrastructure-v3/Chart.yaml
+++ b/charts/newrelic-infrastructure-v3/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: newrelic-infrastructure-v3
 description: A Helm chart to deploy the New Relic Kubernetes monitoring solution
-version: 3.0.17
+version: 3.1.0
 appVersion: 3.0.0
 kubeVersion: ">=1.16.0-0"
 home: https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration/

--- a/charts/newrelic-infrastructure-v3/README.md
+++ b/charts/newrelic-infrastructure-v3/README.md
@@ -24,7 +24,7 @@ Kubernetes: `>=1.16.0-0`
 | common | object | See `values.yaml` | Config that applies to all instances of the solution: kubelet, ksm, control plane and sidecars. |
 | common.agentConfig | object | `{}` | Config for the Infrastructure agent. Will be used by the forwarder sidecars and the agent running integrations. See: https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/ |
 | common.config.interval | duration | `15s` if `lowDataMode == false`, `30s` otherwise. | Intervals larger than 40s are not supported and will cause the NR UI to not behave properly. Any non-nil value will override the `lowDataMode` default. |
-| controlPlane | object | See `values.yaml` | Configuration for the control plane scraper. |
+| controlPlane | object | See `values.yaml` | Configuration for the `nrk8s-controlplane` workload, which collects metrics from the control plane. |
 | controlPlane.affinity | object | Deployed only in master nodes. | Affinity for the control plane DaemonSet. |
 | controlPlane.config.apiServer | object | Common settings for most K8s distributions. | API Server monitoring configuration |
 | controlPlane.config.apiServer.enabled | bool | `true` | Enable API Server monitoring |
@@ -47,13 +47,13 @@ Kubernetes: `>=1.16.0-0`
 | images.forwarder.tag | string | `"1.23.0"` | Tag for the agent sidecar. |
 | images.integration.repository | string | `"newrelic/nri-kubernetes"` | Image for the kubernetes integration. |
 | images.integration.tag | string | `"3.0.0"` | Tag for the kubernetes integration. |
-| integrations | object | `{}` | Config files for other New Relic integrations that should run in this cluster. |
-| ksm | object | See `values.yaml` | Configuration for the Deployment that collects state metrics from KSM (kube-state-metrics). |
+| integrations | object | `{}` | Config files for other New Relic integrations that should run in this cluster. These integrations are run in the `nrk8s-node` pods. |
+| ksm | object | See `values.yaml` | Configuration for the `nrk8s-ksm` Deployment, which collects cluster-wide metrics from KSM (kube-state-metrics). |
 | ksm.config.retries | int | `3` | Number of retries after timeout expired |
 | ksm.config.timeout | string | `"10s"` | Timeout for the ksm API contacted by the integration |
 | ksm.enabled | bool | `true` | Enable cluster state monitoring. Advanced users only. Setting this to `false` is not supported and will break the New Relic experience. |
 | ksm.resources | object | 100m/150M -/850M | Resources for the KSM scraper pod. Keep in mind that sharding is not supported at the moment, so memory usage for this component ramps up quickly on large clusters. |
-| kubelet | object | See `values.yaml` | Configuration for the DaemonSet that collects metrics from the Kubelet. |
+| kubelet | object | See `values.yaml` | Configuration for the `nrk8s-node` DaemonSet, which collects metrics from the Kubelet. |
 | kubelet.config.retries | int | `3` | Number of retries after timeout expired |
 | kubelet.config.timeout | string | `"10s"` | Timeout for the kubelet APIs contacted by the integration |
 | kubelet.enabled | bool | `true` | Enable kubelet monitoring. Advanced users only. Setting this to `false` is not supported and will break the New Relic experience. |

--- a/charts/newrelic-infrastructure-v3/README.md
+++ b/charts/newrelic-infrastructure-v3/README.md
@@ -2,7 +2,7 @@
 
 # newrelic-infrastructure-v3
 
-![Version: 3.0.16](https://img.shields.io/badge/Version-3.0.16-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 A Helm chart to deploy the New Relic Kubernetes monitoring solution
 

--- a/charts/newrelic-infrastructure-v3/templates/kubelet/configmap.yaml
+++ b/charts/newrelic-infrastructure-v3/templates/kubelet/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   labels:
     {{- include "newrelic.labels" . | nindent 4 }}
-  name: {{ template "newrelic.fullname" . }}-kubelet
+  name: {{ template "newrelic.fullname" . }}-node
   namespace: {{ .Release.Namespace }}
 data:
   nri-kubernetes.yml: |

--- a/charts/newrelic-infrastructure-v3/templates/kubelet/configmap.yaml
+++ b/charts/newrelic-infrastructure-v3/templates/kubelet/configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   labels:
     {{- include "newrelic.labels" . | nindent 4 }}
-  name: {{ template "newrelic.fullname" . }}-node
+  name: {{ template "newrelic.fullname" . }}-kubelet
   namespace: {{ .Release.Namespace }}
 data:
   nri-kubernetes.yml: |

--- a/charts/newrelic-infrastructure-v3/templates/kubelet/daemonset.yaml
+++ b/charts/newrelic-infrastructure-v3/templates/kubelet/daemonset.yaml
@@ -224,7 +224,7 @@ spec:
           emptyDir: {}
         - name: nri-kubernetes-config
           configMap:
-            name: {{ template "newrelic.fullname" . }}-node
+            name: {{ template "newrelic.fullname" . }}-kubelet
             items:
               - key: nri-kubernetes.yml
                 path: nri-kubernetes.yml

--- a/charts/newrelic-infrastructure-v3/templates/kubelet/daemonset.yaml
+++ b/charts/newrelic-infrastructure-v3/templates/kubelet/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "newrelic.labels" . | nindent 4 }}
-  name: {{ template "newrelic.fullname" . }}-kubelet
+  name: {{ template "newrelic.fullname" . }}-node
   {{- $legacyAnnotation:= fromYaml (include "newrelic.compatibility.annotations" .) -}}
   {{- with  include "newrelic.compatibility.valueWithFallback" (dict "legacy" $legacyAnnotation "supported" .Values.kubelet.annotations )}}
   annotations: {{ . | nindent 4 }}
@@ -224,7 +224,7 @@ spec:
           emptyDir: {}
         - name: nri-kubernetes-config
           configMap:
-            name: {{ template "newrelic.fullname" . }}-kubelet
+            name: {{ template "newrelic.fullname" . }}-node
             items:
               - key: nri-kubernetes.yml
                 path: nri-kubernetes.yml

--- a/charts/newrelic-infrastructure-v3/tests/podName_test.yaml
+++ b/charts/newrelic-infrastructure-v3/tests/podName_test.yaml
@@ -25,7 +25,7 @@ tests:
         template: templates/controlplane/daemonset.yaml
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-nrk8s-kubelet
+          value: RELEASE-NAME-nrk8s-node
         template: templates/kubelet/daemonset.yaml
   - it: name is overridden as expected
     set:
@@ -43,5 +43,5 @@ tests:
         template: templates/controlplane/daemonset.yaml
       - equal:
           path: metadata.name
-          value: nri-kubernetes-kubelet
+          value: nri-kubernetes-node
         template: templates/kubelet/daemonset.yaml

--- a/charts/newrelic-infrastructure-v3/values.yaml
+++ b/charts/newrelic-infrastructure-v3/values.yaml
@@ -49,7 +49,7 @@ common:
 # @default -- `false`
 lowDataMode:
 
-# kubelet -- Configuration for the DaemonSet that collects metrics from the Kubelet.
+# kubelet -- Configuration for the `nrk8s-node` DaemonSet, which collects metrics from the Kubelet.
 # @default -- See `values.yaml`
 kubelet:
   # -- Enable kubelet monitoring.
@@ -82,7 +82,7 @@ kubelet:
   # port:
   # scheme:
 
-# ksm -- Configuration for the Deployment that collects state metrics from KSM (kube-state-metrics).
+# ksm -- Configuration for the `nrk8s-ksm` Deployment, which collects cluster-wide metrics from KSM (kube-state-metrics).
 # @default -- See `values.yaml`
 ksm:
   # -- Enable cluster state monitoring.
@@ -135,7 +135,7 @@ ksm:
   # -- only the pods matching this namespace taken into account during autodiscovery
   # namespace: "ksm-namespace"
 
-# controlPlane -- Configuration for the control plane scraper.
+# controlPlane -- Configuration for the `nrk8s-controlplane` workload, which collects metrics from the control plane.
 # @default -- See `values.yaml`
 controlPlane:
   # -- Deploy control plane monitoring component.
@@ -434,6 +434,7 @@ rbac:
   pspEnabled: false
 
 # -- Config files for other New Relic integrations that should run in this cluster.
+# These integrations are run in the `nrk8s-node` pods.
 integrations: {}
 # If you wish to monitor services running on Kubernetes you can provide integrations
 # configuration under `integrations`. You just need to create a new entry where


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No

#### What this PR does / why we need it:

Changes the name of the `nrk8s-kubelet` DaemonSet (and its pods) to `nrk8s-node`.

While the most important task of the DaemonSet is pulling metrics from the Kubelet, it can also pull more detailed node metrics, as well as run OHIs. For this reason, the `-node` suffix might be more accurate.

Moreover, the `-kubelet` suffix could be slightly confusing for users that are not extremely familiar with the Kubernetes components, while the word `node` is more universally understandable.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
