### PR TITLE
[common-library] Add verbose flag

### DIFF
--- a/library/CHART-TEMPLATE/Chart.lock
+++ b/library/CHART-TEMPLATE/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: file://../common-library
-  version: 0.14.3
-digest: sha256:210e9bbaf1962a5ef9f5ddc6ddd1910b706a057f3d80649c7b5d61d5a1a5f06f
-generated: "2022-03-22T16:02:11.09227+01:00"
+  version: 0.15.0
+digest: sha256:1ddaf0929329af338a0716042131c70ade47939f7d1e472f9730c9723756610a
+generated: "2022-03-23T15:06:58.602329+01:00"

--- a/library/CHART-TEMPLATE/Chart.yaml
+++ b/library/CHART-TEMPLATE/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.3
+version: 0.15.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,7 +25,7 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: common-library
-    version: 0.14.3
+    version: 0.15.0
     repository: file://../common-library
 
 keywords:

--- a/library/CHART-TEMPLATE/templates/example-cm-hostnetwork.yaml
+++ b/library/CHART-TEMPLATE/templates/example-cm-hostnetwork.yaml
@@ -9,4 +9,4 @@ data:
   hostNetwork-with-if: {{ if include "common.hostNetwork" . }}enabled{{ else }}disabled{{ end }}
   hostNetwork-with-quote: {{ include "common.hostNetwork" . | quote }}
   hostNetwork-with-default: {{ include "common.hostNetwork" . | default "false" | quote }}
-  hostNetwork-boolean: {{ include "common.hostNetwork.value" . | quote }}
+  hostNetwork-value: {{ include "common.hostNetwork.value" . | quote }}

--- a/library/CHART-TEMPLATE/templates/example-cm-verbose.yaml
+++ b/library/CHART-TEMPLATE/templates/example-cm-verbose.yaml
@@ -6,6 +6,6 @@ metadata:
 data:
   {{- /* Be careful because this returns an empty string when false because "false" is evaluated as true in Helm
          Take a look to the tests suite "common_library_lowdatamode_test.yaml" to see who this behaves */}}
-  verbose-with-if: {{ if include "common.verbose" . }}enabled{{ else }}disabled{{ end }}
-  verbose-with-quote: {{ include "common.verbose" . | quote }}
-  verbose-with-default: {{ include "common.verbose" . | default "false" | quote }}
+  verboseLog-with-if: {{ if include "common.verboseLog" . }}enabled{{ else }}disabled{{ end }}
+  verboseLog-with-quote: {{ include "common.verboseLog" . | quote }}
+  verboseLog-with-default: {{ include "common.verboseLog" . | default "false" | quote }}

--- a/library/CHART-TEMPLATE/templates/example-cm-verbose.yaml
+++ b/library/CHART-TEMPLATE/templates/example-cm-verbose.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "common.naming.fullname" . }}-examples-verbose
+  namespace: {{ .Release.Namespace }}
+data:
+  {{- /* Be careful because this returns an empty string when false because "false" is evaluated as true in Helm
+         Take a look to the tests suite "common_library_lowdatamode_test.yaml" to see who this behaves */}}
+  verbose-with-if: {{ if include "common.verbose" . }}enabled{{ else }}disabled{{ end }}
+  verbose-with-quote: {{ include "common.verbose" . | quote }}
+  verbose-with-default: {{ include "common.verbose" . | default "false" | quote }}

--- a/library/CHART-TEMPLATE/templates/example-cm-verbose.yaml
+++ b/library/CHART-TEMPLATE/templates/example-cm-verbose.yaml
@@ -9,3 +9,4 @@ data:
   verboseLog-with-if: {{ if include "common.verboseLog" . }}enabled{{ else }}disabled{{ end }}
   verboseLog-with-quote: {{ include "common.verboseLog" . | quote }}
   verboseLog-with-default: {{ include "common.verboseLog" . | default "false" | quote }}
+  verboseLog-value: {{ include "common.verboseLog.value" . | quote }}

--- a/library/CHART-TEMPLATE/tests/common_library_hostnetwork_cm_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_hostnetwork_cm_test.yaml
@@ -20,7 +20,7 @@ tests:
           path: data.hostNetwork-with-default
           value: "false"
       - equal:
