### PR TITLE
common-library: add licenseKey related helpers

### DIFF
--- a/library/CHART-TEMPLATE/Chart.lock
+++ b/library/CHART-TEMPLATE/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: file://../common-library
-  version: 0.12.1
-digest: sha256:ba0db1033b5868f20165039221e5bfdfe91beb6351f43f1cfb8b83fb974ec14e
-generated: "2022-03-18T13:24:09.40402+01:00"
+  version: 0.13.0
+digest: sha256:72d99579229ac24def379920f9b06b9061d8e80c0f414e47d7027fbbde1ab5ff
+generated: "2022-03-18T14:35:13.200840177+01:00"

--- a/library/CHART-TEMPLATE/Chart.yaml
+++ b/library/CHART-TEMPLATE/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.1
+version: 0.13.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,7 +25,7 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: common-library
-    version: 0.12.1
+    version: 0.13.0
     repository: file://../common-library
 
 keywords:

--- a/library/CHART-TEMPLATE/templates/deployment.yaml
+++ b/library/CHART-TEMPLATE/templates/deployment.yaml
@@ -50,6 +50,12 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
+          env:
+            - name: NRIA_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "common.license.secretName" . }}
+                  key: {{ include "common.license.secretKeyName" . }}
           livenessProbe:
             httpGet:
               path: /

--- a/library/CHART-TEMPLATE/templates/example-cm-licensekey.yaml
+++ b/library/CHART-TEMPLATE/templates/example-cm-licensekey.yaml
@@ -1,0 +1,9 @@
+# This is a dummy CM to test what licenseKey helpers of the common library return
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "common.naming.fullname" . }}-examples
+  namespace: {{ .Release.Namespace }}
+data:
+  licensekey-secret-name: {{ include "common.license.secretName" . }}
+  licensekey-secret-key-name: {{ include "common.license.secretKeyName" . }}

--- a/library/CHART-TEMPLATE/templates/example-secret.yaml
+++ b/library/CHART-TEMPLATE/templates/example-secret.yaml
@@ -1,0 +1,1 @@
+{{- include "common.license.secret" . }}

--- a/library/CHART-TEMPLATE/tests/common_library_license_helpers_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_license_helpers_test.yaml
@@ -1,0 +1,66 @@
+suite: test licenseKey helpers
+templates:
+  - templates/example-cm-licensekey.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+tests:
+  - it: creates secret names for local licenseKey
+    set:
+      licenseKey: local
+    asserts:
+      - equal:
+          path: data.licensekey-secret-name
+          value: nri-my-release-CHART-TEMPLATE-license
+      - equal:
+          path: data.licensekey-secret-key-name
+          value: licenseKey
+  - it: creates secret names for global licenseKey
+    set:
+      global:
+        licenseKey: local
+    asserts:
+      - equal:
+          path: data.licensekey-secret-name
+          value: nri-my-release-CHART-TEMPLATE-license
+      - equal:
+          path: data.licensekey-secret-key-name
+          value: licenseKey
+
+  - it: returns local custom secret names
+    set:
+      customSecretName: local
+      customSecretLicenseKey: localkey
+    asserts:
+      - equal:
+          path: data.licensekey-secret-name
+          value: local
+      - equal:
+          path: data.licensekey-secret-key-name
+          value: localkey
+  - it: returns global custom secret names
+    set:
+      global:
+        customSecretName: global
+        customSecretLicenseKey: globalkey
+    asserts:
+      - equal:
+          path: data.licensekey-secret-name
+          value: global
+      - equal:
+          path: data.licensekey-secret-key-name
+          value: globalkey
+  - it: local secret names override global secret names
+    set:
+      customSecretName: local
+      customSecretLicenseKey: localkey
+      global:
+        customSecretName: global
+        customSecretLicenseKey: globalkey
+    asserts:
+      - equal:
+          path: data.licensekey-secret-name
+          value: local
+      - equal:
+          path: data.licensekey-secret-key-name
+          value: localkey

--- a/library/CHART-TEMPLATE/tests/common_library_license_secret_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_license_secret_test.yaml
@@ -1,0 +1,56 @@
+suite: test licenseKey secret
+templates:
+  - templates/example-secret.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+tests:
+  - it: errors if licenseKey is empty
+    set:
+      global: null
+      licenseKey: null
+    asserts:
+      - failedTemplate:
+          errorMessage: You must specify a licenseKey or a customSecretName containing it
+  - it: creates secret with local license key
+    set:
+      global: null
+      licenseKey: local
+    asserts:
+      - equal:
+          path: data.licenseKey
+          value: bG9jYWw=  # echo -n local | base64
+  - it: creates secret with global license key
+    set:
+      licenseKey: null
+      global:
+        licenseKey: global
+    asserts:
+      - equal:
+          path: data.licenseKey
+          value: Z2xvYmFs  # echo -n global | base64
+  - it: local overrides global
+    set:
+      licenseKey: local
+      global:
+        licenseKey: global
+    asserts:
+      - equal:
+          path: data.licenseKey
+          value: bG9jYWw=  # echo -n local | base64
+
+  - it: does not create a secret if one is provided locally
+    set:
+      licenseKey: I exist but will be ignored
+      customSecretName: foo
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: does not create a secret if one is provided globally
+    set:
+      licenseKey: I exist but will be ignored
+      global:
+        customSecretName: foo
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/library/CHART-TEMPLATE/values.yaml
+++ b/library/CHART-TEMPLATE/values.yaml
@@ -16,6 +16,8 @@ global:
   tolerations: []
   affinity: {}
 
+licenseKey: foobar
+
 replicaCount: 1
 
 image:

