### PR TITLE
[common-library] Change service account creation default to true

### DIFF
--- a/library/CHART-TEMPLATE/Chart.lock
+++ b/library/CHART-TEMPLATE/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: file://../common-library
-  version: 0.12.0
-digest: sha256:ea3bd4d84cd584139292d3fe35a9edf7db5554624061bcbfde5a522bcf5d9bfc
-generated: "2022-03-18T13:11:01.800111+01:00"
+  version: 0.12.1
+digest: sha256:ba0db1033b5868f20165039221e5bfdfe91beb6351f43f1cfb8b83fb974ec14e
+generated: "2022-03-18T13:24:09.40402+01:00"

--- a/library/CHART-TEMPLATE/Chart.yaml
+++ b/library/CHART-TEMPLATE/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.0
+version: 0.12.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,7 +25,7 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: common-library
-    version: 0.12.0
+    version: 0.12.1
     repository: file://../common-library
 
 keywords:

--- a/library/CHART-TEMPLATE/tests/common_library_serviceaccount_create_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_serviceaccount_create_test.yaml
@@ -5,12 +5,25 @@ release:
   name: my-release
   namespace: my-namespace
 tests:
-  - it: default values should not template a service account
+  - it: default values template a service account
     asserts:
       - hasDocuments:
-          count: 0
+          count: 1
+      - equal:
+          path: metadata.name
+          value: nri-my-release-CHART-TEMPLATE
 
-  - it: create (globally) a service account creates a service account with the chart name
+  - it: no global values template a service account
+    set:
+      global: null
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: nri-my-release-CHART-TEMPLATE
+
+  - it: create (globally) a service account
     set:
       global:
         serviceAccount:
@@ -22,7 +35,7 @@ tests:
           path: metadata.name
           value: nri-my-release-CHART-TEMPLATE
 
-  - it: create (locally) a service account creates a service account with the chart name
+  - it: create (locally) a service account
     set:
       serviceAccount:
         create: true
@@ -33,7 +46,24 @@ tests:
           path: metadata.name
           value: nri-my-release-CHART-TEMPLATE
 
-  - it: Allow to override the global creation of a service account
+  - it: disable (globally) a service account
+    set:
+      global:
+        serviceAccount:
+          create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: disable (locally) a service account
+    set:
+      serviceAccount:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Allow to override the global disable of a service account
     set:
       global:
         serviceAccount:
@@ -43,3 +73,17 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: Allow to override the global creation of a service account
+    set:
+      global:
+        serviceAccount:
+          create: false
+      serviceAccount:
+        create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: nri-my-release-CHART-TEMPLATE

--- a/library/CHART-TEMPLATE/tests/common_library_serviceaccount_name_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_serviceaccount_name_test.yaml
@@ -5,7 +5,10 @@ release:
   name: my-release
   namespace: my-namespace
 tests:
-  - it: default values has "default" serviceAccount
+  - it: Not creating a servie account uses "default" service account
+    set:
+      serviceAccount:
+        create: false
     asserts:
       - equal:
           path: spec.template.spec.serviceAccountName

--- a/library/CHART-TEMPLATE/tests/common_library_serviceaccount_name_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_serviceaccount_name_test.yaml
@@ -5,7 +5,7 @@ release:
   name: my-release
   namespace: my-namespace
 tests:
-  - it: Not creating a servie account uses "default" service account
+  - it: Not creating a service account uses "default" service account
     set:
       serviceAccount:
         create: false

--- a/library/common-library/Chart.yaml
+++ b/library/common-library/Chart.yaml
@@ -3,7 +3,7 @@ name: common-library
 description: Provides helpers to provide consistency on all the charts
 
 type: library
-version: 0.12.0
+version: 0.12.1
 
 keywords:
   - newrelic

--- a/library/common-library/templates/_serviceaccount.tpl
+++ b/library/common-library/templates/_serviceaccount.tpl
@@ -1,6 +1,8 @@
 {{- /* Defines if the service account has to be created or not */ -}}
 {{- define "common.serviceAccount.create" -}}
 {{- $valueFound := false -}}
+
+{{- /* Look for a global creation of a service account */ -}}
 {{- if get .Values "serviceAccount" | kindIs "map" -}}
     {{- if (get .Values.serviceAccount "create" | kindIs "bool") -}}
         {{- $valueFound = true -}}
@@ -14,19 +16,32 @@
         {{- end -}}
     {{- end -}}
 {{- end -}}
+
+{{- /* Look for a local creation of a service account */ -}}
 {{- if not $valueFound -}}
     {{- /* This allows us to use `$global` as an empty dict directly in case `Values.global` does not exists */ -}}
     {{- $global := index .Values "global" | default dict -}}
     {{- if get $global "serviceAccount" | kindIs "map" -}}
         {{- if get $global.serviceAccount "create" | kindIs "bool" -}}
+            {{- $valueFound = true -}}
             {{- if $global.serviceAccount.create -}}
                 {{- $global.serviceAccount.create -}}
             {{- end -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}
+
+{{- /* In case no serviceAccount value has been found, default to "true" */ -}}
+{{- if not $valueFound -}}
+  {{- include "common.serviceAccount.createDefaultOveerride" . -}}
+{{- end -}}
 {{- end -}}
 
+
+{{- /* Defines the default if a service account should be created or not */ -}}
+{{- define "common.serviceAccount.createDefaultOveerride" -}}
+true
+{{- end -}}
 
 
 {{- /* Defines the name of the service account */ -}}

--- a/library/common-library/templates/_serviceaccount.tpl
+++ b/library/common-library/templates/_serviceaccount.tpl
@@ -33,13 +33,13 @@
 
 {{- /* In case no serviceAccount value has been found, default to "true" */ -}}
 {{- if not $valueFound -}}
-  {{- include "common.serviceAccount.createDefaultOveerride" . -}}
+  {{- include "common.serviceAccount.createDefaultOverride" . -}}
 {{- end -}}
 {{- end -}}
 
 
 {{- /* Defines the default if a service account should be created or not */ -}}
-{{- define "common.serviceAccount.createDefaultOveerride" -}}
+{{- define "common.serviceAccount.createDefaultOverride" -}}
 true
 {{- end -}}
 


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

We normally use `serviceAccount` for our needs so we should have them enabled by default if there is nothing in the values. This changes the default before we go GA so we do not break everything.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
