### PR TITLE
[newrelic-infrastructure-v3] improved error messages

### DIFF
--- a/charts/newrelic-infrastructure-v3/Chart.yaml
+++ b/charts/newrelic-infrastructure-v3/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: newrelic-infrastructure-v3
 description: A Helm chart to deploy the New Relic Kubernetes monitoring solution
-version: 3.0.17
+version: 3.0.18
 appVersion: 3.0.0
 kubeVersion: ">=1.16.0-0"
 home: https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration/

--- a/charts/newrelic-infrastructure-v3/templates/NOTES.txt
+++ b/charts/newrelic-infrastructure-v3/templates/NOTES.txt
@@ -95,7 +95,7 @@ future. Please migrate your agent config to the new format in the `common.agentC
 {{- end }}
 
 
-{{ $errors:= "\n" }}
+{{ $errors:= "" }}
 
 {{- if .Values.logFile }}
 {{ $errors = printf "%s\n\n%s" $errors (include "newrelic.compatibility.message.logFile" . ) }}
@@ -113,7 +113,7 @@ future. Please migrate your agent config to the new format in the `common.agentC
 {{ $errors = printf "%s\n\n%s" $errors (include "newrelic.compatibility.message.image" . ) }}
 {{- end }}
 
-{{- if (or .Values.enableWindows .Values.windowsOsList .Values.windowsSecurityContext .Values.windowsNodeSelector)}}
+{{- if .Values.enableWindows }}
 {{ $errors = printf "%s\n\n%s" $errors (include "newrelic.compatibility.message.windows" . ) }}
 {{- end }}
 
