### PR TITLE
[common-library] Add host network helper

### DIFF
--- a/library/CHART-TEMPLATE/Chart.lock
+++ b/library/CHART-TEMPLATE/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: file://../common-library
-  version: 0.11.0
-digest: sha256:83edc5b9643b33c3420a2d6a19bea14b534d45d6ffb3284519a133904298f3a3
-generated: "2022-03-18T11:33:06.922088+01:00"
+  version: 0.12.0
+digest: sha256:ea3bd4d84cd584139292d3fe35a9edf7db5554624061bcbfde5a522bcf5d9bfc
+generated: "2022-03-18T13:11:01.800111+01:00"

--- a/library/CHART-TEMPLATE/Chart.yaml
+++ b/library/CHART-TEMPLATE/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.0
+version: 0.12.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,7 +25,7 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: common-library
-    version: 0.11.0
+    version: 0.12.0
     repository: file://../common-library
 
 keywords:

--- a/library/CHART-TEMPLATE/templates/deployment.yaml
+++ b/library/CHART-TEMPLATE/templates/deployment.yaml
@@ -23,6 +23,9 @@ spec:
       imagePullSecrets:
         {{- . | nindent 8 }}
       {{- end }}
+      {{- with include "common.hostNetwork" . }}
+      hostNetwork: {{ . }}
+      {{- end }}
       serviceAccountName: {{ include "common.serviceAccount.name" . }}
       {{- with include "common.securityContext.pod" . }}
       securityContext:

--- a/library/CHART-TEMPLATE/tests/common_library_hostnetwork_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_hostnetwork_test.yaml
@@ -1,0 +1,61 @@
+suite: test hostNetwork helper
+templates:
+  - templates/deployment.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+set:
+  licenseKey: test-license-key
+  cluster: test-cluster
+tests:
+  - it: Is false by default
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: false
+
+  - it: Is false with everything null
+    set:
+      global: null
+      hostNetwork: null
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: false
+
+  - it: Enable hostNetwork (globally)
+    set:
+      global:
+        hostNetwork: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+
+  - it: Enable hostNetwork (locally)
+    set:
+      hostNetwork: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+
+  - it: Overrides to false the global state locally
+    set:
+      global:
+        hostNetwork: true
+      hostNetwork: false
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: false
+
+  - it: Overrides to true the global state locally
+    set:
+      global:
+        hostNetwork: false
+      hostNetwork: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true

--- a/library/CHART-TEMPLATE/values.yaml
+++ b/library/CHART-TEMPLATE/values.yaml
@@ -11,6 +11,7 @@ global:
     # The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template
     name:
+  hostNetwork:
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -41,6 +42,8 @@ podAnnotations: {}
 
 podSecurityContext: {}
   # fsGroup: 2000
+
+hostNetwork:
 
 securityContext: {}
   # capabilities:

--- a/library/common-library/Chart.yaml
+++ b/library/common-library/Chart.yaml
@@ -3,7 +3,7 @@ name: common-library
 description: Provides helpers to provide consistency on all the charts
 
 type: library
-version: 0.11.0
+version: 0.12.0
 
 keywords:
   - newrelic

--- a/library/common-library/templates/_hostnetwork.tpl
+++ b/library/common-library/templates/_hostnetwork.tpl
@@ -1,0 +1,34 @@
+{{- /*
+Abstraction of the hostNetwork toggle.
+This helper allows to override the global `.global.hostNetwork` with the value of `.hostNetwork`.
+Returns "true" if `hostNetwork` is enabled, otherwise fallbacks to a overridable function
+*/ -}}
+{{- define "common.hostNetwork" -}}
+{{- /* This allows us to use `$global` as an empty dict directly in case `Values.global` does not exists */ -}}
+{{- $global := index .Values "global" | default dict -}}
+
+{{- /* `get` will return "" (empty string) if value is not found, and the value otherwise, so we can type-assert with kindIs */ -}}
+{{- if get .Values "hostNetwork" | kindIs "bool" -}}
+    {{- if .Values.hostNetwork -}}
+        true
+    {{- else -}}
+        false
+    {{- end -}}
+{{- else if get $global "hostNetwork" | kindIs "bool" -}}
+    {{- if $global.hostNetwork -}}
+        true
+    {{- else -}}
+        false
+    {{- end -}}
+{{- else -}}
+    {{- include "common.hostNetwork.defaultOverride" . -}}
+{{- end -}}
+{{- end -}}
+
+
+{{- /*
+This allows to change the default of the helper `common.hostNetwork`. Defaults to empty string: "" (Helm falsiness)
+*/ -}}
+{{- define "common.hostNetwork.defaultOverride" -}}
+false
+{{- end -}}

--- a/library/common-library/templates/_hostnetwork.tpl
+++ b/library/common-library/templates/_hostnetwork.tpl
@@ -9,17 +9,9 @@ Returns "true" if `hostNetwork` is enabled, otherwise fallbacks to a overridable
 
 {{- /* `get` will return "" (empty string) if value is not found, and the value otherwise, so we can type-assert with kindIs */ -}}
 {{- if get .Values "hostNetwork" | kindIs "bool" -}}
-    {{- if .Values.hostNetwork -}}
-        true
-    {{- else -}}
-        false
-    {{- end -}}
+    {{- .Values.hostNetwork -}}
 {{- else if get $global "hostNetwork" | kindIs "bool" -}}
-    {{- if $global.hostNetwork -}}
-        true
-    {{- else -}}
-        false
-    {{- end -}}
+    {{- $global.hostNetwork -}}
 {{- else -}}
     {{- include "common.hostNetwork.defaultOverride" . -}}
 {{- end -}}
@@ -27,7 +19,7 @@ Returns "true" if `hostNetwork` is enabled, otherwise fallbacks to a overridable
 
 
 {{- /*
-This allows to change the default of the helper `common.hostNetwork`. Defaults to empty string: "" (Helm falsiness)
+This allows to change the default of the helper `common.hostNetwork`. Defaults to false
 */ -}}
 {{- define "common.hostNetwork.defaultOverride" -}}
 false


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

This adds to chart template and common library the ability to set `hostNetwork` to the pods.

#### Checklist
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
