### PR TITLE
common-library: implement privileged helper

### DIFF
--- a/library/CHART-TEMPLATE/Chart.lock
+++ b/library/CHART-TEMPLATE/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: file://../common-library
-  version: 0.13.0
-digest: sha256:72d99579229ac24def379920f9b06b9061d8e80c0f414e47d7027fbbde1ab5ff
-generated: "2022-03-18T14:35:13.200840177+01:00"
+  version: 0.14.0
+digest: sha256:e1acdf66476a15018db7790cdb1425416e4fbf6eb926f6a5be6e15b786d7afba
+generated: "2022-03-18T16:53:58.631152315+01:00"

--- a/library/CHART-TEMPLATE/Chart.yaml
+++ b/library/CHART-TEMPLATE/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.0
+version: 0.14.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,7 +25,7 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: common-library
-    version: 0.13.0
+    version: 0.14.0
     repository: file://../common-library
 
 keywords:

--- a/library/CHART-TEMPLATE/templates/example-cm-privileged.yaml
+++ b/library/CHART-TEMPLATE/templates/example-cm-privileged.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "common.naming.fullname" . }}-privileged-examples
+  namespace: {{ .Release.Namespace }}
+data:
+  {{- /* Be careful because this returns an empty string when false because "false" is evaluated as true in Helm
+         Take a look to the tests suite "common_library_privileged_test.yaml" to see who this behaves */}}
+  privileged-with-if: {{ if include "common.privileged" . }}enabled{{ else }}disabled{{ end }}
+  privileged-with-quote: {{ include "common.privileged" . | quote }}
+  privileged-with-default: {{ include "common.privileged" . | default "false" | quote }}

--- a/library/CHART-TEMPLATE/tests/common_library_privileged_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_privileged_test.yaml
@@ -1,0 +1,97 @@
+suite: test privileged helper
+templates:
+  - templates/example-cm-privileged.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+set:
+  licenseKey: test-license-key
+  cluster: test-cluster
+tests:
+  - it: Is false by default
+    asserts:
+      - equal:
+          path: data.privileged-with-if
+          value: "disabled"
+      - equal:
+          path: data.privileged-with-quote
+          value: ""
+      - equal:
+          path: data.privileged-with-default
+          value: "false"
+
+  - it: Is false with everything null
+    set:
+      global: null
+      privileged: null
+    asserts:
+      - equal:
+          path: data.privileged-with-if
+          value: "disabled"
+      - equal:
+          path: data.privileged-with-quote
+          value: ""
+      - equal:
+          path: data.privileged-with-default
+          value: "false"
+
+  - it: Enable low data mode (globally)
+    set:
+      global:
+        privileged: true
+    asserts:
+      - equal:
+          path: data.privileged-with-if
+          value: "enabled"
+      - equal:
+          path: data.privileged-with-quote
+          value: "true"
+      - equal:
+          path: data.privileged-with-default
+          value: "true"
+
+  - it: Enable low data mode (locally)
+    set:
+      privileged: true
+    asserts:
+      - equal:
+          path: data.privileged-with-if
+          value: "enabled"
+      - equal:
+          path: data.privileged-with-quote
+          value: "true"
+      - equal:
+          path: data.privileged-with-default
+          value: "true"
+
+  - it: Overrides to false the global state locally
+    set:
+      global:
+        privileged: true
+      privileged: false
+    asserts:
+      - equal:
+          path: data.privileged-with-if
+          value: "disabled"
+      - equal:
+          path: data.privileged-with-quote
+          value: ""
+      - equal:
+          path: data.privileged-with-default
+          value: "false"
+
+  - it: Overrides to true the global state locally
+    set:
+      global:
+        privileged: false
+      privileged: true
+    asserts:
+      - equal:
+          path: data.privileged-with-if
+          value: "enabled"
+      - equal:
+          path: data.privileged-with-quote
+          value: "true"
+      - equal:
+          path: data.privileged-with-default
+          value: "true"