-          path: data.hostNetwork-boolean
+          path: data.hostNetwork-value
           value: "false"
 
   - it: Is false with everything null
@@ -38,7 +38,7 @@ tests:
           path: data.hostNetwork-with-default
           value: "false"
       - equal:
-          path: data.hostNetwork-boolean
+          path: data.hostNetwork-value
           value: "false"
 
   - it: Enable low data mode (globally)
@@ -56,7 +56,7 @@ tests:
           path: data.hostNetwork-with-default
           value: "true"
       - equal:
-          path: data.hostNetwork-boolean
+          path: data.hostNetwork-value
           value: "true"
 
   - it: Enable low data mode (locally)
@@ -73,7 +73,7 @@ tests:
           path: data.hostNetwork-with-default
           value: "true"
       - equal:
-          path: data.hostNetwork-boolean
+          path: data.hostNetwork-value
           value: "true"
 
   - it: Overrides to false the global state locally
@@ -92,7 +92,7 @@ tests:
           path: data.hostNetwork-with-default
           value: "false"
       - equal:
-          path: data.hostNetwork-boolean
+          path: data.hostNetwork-value
           value: "false"
 
   - it: Overrides to true the global state locally
@@ -111,5 +111,5 @@ tests:
           path: data.hostNetwork-with-default
           value: "true"
       - equal:
-          path: data.hostNetwork-boolean
+          path: data.hostNetwork-value
           value: "true"

--- a/library/CHART-TEMPLATE/tests/common_library_verbose_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_verbose_test.yaml
@@ -1,0 +1,97 @@
+suite: test verbose helper
+templates:
+  - templates/example-cm-verbose.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+set:
+  licenseKey: test-license-key
+  cluster: test-cluster
+tests:
+  - it: Is false by default
+    asserts:
+      - equal:
+          path: data.verbose-with-if
+          value: "disabled"
+      - equal:
+          path: data.verbose-with-quote
+          value: ""
+      - equal:
+          path: data.verbose-with-default
+          value: "false"
+
+  - it: Is false with everything null
+    set:
+      global: null
+      verbose: null
+    asserts:
+      - equal:
+          path: data.verbose-with-if
+          value: "disabled"
+      - equal:
+          path: data.verbose-with-quote
+          value: ""
+      - equal:
+          path: data.verbose-with-default
+          value: "false"
+
+  - it: Enable low data mode (globally)
+    set:
+      global:
+        verbose: true
+    asserts:
+      - equal:
+          path: data.verbose-with-if
+          value: "enabled"
+      - equal:
+          path: data.verbose-with-quote
+          value: "true"
+      - equal:
+          path: data.verbose-with-default
+          value: "true"
+
+  - it: Enable low data mode (locally)
+    set:
+      verbose: true
+    asserts:
+      - equal:
+          path: data.verbose-with-if
+          value: "enabled"
+      - equal:
+          path: data.verbose-with-quote
+          value: "true"
+      - equal:
+          path: data.verbose-with-default
+          value: "true"
+
+  - it: Overrides to false the global state locally
+    set:
+      global:
+        verbose: true
+      verbose: false
+    asserts:
+      - equal:
+          path: data.verbose-with-if
+          value: "disabled"
+      - equal:
+          path: data.verbose-with-quote
+          value: ""
+      - equal:
+          path: data.verbose-with-default
+          value: "false"
+
+  - it: Overrides to true the global state locally
+    set:
+      global:
+        verbose: false
+      verbose: true
+    asserts:
+      - equal:
+          path: data.verbose-with-if
+          value: "enabled"
+      - equal:
+          path: data.verbose-with-quote
+          value: "true"
+      - equal:
+          path: data.verbose-with-default
+          value: "true"

--- a/library/CHART-TEMPLATE/tests/common_library_verbose_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_verbose_test.yaml
@@ -11,87 +11,87 @@ tests:
   - it: Is false by default
     asserts:
       - equal:
-          path: data.verbose-with-if
+          path: data.verboseLog-with-if
           value: "disabled"
       - equal:
-          path: data.verbose-with-quote
+          path: data.verboseLog-with-quote
           value: ""
       - equal:
-          path: data.verbose-with-default
+          path: data.verboseLog-with-default
           value: "false"
 
   - it: Is false with everything null
     set:
       global: null
