### PR TITLE
[common-library] Fix hostNetwork default behavior

### DIFF
--- a/library/CHART-TEMPLATE/Chart.lock
+++ b/library/CHART-TEMPLATE/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: file://../common-library
-  version: 0.14.2
-digest: sha256:5656d2f5615c1c93a1b5d7bf3250b7e7854beb7819eda733b1d845b8362bb268
-generated: "2022-03-22T10:19:43.064708+01:00"
+  version: 0.14.3
+digest: sha256:210e9bbaf1962a5ef9f5ddc6ddd1910b706a057f3d80649c7b5d61d5a1a5f06f
+generated: "2022-03-22T16:02:11.09227+01:00"

--- a/library/CHART-TEMPLATE/Chart.yaml
+++ b/library/CHART-TEMPLATE/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.2
+version: 0.14.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,7 +25,7 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: common-library
-    version: 0.14.2
+    version: 0.14.3
     repository: file://../common-library
 
 keywords:

--- a/library/CHART-TEMPLATE/templates/deployment.yaml
+++ b/library/CHART-TEMPLATE/templates/deployment.yaml
@@ -23,10 +23,6 @@ spec:
       imagePullSecrets:
         {{- . | nindent 8 }}
       {{- end }}
-      {{- with include "common.hostNetwork" . }}
-      hostNetwork: {{ . }}
-      {{- end }}
-      serviceAccountName: {{ include "common.serviceAccount.name" . }}
       {{- with include "common.securityContext.pod" . }}
       securityContext:
         {{- . | nindent 8 }}
@@ -38,6 +34,10 @@ spec:
       dnsConfig:
         {{- . | nindent 8 }}
       {{- end }}
+
+      hostNetwork: {{ include "common.hostNetwork.boolean" . }}
+      serviceAccountName: {{ include "common.serviceAccount.name" . }}
+
       containers:
         - name: {{ .Chart.Name }}
           {{- with include "common.securityContext.container" . }}

--- a/library/CHART-TEMPLATE/templates/deployment.yaml
+++ b/library/CHART-TEMPLATE/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
 
-      hostNetwork: {{ include "common.hostNetwork.boolean" . }}
+      hostNetwork: {{ include "common.hostNetwork.value" . }}
       serviceAccountName: {{ include "common.serviceAccount.name" . }}
 
       containers:

--- a/library/CHART-TEMPLATE/templates/example-cm-hostnetwork.yaml
+++ b/library/CHART-TEMPLATE/templates/example-cm-hostnetwork.yaml
@@ -9,4 +9,4 @@ data:
   hostNetwork-with-if: {{ if include "common.hostNetwork" . }}enabled{{ else }}disabled{{ end }}
   hostNetwork-with-quote: {{ include "common.hostNetwork" . | quote }}
   hostNetwork-with-default: {{ include "common.hostNetwork" . | default "false" | quote }}
-  hostNetwork-boolean: {{ include "common.hostNetwork.boolean" . | quote }}
+  hostNetwork-boolean: {{ include "common.hostNetwork.value" . | quote }}

--- a/library/CHART-TEMPLATE/templates/example-cm-hostnetwork.yaml
+++ b/library/CHART-TEMPLATE/templates/example-cm-hostnetwork.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "common.naming.fullname" . }}-hostnetwork-examples
+  namespace: {{ .Release.Namespace }}
+data:
+  {{- /* Be careful because this returns an empty string when false because "false" is evaluated as true in Helm
+         Take a look to the tests suite "common_library_hostnetwork_deployment_test.yaml" to see who this behaves */}}
+  hostNetwork-with-if: {{ if include "common.hostNetwork" . }}enabled{{ else }}disabled{{ end }}
+  hostNetwork-with-quote: {{ include "common.hostNetwork" . | quote }}
+  hostNetwork-with-default: {{ include "common.hostNetwork" . | default "false" | quote }}
+  hostNetwork-boolean: {{ include "common.hostNetwork.boolean" . | quote }}

--- a/library/CHART-TEMPLATE/tests/common_library_hostnetwork_cm_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_hostnetwork_cm_test.yaml
@@ -1,0 +1,115 @@
+suite: test hostNetwork helper in the configMap example
+templates:
+  - templates/example-cm-hostnetwork.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+set:
+  licenseKey: test-license-key
+  cluster: test-cluster
+tests:
+  - it: Is false by default
+    asserts:
+      - equal:
+          path: data.hostNetwork-with-if
+          value: "disabled"
+      - equal:
+          path: data.hostNetwork-with-quote
+          value: ""
+      - equal:
+          path: data.hostNetwork-with-default
+          value: "false"
+      - equal:
+          path: data.hostNetwork-boolean
+          value: "false"
+
+  - it: Is false with everything null
+    set:
+      global: null
+      hostNetwork: null
+    asserts:
+      - equal:
+          path: data.hostNetwork-with-if
+          value: "disabled"
+      - equal:
+          path: data.hostNetwork-with-quote
+          value: ""
+      - equal:
+          path: data.hostNetwork-with-default
+          value: "false"
+      - equal:
+          path: data.hostNetwork-boolean
+          value: "false"
+
+  - it: Enable low data mode (globally)
+    set:
+      global:
+        hostNetwork: true
+    asserts:
+      - equal:
+          path: data.hostNetwork-with-if
+          value: "enabled"
+      - equal:
+          path: data.hostNetwork-with-quote
+          value: "true"
+      - equal:
+          path: data.hostNetwork-with-default
+          value: "true"
+      - equal:
+          path: data.hostNetwork-boolean
+          value: "true"
+
+  - it: Enable low data mode (locally)
+    set:
+      hostNetwork: true
+    asserts:
+      - equal:
+          path: data.hostNetwork-with-if
+          value: "enabled"
+      - equal:
+          path: data.hostNetwork-with-quote
+          value: "true"
+      - equal:
+          path: data.hostNetwork-with-default
+          value: "true"
+      - equal:
+          path: data.hostNetwork-boolean
+          value: "true"
+
+  - it: Overrides to false the global state locally
+    set:
+      global:
+        hostNetwork: true
+      hostNetwork: false
+    asserts:
+      - equal:
+          path: data.hostNetwork-with-if
+          value: "disabled"
+      - equal:
+          path: data.hostNetwork-with-quote
+          value: ""
+      - equal:
+          path: data.hostNetwork-with-default
+          value: "false"
+      - equal:
+          path: data.hostNetwork-boolean
+          value: "false"
+
+  - it: Overrides to true the global state locally
+    set:
+      global:
+        hostNetwork: false
+      hostNetwork: true
+    asserts:
+      - equal:
+          path: data.hostNetwork-with-if
+          value: "enabled"
+      - equal:
+          path: data.hostNetwork-with-quote
+          value: "true"
+      - equal:
+          path: data.hostNetwork-with-default
+          value: "true"
+      - equal:
+          path: data.hostNetwork-boolean
+          value: "true"

