### PR TITLE
[common-library] Fix template naming

### DIFF
--- a/library/CHART-TEMPLATE/Chart.lock
+++ b/library/CHART-TEMPLATE/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: file://../common-library
   version: 0.14.2
 digest: sha256:5656d2f5615c1c93a1b5d7bf3250b7e7854beb7819eda733b1d845b8362bb268
-generated: "2022-03-22T09:36:18.380063+01:00"
+generated: "2022-03-22T10:19:43.064708+01:00"

--- a/library/CHART-TEMPLATE/Chart.lock
+++ b/library/CHART-TEMPLATE/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: file://../common-library
-  version: 0.14.1
-digest: sha256:965d175aadf4f8a9a364c71e5c68c4915569d0a6e4720a3c37888a317f830c2a
-generated: "2022-03-21T11:42:15.234049+01:00"
+  version: 0.14.2
+digest: sha256:5656d2f5615c1c93a1b5d7bf3250b7e7854beb7819eda733b1d845b8362bb268
+generated: "2022-03-22T09:36:18.380063+01:00"

--- a/library/CHART-TEMPLATE/Chart.yaml
+++ b/library/CHART-TEMPLATE/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.1
+version: 0.14.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,7 +25,7 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: common-library
-    version: 0.14.1
+    version: 0.14.2
     repository: file://../common-library
 
 keywords:

--- a/library/common-library/Chart.yaml
+++ b/library/common-library/Chart.yaml
@@ -3,7 +3,7 @@ name: common-library
 description: Provides helpers to provide consistency on all the charts
 
 type: library
-version: 0.14.1
+version: 0.14.2
 
 keywords:
   - newrelic

--- a/library/common-library/templates/_naming.tpl
+++ b/library/common-library/templates/_naming.tpl
@@ -26,7 +26,7 @@ If release name contains chart name it will be used as a full name.
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
 
-{{- $name := default (include "common.naming.chartnameOverride" .) .Values.nameOverride }}
+{{- $name := .Values.nameOverride | default (include "common.naming.chartnameOverride" .) }}
 
 {{- if contains (lower $name) (lower .Release.Name) }}
 {{- $name = $name | trunc 63 | trimSuffix "-" }}

--- a/library/common-library/templates/_naming.tpl
+++ b/library/common-library/templates/_naming.tpl
@@ -26,7 +26,7 @@ If release name contains chart name it will be used as a full name.
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
 
-{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- $name := default (include "common.naming.chartnameOverride" .) .Values.nameOverride }}
 
 {{- if contains (lower $name) (lower .Release.Name) }}
 {{- $name = $name | trunc 63 | trimSuffix "-" }}
@@ -48,6 +48,8 @@ If release name contains chart name it will be used as a full name.
 
 {{/*
 Create chart name and version as used by the chart label.
+Here we do not use (include "common.naming.chartnameOverride" .) because is only used for the labels.
+This function should not be used for naming objects. Use "common.naming.{name,fullname}" instead.
 */}}
 {{- define "common.naming.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

The function that overrides the chart name was implemented but not used in `common.naming.fullname` function. 

#### Checklist
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
