### PR TITLE
Fix chart linting

### DIFF
--- a/.github/ct-install.yaml
+++ b/.github/ct-install.yaml
@@ -11,7 +11,7 @@
 # for the step that lint that includes all the folders at the same time and other of the installation step that test installability
 
 chart-dirs:
-  - library
+# - library  # I leave this commented for clarity's sake
   - charts
 
 chart-repos:

--- a/.github/workflows/lint_test_charts.yaml
+++ b/.github/workflows/lint_test_charts.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Check for changed installable charts
         id: list-changed
         run: |
-          changed=$(ct list-changed)
+          changed=$(ct list-changed --config .github/ct-install.yaml)
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi
@@ -63,6 +63,6 @@ jobs:
         run: kubectl create ns ct
 
       - name: Test install charts
-        run: ct install --namespace ct
+        run: ct install --namespace ct --config .github/ct-install.yaml
       - name: Test upgrade charts
-        run: ct install --namespace ct --upgrade
+        run: ct install --namespace ct --config .github/ct-install.yaml --upgrade


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

We introduced a regression in the PR #713 that broke the tests but only for change in `nri-bundle` helm chart.

A log can be seen here: https://github.com/newrelic/helm-charts/runs/5430202040?check_suite_focus=true#step:7:23

But I copy and paste it here in case Github rotates the logs:
```
Run ct lint --config .github/ct-lint.yaml
Linting charts...

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 nri-bundle => (version: "3.4.0", path: "charts/nri-bundle")
------------------------------------------------------------------------------------------------------------------------

Error: Error linting charts: Error building dependencies for chart 'nri-bundle => (version: "3.4.0", path: "charts/nri-bundle")': Error waiting for process: exit status 1
Error: no repository definition for https://kubernetes.github.io/kube-state-metrics, https://pixie-operator-charts.storage.googleapis.com./ Please add the missing repos via 'helm repo add'
------------------------------------------------------------------------------------------------------------------------
No chart changes detected.
------------------------------------------------------------------------------------------------------------------------
Error linting charts: Error building dependencies for chart 'nri-bundle => (version: "3.4.0", path: "charts/nri-bundle")': Error waiting for process: exit status 1
Error: Process completed with exit code 1.
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
