### PR TITLE
[common-library] Add dnsConfig feature to the common library

### DIFF
--- a/library/CHART-TEMPLATE/Chart.lock
+++ b/library/CHART-TEMPLATE/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: file://../common-library
-  version: 0.9.0
-digest: sha256:a4d77b4baea7aee359a160157aa2a0187285827a03fde1b6da4168ae61f70989
-generated: "2022-03-15T16:01:23.39701+01:00"
+  version: 0.10.0
+digest: sha256:81087781c9d1d118efc31743f7d7b4cbeb790dbb1d0d3a2a8144ae0e427af4c8
+generated: "2022-03-17T16:32:44.730673+01:00"

--- a/library/CHART-TEMPLATE/Chart.yaml
+++ b/library/CHART-TEMPLATE/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.0
+version: 0.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,7 +25,7 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: common-library
-    version: 0.9.0
+    version: 0.10.0
     repository: file://../common-library
 
 keywords:

--- a/library/CHART-TEMPLATE/templates/deployment.yaml
+++ b/library/CHART-TEMPLATE/templates/deployment.yaml
@@ -29,6 +29,10 @@ spec:
       {{- with include "common.priorityClassName" . }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with include "common.dnsConfig" . }}
+      dnsConfig:
+        {{- . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/library/CHART-TEMPLATE/tests/common_library_dnsconfig_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_dnsconfig_test.yaml
@@ -1,0 +1,47 @@
+suite: test dnsconfig helpers
+templates:
+  - templates/deployment.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+tests:
+  - it: does not set dnsConfig if not specified
+    set:
+      global: null
+      dnsConfig: null
+    asserts:
+      - isNull:
+          path: spec.template.spec.dnsConfig
+  - it: does set dnsConfig if specified in values
+    set:
+      global: null
+      dnsConfig:
+        key: value
+    asserts:
+      - equal:
+          path: spec.template.spec.dnsConfig
+          value:
+            key: value
+  - it: does set dnsConfig if specified in global
+    set:
+      global:
+        dnsConfig:
+          key: value
+      dnsConfig: null
+    asserts:
+      - equal:
+          path: spec.template.spec.dnsConfig
+          value:
+            key: value
+  - it: overwrites dnsConfig from globals when specified in values
+    set:
+      global:
+        dnsConfig:
+          keyOnGlobal: foo
+      dnsConfig:
+        keyOnValues: bar
+    asserts:
+      - equal:
+          path: spec.template.spec.dnsConfig
+          value:
+            keyOnValues: bar

--- a/library/common-library/Chart.yaml
+++ b/library/common-library/Chart.yaml
@@ -3,7 +3,7 @@ name: common-library
 description: Provides helpers to provide consistency on all the charts
 
 type: library
-version: 0.9.0
+version: 0.10.0
 
 keywords:
   - newrelic

--- a/library/common-library/templates/_dnsconfig.tpl
+++ b/library/common-library/templates/_dnsconfig.tpl
@@ -1,0 +1,10 @@
+{{- /* Defines the Pod dnsConfig */ -}}
+{{- define "common.dnsConfig" -}}
+    {{- if .Values.dnsConfig -}}
+        {{- toYaml .Values.dnsConfig -}}
+    {{- else if .Values.global -}}
+        {{- if .Values.global.dnsConfig -}}
+            {{- toYaml .Values.global.dnsConfig -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
We still have to adapt all the helm charts to use this but this allows us to change `dnsConfig` through all our helm charts.

#### Which issue this PR fixes
  - Fixes #589 

#### Special notes for your reviewer:

#### Checklist
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