--- a/library/common-library/Chart.yaml
+++ b/library/common-library/Chart.yaml
@@ -3,7 +3,7 @@ name: common-library
 description: Provides helpers to provide consistency on all the charts
 
 type: library
-version: 0.13.0
+version: 0.14.0
 
 keywords:
   - newrelic

--- a/library/common-library/templates/_privileged.tpl
+++ b/library/common-library/templates/_privileged.tpl
@@ -18,17 +18,18 @@ And then use the helpers this library provides to render those.
 {{- $global := index .Values "global" | default dict -}}
 {{- /* `get` will return "" (empty string) if value is not found, and the value otherwise, so we can type-assert with kindIs */ -}}
 {{- if get .Values "privileged" | kindIs "bool" -}}
-    {{- with .Values.privileged -}}
-        {{- . -}}
+    {{- if .Values.privileged -}}
+        {{- .Values.privileged -}}
     {{- end -}}
 {{- else if get $global "privileged" | kindIs "bool" -}}
-    {{- with $global.privileged -}}
-        {{- . -}}
+    {{- if $global.privileged -}}
+        {{- $global.privileged -}}
     {{- end -}}
 {{- else -}}
     {{- include "common.privileged.defaultOverride" . -}}
 {{- end -}}
 {{- end -}}
+
 
 {{- /*
 This allows to change the default user setting for `privileged`, by default it returns a falsy value ("").

--- a/library/common-library/templates/_privileged.tpl
+++ b/library/common-library/templates/_privileged.tpl
@@ -1,0 +1,37 @@
+{{- /*
+This file contains helpers to handle whether the chart should assume it is fine to deploy itself with elevated
+privileges, thus changing the defaults for hostNetwork, securityContexts, etc.
+Please note that either local or global definitions of the aforementioned settings will override the privileged flag.
+*/ -}}
+
+{{- /*
+common.privileged is a helper that returns whether the chart should assume the user is fine deploying privileged pods.
+Chart writers should _not_ use this to populate securityContext.privileged directly, but rather to tweak their implementation of:
+- common.securityContext.containerDefaults
+- common.securityContext.podDefaults
+- common.hostNetwork.defaultOverride
+And then use the helpers this library provides to render those.
+*/ -}}
+{{- /* Chart writers should not rely on this helper directly. */ -}}
+{{- define "common.privileged" -}}
+{{- /* This allows us to use `$global` as an empty dict directly in case `Values.global` does not exists. */ -}}
+{{- $global := index .Values "global" | default dict -}}
+{{- /* `get` will return "" (empty string) if value is not found, and the value otherwise, so we can type-assert with kindIs */ -}}
+{{- if get .Values "privileged" | kindIs "bool" -}}
+    {{- with .Values.privileged -}}
+        {{- . -}}
+    {{- end -}}
+{{- else if get $global "privileged" | kindIs "bool" -}}
+    {{- with $global.privileged -}}
+        {{- . -}}
+    {{- end -}}
+{{- else -}}
+    {{- include "common.privileged.defaultOverride" . -}}
+{{- end -}}
+{{- end -}}
+
+{{- /*
+This allows to change the default user setting for `privileged`, by default it returns a falsy value ("").
+*/ -}}
+{{- define "common.privileged.defaultOverride" -}}
+{{- end -}}


### PR DESCRIPTION
This PR implements the `common.privileged` helper.

As stated in the comments, all the logic of handling how this flag impacts settings such as `hostNetwork` or the pod and container `securityContext`s is deliberately left out from the common library, and instead Chart writers are expected to use `common.privileged` to define their default overrides for the mentioned settings.

I have two reasons to believe this is a better option than trying to implement this in the library:
1. We only have one chart (two, if you count logging, but its special so refer to point 2) that uses the privileged mode. I believe we should only implement common things in the common library and logic used by one chart is not common.
2. Charts that require the privileged flag require it because they do weird things. It is likely that different charts that use `common.privileged` understand the meaning of "privileged" in different ways, and therefore will require specific behavior to handle it. For this reason, I believe it's just simpler to offload this to the chart rather to try to find some common-yet-flexible approach.