@@ -130,5 +130,5 @@ future. Please migrate your agent config to the new format in the `common.agentC
 {{- end }}
 
 {{- if $errors | trim}}
-{{- fail $errors }}
+{{- fail (printf "\n\n%s\n%s" (include "newrelic.compatibility.message.common" . ) $errors )  }}
 {{- end }}

--- a/charts/newrelic-infrastructure-v3/templates/_helpers_compatibility.tpl
+++ b/charts/newrelic-infrastructure-v3/templates/_helpers_compatibility.tpl
@@ -85,35 +85,52 @@ Returns legacy integrations_config configmap data
 {{- end -}}
 
 {{- define "newrelic.compatibility.message.logFile" -}}
-The `logFile` option is no longer supported and has been replaced by common.agentConfig.log_file.
+The 'logFile' option is no longer supported and has been replaced by:
+ - common.agentConfig.log_file.
+
+------
 {{- end -}}
 
 {{- define "newrelic.compatibility.message.resources" -}}
-You have specified the legacy `resources` option in your values, which is not fully compatible with the v3 version.
+You have specified the legacy 'resources' option in your values, which is not fully compatible with the v3 version.
 This version deploys three different components and therefore you'll need to specify resources for each of them.
-Please use `ksm.resources`, `controlPlane.resources` and `kubelet.resources`.
+Please use
+ - ksm.resources,
+ - controlPlane.resources,
+ - kubelet.resources.
+
+------
 {{- end -}}
 
 {{- define "newrelic.compatibility.message.tolerations" -}}
-You have specified the legacy `tolerations` option in your values, which is not fully compatible with the v3 version.
+You have specified the legacy 'tolerations' option in your values, which is not fully compatible with the v3 version.
 This version deploys three different components and therefore you'll need to specify tolerations for each of them.
-Please use `ksm.tolerations`, `controlPlane.tolerations` and `kubelet.tolerations`.
+Please use
+ - ksm.tolerations,
+ - controlPlane.tolerations,
+ - kubelet.tolerations.
+
+------
 {{- end -}}
 
 {{- define "newrelic.compatibility.message.apiServerSecurePort" -}}
-You have specified the legacy `apiServerSecurePort` option in your values, which is not fully compatible with the v3
+You have specified the legacy 'apiServerSecurePort' option in your values, which is not fully compatible with the v3
 version.
-Please configure the API Server port as a part of `apiServer.autodiscover[].endpoints`.
+Please configure the API Server port as a part of 'apiServer.autodiscover[].endpoints'
+
+------
 {{- end -}}
 
 {{- define "newrelic.compatibility.message.windows" -}}
 nri-kubernetes v3 does not support deploying into windows Nodes.
 Please use the latest 2.x version of the chart.
+
+------
 {{- end -}}
 
 {{- define "newrelic.compatibility.message.etcdSecrets" -}}
 Values "etcdTlsSecretName" and "etcdTlsSecretNamespace" are no longer supported, please specify them as a part of the
-`etcd` config in the values, for example:
+'etcd' config in the values, for example:
  - endpoints:
      - url: https://localhost:9979
        insecureSkipVerify: true
@@ -122,11 +139,13 @@ Values "etcdTlsSecretName" and "etcdTlsSecretNamespace" are no longer supported,
          mtls:
            secretName: {{ .Values.etcdTlsSecretName | default "etcdTlsSecretName"}}
            secretNamespace: {{ .Values.etcdTlsSecretNamespace | default "etcdTlsSecretNamespace"}}
+
+------
 {{- end -}}
 
 {{- define "newrelic.compatibility.message.apiURL" -}}
 Values "controllerManagerEndpointUrl", "etcdEndpointUrl", "apiServerEndpointUrl", "schedulerEndpointUrl" are no longer
-supported, please specify them as a part of the `controlplane` config in the values, for example
+supported, please specify them as a part of the 'controlplane' config in the values, for example
   autodiscover:
     - selector: "tier=control-plane,component=etcd"
       namespace: kube-system
@@ -136,10 +155,12 @@ supported, please specify them as a part of the `controlplane` config in the val
           insecureSkipVerify: true
           auth:
             type: bearer
+
+------
 {{- end -}}
 
 {{- define "newrelic.compatibility.message.image" -}}
-Configuring image repository an tag under `image` is no longer supported.
+Configuring image repository an tag under 'image' is no longer supported.
 The following values are no longer supported and are currently ignored:
  - image.repository
  - image.tag
@@ -151,4 +172,15 @@ Please set:
  - images.forwarder.* to configure the infrastructure-agent forwarder.
  - images.agent.* to configure the image bundling the infrastructure-agent and on-host integrations.
  - images.integration.* to configure the image in charge of scraping k8s data.
+
+------
+{{- end -}}
+
+{{- define "newrelic.compatibility.message.common" -}}
+######
+The chart cannot be rendered since the values listed below are not supported. Please replace those with the new ones compatible with newrelic-infrastructure V3.
+
+Keep in mind that the flag "--reuse-values" is not supported when migrating from V2 to V3.
+Further information can be found in the official docs https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/get-started/changes-since-v3#migration-guide"
+######
 {{- end -}}


### PR DESCRIPTION
#### Is this a new chart
no
#### What this PR does / why we need it:
 - `--reuse-values` is not allowed when migrating from V2 to V3. It is specified into the docs, however it was not super clear at update time.

 - Moreover I refactor a bit the errors adding a link to docs:

```
Error: UPGRADE FAILED: execution error at (nri-bundle/charts/newrelic-infrastructure/templates/NOTES.txt:133:4):

######
The chart cannot be rendered since the values listed below are not supported. Please replace those with the new ones compatible with newrelic-infrastructure V3.

Keep in mind that the flag "--reuse-values" is not supported when migrating from V2 to V3.
Further information can be found in the official docs https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/get-started/changes-since-v3#migration-guide"
######


You have specified the legacy 'tolerations' option in your values, which is not fully compatible with the v3 version.
This version deploys three different components and therefore you'll need to specify tolerations for each of them.
Please use
 - ksm.tolerations,
 - controlPlane.tolerations,
 - kubelet.tolerations.

------

nri-kubernetes v3 does not support deploying into windows Nodes.
Please use the latest 2.x version of the chart.

------
```

 - enableWindows  compatibility rule was too strict

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
