### PR TITLE
[nri-bundle] Update README.md

### DIFF
--- a/charts/nri-bundle/README.md
+++ b/charts/nri-bundle/README.md
@@ -166,7 +166,7 @@ helm install newrelic/nri-bundle \
 ```
 
 [1]: https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/license-key
-[2]: https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics
+[2]: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics
 [3]: https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-infrastructure
 [4]: https://github.com/newrelic/helm-charts/tree/master/charts/nri-prometheus
 [5]: https://github.com/newrelic/helm-charts/tree/master/charts/nri-metadata-injection


### PR DESCRIPTION
#### Is this a new chart
no

#### What this PR does / why we need it:
This change fixes the link in the readme to point to the new location for the `kube-state-metrics` helm chart.

The kube-state-metrics chart moved to the prometheus-community org as of v2.13: https://github.com/kubernetes/kube-state-metrics/releases/tag/kube-state-metrics-helm-chart-2.13.3

#### Special notes for your reviewer:

Old link was 404

#### Checklist
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