-      verbose: null
+      verboseLog: null
     asserts:
       - equal:
-          path: data.verbose-with-if
+          path: data.verboseLog-with-if
           value: "disabled"
       - equal:
-          path: data.verbose-with-quote
+          path: data.verboseLog-with-quote
           value: ""
       - equal:
-          path: data.verbose-with-default
+          path: data.verboseLog-with-default
           value: "false"
 
-  - it: Enable low data mode (globally)
+  - it: Enable verboseLog (globally)
     set:
       global:
-        verbose: true
+        verboseLog: true
     asserts:
       - equal:
-          path: data.verbose-with-if
+          path: data.verboseLog-with-if
           value: "enabled"
       - equal:
-          path: data.verbose-with-quote
+          path: data.verboseLog-with-quote
           value: "true"
       - equal:
-          path: data.verbose-with-default
+          path: data.verboseLog-with-default
           value: "true"
 
-  - it: Enable low data mode (locally)
+  - it: Enable verboseLog (locally)
     set:
-      verbose: true
+      verboseLog: true
     asserts:
       - equal:
-          path: data.verbose-with-if
+          path: data.verboseLog-with-if
           value: "enabled"
       - equal:
-          path: data.verbose-with-quote
+          path: data.verboseLog-with-quote
           value: "true"
       - equal:
-          path: data.verbose-with-default
+          path: data.verboseLog-with-default
           value: "true"
 
   - it: Overrides to false the global state locally
     set:
       global:
-        verbose: true
-      verbose: false
+        verboseLog: true
+      verboseLog: false
     asserts:
       - equal:
-          path: data.verbose-with-if
+          path: data.verboseLog-with-if
           value: "disabled"
       - equal:
-          path: data.verbose-with-quote
+          path: data.verboseLog-with-quote
           value: ""
       - equal:
-          path: data.verbose-with-default
+          path: data.verboseLog-with-default
           value: "false"
 
   - it: Overrides to true the global state locally
     set:
       global:
-        verbose: false
-      verbose: true
+        verboseLog: false
+      verboseLog: true
     asserts:
       - equal:
-          path: data.verbose-with-if
+          path: data.verboseLog-with-if
           value: "enabled"
       - equal:
-          path: data.verbose-with-quote
+          path: data.verboseLog-with-quote
           value: "true"
       - equal:
-          path: data.verbose-with-default
+          path: data.verboseLog-with-default
           value: "true"

--- a/library/CHART-TEMPLATE/tests/common_library_verbose_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_verbose_test.yaml
@@ -19,6 +19,9 @@ tests:
       - equal:
           path: data.verboseLog-with-default
           value: "false"
+      - equal:
+          path: data.verboseLog-value
+          value: "false"
 
   - it: Is false with everything null
     set:
@@ -33,6 +36,9 @@ tests:
           value: ""
       - equal:
           path: data.verboseLog-with-default
+          value: "false"
+      - equal:
+          path: data.verboseLog-value
           value: "false"
 
   - it: Enable verboseLog (globally)
@@ -49,6 +55,9 @@ tests:
       - equal:
           path: data.verboseLog-with-default
           value: "true"
+      - equal:
+          path: data.verboseLog-value
+          value: "true"
 
   - it: Enable verboseLog (locally)
     set:
@@ -62,6 +71,9 @@ tests:
           value: "true"
       - equal:
           path: data.verboseLog-with-default
+          value: "true"
+      - equal:
+          path: data.verboseLog-value
           value: "true"
 
   - it: Overrides to false the global state locally
@@ -79,6 +91,9 @@ tests:
       - equal:
           path: data.verboseLog-with-default
           value: "false"
+      - equal:
+          path: data.verboseLog-value
+          value: "false"
 
   - it: Overrides to true the global state locally
     set:
@@ -94,4 +109,7 @@ tests:
           value: "true"
       - equal:
           path: data.verboseLog-with-default
+          value: "true"
+      - equal:
+          path: data.verboseLog-value
           value: "true"

--- a/library/CHART-TEMPLATE/values.yaml
+++ b/library/CHART-TEMPLATE/values.yaml
@@ -12,6 +12,7 @@ global:
     # If not set and create is true, a name is generated using the fullname template
     name:
   hostNetwork:
