### PR TITLE
[common-library] Fix local service account name

### DIFF
--- a/library/CHART-TEMPLATE/Chart.lock
+++ b/library/CHART-TEMPLATE/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: file://../common-library
-  version: 0.6.0
-digest: sha256:e9dd9cd01c6a5829c1a75d6c0db8181ee99c33059f6cd2db4b7c245194b08005
-generated: "2022-03-09T10:04:52.333512+01:00"
+  version: 0.6.1
+digest: sha256:59556b116797c11f7f9f506a9363f89f54c7e0b235b47356db63799f81d520d2
+generated: "2022-03-09T11:01:57.786989+01:00"

--- a/library/CHART-TEMPLATE/Chart.yaml
+++ b/library/CHART-TEMPLATE/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,7 +25,7 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: common-library
-    version: 0.6.0
+    version: 0.6.1
     repository: file://../common-library
 
 keywords:

--- a/library/CHART-TEMPLATE/tests/common_library_serviceaccount_name_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_serviceaccount_name_test.yaml
@@ -44,3 +44,13 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: default
+
+  - it: allow to override the serviceacocunt name with the local one
+    set:
+      serviceAccount:
+        name: "my-local-service-account-name"
+        create: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: my-local-service-account-name

--- a/library/CHART-TEMPLATE/tests/common_library_serviceaccount_name_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_serviceaccount_name_test.yaml
@@ -49,6 +49,16 @@ tests:
     set:
       serviceAccount:
         name: "my-local-service-account-name"
+        create: false
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: my-local-service-account-name
+
+  - it: allow to override the serviceacocunt name with the local one
+    set:
+      serviceAccount:
+        name: "my-local-service-account-name"
         create: true
     asserts:
       - equal:

--- a/library/CHART-TEMPLATE/tests/common_library_serviceaccount_name_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_serviceaccount_name_test.yaml
@@ -45,8 +45,34 @@ tests:
           path: spec.template.spec.serviceAccountName
           value: default
 
+  - it: allow to override the serviceacocunt name with the global one
+    set:
+      global:
+        serviceAccount:
+          name: "my-global-service-account-name"
+          create: false
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: my-global-service-account-name
+
+  - it: allow to override the serviceacocunt name with the global one
+    set:
+      global:
+        serviceAccount:
+          name: "my-global-service-account-name"
+          create: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: my-global-service-account-name
+
   - it: allow to override the serviceacocunt name with the local one
     set:
+      global:
+        serviceAccount:
+          name: "my-global-service-account-name"
+          create: true
       serviceAccount:
         name: "my-local-service-account-name"
         create: false
@@ -57,6 +83,10 @@ tests:
 
   - it: allow to override the serviceacocunt name with the local one
     set:
+      global:
+        serviceAccount:
+          name: "my-global-service-account-name"
+          create: true
       serviceAccount:
         name: "my-local-service-account-name"
         create: true

--- a/library/CHART-TEMPLATE/tests/common_library_serviceaccount_name_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_serviceaccount_name_test.yaml
@@ -45,7 +45,7 @@ tests:
           path: spec.template.spec.serviceAccountName
           value: default
 
-  - it: allow to override the serviceacocunt name with the global one
+  - it: allow to override the serviceacocunt name with the global one when create is false
     set:
       global:
         serviceAccount:
@@ -56,7 +56,7 @@ tests:
           path: spec.template.spec.serviceAccountName
           value: my-global-service-account-name
 
-  - it: allow to override the serviceacocunt name with the global one
+  - it: allow to override the serviceacocunt name with the global one when create is true
     set:
       global:
         serviceAccount:
@@ -67,7 +67,7 @@ tests:
           path: spec.template.spec.serviceAccountName
           value: my-global-service-account-name
 
-  - it: allow to override the serviceacocunt name with the local one
+  - it: allow to override the serviceacocunt name with the local one when create is false
     set:
       global:
         serviceAccount:
@@ -81,7 +81,7 @@ tests:
           path: spec.template.spec.serviceAccountName
           value: my-local-service-account-name
 
-  - it: allow to override the serviceacocunt name with the local one
+  - it: allow to override the serviceacocunt name with the local one when create is true
     set:
       global:
         serviceAccount:

--- a/library/common-library/Chart.yaml
+++ b/library/common-library/Chart.yaml
@@ -3,7 +3,7 @@ name: common-library
 description: Provides helpers to provide consistency on all the charts
 
 type: library
-version: 0.6.0
+version: 0.6.1
 
 keywords:
   - newrelic

--- a/library/common-library/templates/_serviceaccount.tpl
+++ b/library/common-library/templates/_serviceaccount.tpl
@@ -47,9 +47,9 @@
 {{- end -}}
 
 {{- if (include "common.serviceAccount.create" .) -}}
-    {{- default (include "common.naming.fullname" .) $localServiceAccount $globalServiceAccount -}}
+    {{- $globalServiceAccount | default $localServiceAccount | default (include "common.naming.fullname" .) -}}
 {{- else -}}
-    {{- default "default" $localServiceAccount $globalServiceAccount -}}
+    {{- $globalServiceAccount | default $localServiceAccount | default "default" -}}
 {{- end -}}
 {{- end -}}
 

--- a/library/common-library/templates/_serviceaccount.tpl
+++ b/library/common-library/templates/_serviceaccount.tpl
@@ -47,9 +47,9 @@
 {{- end -}}
 
 {{- if (include "common.serviceAccount.create" .) -}}
-    {{- $globalServiceAccount | default $localServiceAccount | default (include "common.naming.fullname" .) -}}
+    {{- $localServiceAccount | default $globalServiceAccount | default (include "common.naming.fullname" .) -}}
 {{- else -}}
-    {{- $globalServiceAccount | default $localServiceAccount | default "default" -}}
+    {{- $localServiceAccount | default $globalServiceAccount | default "default" -}}
 {{- end -}}
 {{- end -}}
 

--- a/library/common-library/templates/_serviceaccount.tpl
+++ b/library/common-library/templates/_serviceaccount.tpl
@@ -47,9 +47,9 @@
 {{- end -}}
 
 {{- if (include "common.serviceAccount.create" .) -}}
-    {{- default (include "common.naming.fullname" .) $globalServiceAccount $localServiceAccount -}}
+    {{- default (include "common.naming.fullname" .) $localServiceAccount $globalServiceAccount -}}
 {{- else -}}
-    {{- default "default" $globalServiceAccount $localServiceAccount -}}
+    {{- default "default" $localServiceAccount $globalServiceAccount -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
When setting a .values service account name should take precedence to the default one