--- a/library/CHART-TEMPLATE/tests/common_library_hostnetwork_deployment_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_hostnetwork_deployment_test.yaml
@@ -1,4 +1,4 @@
-suite: test hostNetwork helper
+suite: test hostNetwork helper in the deployment template
 templates:
   - templates/deployment.yaml
 release:

--- a/library/common-library/Chart.yaml
+++ b/library/common-library/Chart.yaml
@@ -3,7 +3,7 @@ name: common-library
 description: Provides helpers to provide consistency on all the charts
 
 type: library
-version: 0.14.2
+version: 0.14.3
 
 keywords:
   - newrelic

--- a/library/common-library/templates/_hostnetwork.tpl
+++ b/library/common-library/templates/_hostnetwork.tpl
@@ -7,11 +7,21 @@ Returns "true" if `hostNetwork` is enabled, otherwise fallbacks to a overridable
 {{- /* This allows us to use `$global` as an empty dict directly in case `Values.global` does not exists */ -}}
 {{- $global := index .Values "global" | default dict -}}
 
-{{- /* `get` will return "" (empty string) if value is not found, and the value otherwise, so we can type-assert with kindIs */ -}}
+{{- /*
+`get` will return "" (empty string) if value is not found, and the value otherwise, so we can type-assert with kindIs
+
+We also want only to return when this is true, returning `false` here will template "false" (string) when doing
+an `(include "common.hostNetwork" .)`, which is not an "empty string" so it is `true` if it is used
+as an evaluation somewhere else.
+*/ -}}
 {{- if get .Values "hostNetwork" | kindIs "bool" -}}
-    {{- .Values.hostNetwork -}}
+    {{- if .Values.hostNetwork -}}
+        {{- .Values.hostNetwork -}}
+    {{- end -}}
 {{- else if get $global "hostNetwork" | kindIs "bool" -}}
-    {{- $global.hostNetwork -}}
+    {{- if $global.hostNetwork -}}
+        {{- $global.hostNetwork -}}
+    {{- end -}}
 {{- else -}}
     {{- include "common.hostNetwork.defaultOverride" . -}}
 {{- end -}}
@@ -19,8 +29,20 @@ Returns "true" if `hostNetwork` is enabled, otherwise fallbacks to a overridable
 
 
 {{- /*
+Abstraction of the hostNetwork toggle.
+This helper allows to override the global `.global.hostNetwork` with the value of `.hostNetwork`.
+Returns "true" if `hostNetwork` is enabled, otherwise fallbacks to a overridable function
+*/ -}}
+{{- define "common.hostNetwork.boolean" -}}
+{{- if include "common.hostNetwork" . -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{- /*
 This allows to change the default of the helper `common.hostNetwork`. Defaults to false
 */ -}}
 {{- define "common.hostNetwork.defaultOverride" -}}
-false
 {{- end -}}

--- a/library/common-library/templates/_hostnetwork.tpl
+++ b/library/common-library/templates/_hostnetwork.tpl
@@ -33,7 +33,7 @@ Abstraction of the hostNetwork toggle.
 This helper allows to override the global `.global.hostNetwork` with the value of `.hostNetwork`.
 Returns "true" if `hostNetwork` is enabled, otherwise fallbacks to a overridable function
 */ -}}
-{{- define "common.hostNetwork.boolean" -}}
+{{- define "common.hostNetwork.value" -}}
 {{- if include "common.hostNetwork" . -}}
 true
 {{- else -}}

--- a/library/common-library/templates/_hostnetwork.tpl
+++ b/library/common-library/templates/_hostnetwork.tpl
@@ -30,8 +30,7 @@ as an evaluation somewhere else.
 
 {{- /*
 Abstraction of the hostNetwork toggle.
-This helper allows to override the global `.global.hostNetwork` with the value of `.hostNetwork`.
-Returns "true" if `hostNetwork` is enabled, otherwise fallbacks to a overridable function
+This helper abstracts the function "common.hostNetwork" to return true or false directly.
 */ -}}
 {{- define "common.hostNetwork.value" -}}
 {{- if include "common.hostNetwork" . -}}


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:
`hostNetwork` was not correctly developed and printed `false` when being called. A new test, template and function have been added to solve this issue.

#### Checklist
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