--- a/library/common-library/Chart.yaml
+++ b/library/common-library/Chart.yaml
@@ -3,7 +3,7 @@ name: common-library
 description: Provides helpers to provide consistency on all the charts
 
 type: library
-version: 0.12.1
+version: 0.13.0
 
 keywords:
   - newrelic

--- a/library/common-library/templates/_license.tpl
+++ b/library/common-library/templates/_license.tpl
@@ -1,0 +1,62 @@
+{{/*
+Return the name of the secret holding the License Key.
+*/}}
+{{- define "common.license.secretName" -}}
+{{ include "common.license._customSecretName" . | default (printf "%s-license" (include "common.naming.fullname" . )) }}
+{{- end -}}
+
+{{/*
+Return the name key for the License Key inside the secret.
+*/}}
+{{- define "common.license.secretKeyName" -}}
+{{ include "common.license._customSecretKey" . | default "licenseKey" }}
+{{- end -}}
+
+{{/*
+Charts using this library can implement this function. If it returns a truthy value, common.license.secret will not
+fail if an empty licenseKey is provided.
+*/}}
+{{- define "common.license.overrides.allowEmpty" -}}
+{{- end }}
+
+{{/*
+Return local licenseKey if set, global otherwise.
+This helper is for internal use.
+*/}}
+{{- define "common.license._licenseKey" -}}
+{{- if .Values.licenseKey -}}
+  {{- .Values.licenseKey -}}
+{{- else if .Values.global -}}
+  {{- if .Values.global.licenseKey -}}
+    {{- .Values.global.licenseKey -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the name of the secret holding the License Key.
+This helper is for internal use.
+*/}}
+{{- define "common.license._customSecretName" -}}
+{{- if .Values.customSecretName -}}
+  {{- .Values.customSecretName -}}
+{{- else if .Values.global -}}
+  {{- if .Values.global.customSecretName -}}
+    {{- .Values.global.customSecretName -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the name key for the License Key inside the secret.
+This helper is for internal use.
+*/}}
+{{- define "common.license._customSecretKey" -}}
+{{- if .Values.customSecretLicenseKey -}}
+  {{- .Values.customSecretLicenseKey -}}
+{{- else if .Values.global -}}
+  {{- if .Values.global.customSecretLicenseKey }}
+    {{- .Values.global.customSecretLicenseKey -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/library/common-library/templates/_license.tpl
+++ b/library/common-library/templates/_license.tpl
@@ -13,13 +13,6 @@ Return the name key for the License Key inside the secret.
 {{- end -}}
 
 {{/*
-Charts using this library can implement this function. If it returns a truthy value, common.license.secret will not
-fail if an empty licenseKey is provided.
-*/}}
-{{- define "common.license.overrides.allowEmpty" -}}
-{{- end }}
-
-{{/*
 Return local licenseKey if set, global otherwise.
 This helper is for internal use.
 */}}

--- a/library/common-library/templates/_license_secret.yaml.tpl
+++ b/library/common-library/templates/_license_secret.yaml.tpl
@@ -5,9 +5,7 @@ Renders the license key secret if user has not specified a custom secret.
 {{- if not (include "common.license._customSecretName" .) }}
 {{- /* Fail if licenseKey is empty and required: */ -}}
 {{- if not (include "common.license._licenseKey" .) }}
-    {{- if not (include "common.license.overrides.allowEmpty" .) }}
     {{- fail "You must specify a licenseKey or a customSecretName containing it" }}
-    {{- end }}
 {{- end }}
 ---
 apiVersion: v1

--- a/library/common-library/templates/_license_secret.yaml.tpl
+++ b/library/common-library/templates/_license_secret.yaml.tpl
@@ -1,0 +1,23 @@
+{{/*
+Renders the license key secret if user has not specified a custom secret.
+*/}}
+{{- define "common.license.secret" }}
+{{- if not (include "common.license._customSecretName" .) }}
+{{- /* Fail if licenseKey is empty and required: */ -}}
+{{- if not (include "common.license._licenseKey" .) }}
+    {{- if not (include "common.license.overrides.allowEmpty" .) }}
+    {{- fail "You must specify a licenseKey or a customSecretName containing it" }}
+    {{- end }}
+{{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "common.license.secretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+data:
+  {{ include "common.license.secretKeyName" . }}: {{ include "common.license._licenseKey" . | b64enc }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
The following helper functions have been added to the common library:
- `common.license.secretName`, returing the name of the secret holding the license key.
- `common.license.secretKeyName`, returing name of the key inside the secret containing the license key.
- `common.license.secret`, which renders a secret if and only if user supplies the license key ad-hoc in the values.

All the logic of handling both globals _and_ custom secret names for the keys are already implemented in the helpers above, so chart writers only have to do two things:

1, include the `common.licenseKey.secret` template:
```
───────┬───────────────────────────────────────────────────────────────────────
       │ File: example-secret.yaml
       │ Size: 44 B
───────┼───────────────────────────────────────────────────────────────────────
   1   │ {{- include "common.licenseKey.secret" . }}
───────┴───────────────────────────────────────────────────────────────────────
```

2, reference it using the helpers:
```yaml
  env:
    - name: NRIA_LICENSE_KEY
      valueFrom:
        secretKeyRef:
          name: {{ include "common.licenseKey.secretName" . }}
          key: {{ include "common.licenseKey.secretKeyName" . }}
```

The library takes care of:

1. Not rendering anything in the secret if the user is providing their own.
2. Returning either the user-provided, or the generated names in `common.licenseKey.secretName` and `common.licenseKey.secretKeyName`, looking for globals.
3. Validating a license key has been provided.

Moreover, an overridable `common.licenseKey.overrides.allowEmpty` helper is defined, which by default returns false. Charts using the library may override the helpr to return true, in which case, the library will not error if a `licenseKey` is not defined in the user values.