+  verboseLog:
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -46,6 +47,7 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 hostNetwork:
+verboseLog:
 
 securityContext: {}
   # capabilities:

--- a/library/common-library/Chart.yaml
+++ b/library/common-library/Chart.yaml
@@ -3,7 +3,7 @@ name: common-library
 description: Provides helpers to provide consistency on all the charts
 
 type: library
-version: 0.14.3
+version: 0.15.0
 
 keywords:
   - newrelic

--- a/library/common-library/templates/_verbose-log.tpl
+++ b/library/common-library/templates/_verbose-log.tpl
@@ -1,25 +1,25 @@
 {{- /*
 Abstraction of the verbose toggle.
-This helper allows to override the global `.global.verbose` with the value of `.verbose`.
+This helper allows to override the global `.global.verboseLog` with the value of `.verboseLog`.
 Returns "true" if `verbose` is enabled, otherwise "" (empty string)
 */ -}}
-{{- define "common.verbose" -}}
+{{- define "common.verboseLog" -}}
 {{- /* `get` will return "" (empty string) if value is not found, and the value otherwise, so we can type-assert with kindIs */ -}}
-{{- if (get .Values "verbose" | kindIs "bool") -}}
-    {{- if .Values.verbose -}}
+{{- if (get .Values "verboseLog" | kindIs "bool") -}}
+    {{- if .Values.verboseLog -}}
         {{- /*
             We want only to return when this is true, returning `false` here will template "false" (string) when doing
-            an `(include "common.verbose" .)`, which is not an "empty string" so it is `true` if it is used
+            an `(include "common.verboseLog" .)`, which is not an "empty string" so it is `true` if it is used
             as an evaluation somewhere else.
         */ -}}
-        {{- .Values.verbose -}}
+        {{- .Values.verboseLog -}}
     {{- end -}}
 {{- else -}}
 {{- /* This allows us to use `$global` as an empty dict directly in case `Values.global` does not exists */ -}}
 {{- $global := index .Values "global" | default dict -}}
-{{- if get $global "verbose" | kindIs "bool" -}}
-    {{- if $global.verbose -}}
-        {{- $global.verbose -}}
+{{- if get $global "verboseLog" | kindIs "bool" -}}
+    {{- if $global.verboseLog -}}
+        {{- $global.verboseLog -}}
     {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/library/common-library/templates/_verbose-log.tpl
+++ b/library/common-library/templates/_verbose-log.tpl
@@ -24,3 +24,16 @@ Returns "true" if `verbose` is enabled, otherwise "" (empty string)
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+
+{{- /*
+Abstraction of the verbose toggle.
+This helper abstracts the function "common.verboseLog" to return true or false directly.
+*/ -}}
+{{- define "common.verboseLog.value" -}}
+{{- if include "common.verboseLog" . -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}

--- a/library/common-library/templates/_verbose.tpl
+++ b/library/common-library/templates/_verbose.tpl
@@ -1,0 +1,26 @@
+{{- /*
+Abstraction of the verbose toggle.
+This helper allows to override the global `.global.verbose` with the value of `.verbose`.
+Returns "true" if `verbose` is enabled, otherwise "" (empty string)
+*/ -}}
+{{- define "common.verbose" -}}
+{{- /* `get` will return "" (empty string) if value is not found, and the value otherwise, so we can type-assert with kindIs */ -}}
+{{- if (get .Values "verbose" | kindIs "bool") -}}
+    {{- if .Values.verbose -}}
+        {{- /*
+            We want only to return when this is true, returning `false` here will template "false" (string) when doing
+            an `(include "common.verbose" .)`, which is not an "empty string" so it is `true` if it is used
+            as an evaluation somewhere else.
+        */ -}}
+        {{- .Values.verbose -}}
+    {{- end -}}
+{{- else -}}
+{{- /* This allows us to use `$global` as an empty dict directly in case `Values.global` does not exists */ -}}
+{{- $global := index .Values "global" | default dict -}}
+{{- if get $global "verbose" | kindIs "bool" -}}
+    {{- if $global.verbose -}}
+        {{- $global.verbose -}}
+    {{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

This allows toggling the debug verbosity consistently in all the Helm charts that use this library 

#### Checklist
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
