### PR TITLE
[common-library] Fail when no cluster name is given by the user

### DIFF
--- a/library/CHART-TEMPLATE/Chart.lock
+++ b/library/CHART-TEMPLATE/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: file://../common-library
-  version: 0.15.0
-digest: sha256:1ddaf0929329af338a0716042131c70ade47939f7d1e472f9730c9723756610a
-generated: "2022-03-23T15:06:58.602329+01:00"
+  version: 0.15.1
+digest: sha256:1e8423fe07f82a37502affc6e512f00e3c2a115901ff2135ab50a5b8d21616c7
+generated: "2022-03-30T12:56:28.866008+02:00"

--- a/library/CHART-TEMPLATE/Chart.yaml
+++ b/library/CHART-TEMPLATE/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.0
+version: 0.15.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,7 +25,7 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: common-library
-    version: 0.15.0
+    version: 0.15.1
     repository: file://../common-library
 
 keywords:

--- a/library/CHART-TEMPLATE/tests/common_cluster_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_cluster_test.yaml
@@ -11,14 +11,34 @@ release:
 #constantly to overwrite it.
 
 tests:
-  - it: helper works (and fails) when global is null and no local cluster value
+  - it: helper works when global is null
     set:
       global: null
+      cluster: test-cluster
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: test-cluster
+
+  - it: helper works when local is null
+    set:
+      global:
+        cluster: test-cluster
       cluster: null
     asserts:
       - equal:
           path: spec.template.spec.containers[0].env[0].value
-          value: null
+          value: test-cluster
+
+#I found no way of asserting failing configurations. This test fails with:
+# Error: execution error at (CHART-TEMPLATE/templates/deployment.yaml:71:24): There is not cluster name definition set neither in `.global.cluster' nor `.cluster' in your values.yaml. Cluster name is required.
+#  - it: helper works (and fails) when cluster is null everywhere
+#    set:
+#      global: null
+#      cluster: test
+#    asserts:
+#      - hasDocuments:
+#          count: 0
 
   - it: sets local cluster as cluster name even if global is set
     set:

--- a/library/CHART-TEMPLATE/tests/common_cluster_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_cluster_test.yaml
@@ -4,20 +4,22 @@ templates:
 release:
   name: my-release
   namespace: my-namespace
-set:
+
+# The name of the cluster is mandatory, to not make all the tests fail because they have no license
+# and not having to add license to all the tests I have added it to the `values.yaml`.
+# This change makes this tests a bit funky because we have to manually set local cluster to null
+#constantly to overwrite it.
+
 tests:
-  - it: sets null as cluster name if not specified
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[0].env[0].value
-          value: null
-  - it: works when global is null and no local cluster value
+  - it: helper works (and fails) when global is null and no local cluster value
     set:
       global: null
+      cluster: null
     asserts:
       - equal:
           path: spec.template.spec.containers[0].env[0].value
           value: null
+
   - it: sets local cluster as cluster name even if global is set
     set:
       cluster: test-cluster
@@ -27,10 +29,12 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[0].value
           value: test-cluster
+
   - it: sets global cluster as name if only global is set
     set:
       global:
         cluster: global-cluster
+      cluster: null
     asserts:
       - equal:
           path: spec.template.spec.containers[0].env[0].value

--- a/library/CHART-TEMPLATE/tests/common_cluster_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_cluster_test.yaml
@@ -8,7 +8,7 @@ release:
 # The name of the cluster is mandatory, to not make all the tests fail because they have no license
 # and not having to add license to all the tests I have added it to the `values.yaml`.
 # This change makes this tests a bit funky because we have to manually set local cluster to null
-#constantly to overwrite it.
+# constantly to overwrite it.
 
 tests:
   - it: helper works when global is null
@@ -40,20 +40,10 @@ tests:
 
   - it: sets local cluster as cluster name even if global is set
     set:
-      cluster: test-cluster
       global:
         cluster: global-cluster
+      cluster: test-cluster
     asserts:
       - equal:
           path: spec.template.spec.containers[0].env[0].value
           value: test-cluster
-
-  - it: sets global cluster as name if only global is set
-    set:
-      global:
-        cluster: global-cluster
-      cluster: null
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[0].env[0].value
-          value: global-cluster

--- a/library/CHART-TEMPLATE/tests/common_cluster_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_cluster_test.yaml
@@ -30,15 +30,13 @@ tests:
           path: spec.template.spec.containers[0].env[0].value
           value: test-cluster
 
-#I found no way of asserting failing configurations. This test fails with:
-# Error: execution error at (CHART-TEMPLATE/templates/deployment.yaml:71:24): There is not cluster name definition set neither in `.global.cluster' nor `.cluster' in your values.yaml. Cluster name is required.
-#  - it: helper works (and fails) when cluster is null everywhere
-#    set:
-#      global: null
-#      cluster: test
-#    asserts:
-#      - hasDocuments:
-#          count: 0
+  - it: helper works (and fails) when cluster is null everywhere
+    set:
+      global: null
+      cluster: null
+    asserts:
+      - failedTemplate:
+          errorMessage: "There is not cluster name definition set neither in `.global.cluster' nor `.cluster' in your values.yaml. Cluster name is required."
 
   - it: sets local cluster as cluster name even if global is set
     set:

--- a/library/CHART-TEMPLATE/tests/common_images_security_context_container_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_images_security_context_container_test.yaml
@@ -4,7 +4,6 @@ templates:
 release:
   name: my-release
   namespace: my-namespace
-set:
 tests:
   - it: does not set securityContext if not specified
     set:

--- a/library/CHART-TEMPLATE/tests/common_images_security_context_pod_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_images_security_context_pod_test.yaml
@@ -4,7 +4,6 @@ templates:
 release:
   name: my-release
   namespace: my-namespace
-set:
 tests:
   - it: does not set podSecurityContext if not specified
     set:

--- a/library/CHART-TEMPLATE/tests/common_library_fedramp_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_fedramp_test.yaml
@@ -4,9 +4,6 @@ templates:
 release:
   name: my-release
   namespace: my-namespace
-set:
-  licenseKey: test-license-key
-  cluster: test-cluster
 tests:
   - it: does not set fedRAMP if not specified
     set:

--- a/library/CHART-TEMPLATE/tests/common_library_hostnetwork_deployment_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_hostnetwork_deployment_test.yaml
@@ -4,9 +4,6 @@ templates:
 release:
   name: my-release
   namespace: my-namespace
-set:
-  licenseKey: test-license-key
-  cluster: test-cluster
 tests:
   - it: Is false by default
     asserts:

--- a/library/CHART-TEMPLATE/tests/common_library_lowdatamode_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_lowdatamode_test.yaml
@@ -4,9 +4,6 @@ templates:
 release:
   name: my-release
   namespace: my-namespace
-set:
-  licenseKey: test-license-key
-  cluster: test-cluster
 tests:
   - it: Is false by default
     asserts:

--- a/library/CHART-TEMPLATE/tests/common_library_privileged_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_privileged_test.yaml
@@ -4,9 +4,6 @@ templates:
 release:
   name: my-release
   namespace: my-namespace
-set:
-  licenseKey: test-license-key
-  cluster: test-cluster
 tests:
   - it: Is false by default
     asserts:

--- a/library/CHART-TEMPLATE/tests/common_library_proxy_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_proxy_test.yaml
@@ -4,9 +4,6 @@ templates:
 release:
   name: my-release
   namespace: my-namespace
-set:
-  licenseKey: test-license-key
-  cluster: test-cluster
 tests:
   - it: does not set proxy if not specified
     set:

--- a/library/CHART-TEMPLATE/tests/common_library_serviceaccount_annotations_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_serviceaccount_annotations_test.yaml
@@ -4,7 +4,6 @@ templates:
 release:
   name: my-release
   namespace: my-namespace
-
 tests:
   - it: default values has no annotations
     set:

--- a/library/CHART-TEMPLATE/tests/common_library_staging_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_staging_test.yaml
@@ -4,9 +4,6 @@ templates:
 release:
   name: my-release
   namespace: my-namespace
-set:
-  licenseKey: test-license-key
-  cluster: test-cluster
 tests:
   - it: Is false by default
     asserts:

--- a/library/CHART-TEMPLATE/values.yaml
+++ b/library/CHART-TEMPLATE/values.yaml
@@ -18,6 +18,7 @@ global:
   affinity: {}
 
 licenseKey: foobar
+cluster: barfoo
 
 replicaCount: 1
 

--- a/library/common-library/Chart.yaml
+++ b/library/common-library/Chart.yaml
@@ -3,7 +3,7 @@ name: common-library
 description: Provides helpers to provide consistency on all the charts
 
 type: library
-version: 0.15.0
+version: 0.15.1
 
 keywords:
   - newrelic

--- a/library/common-library/templates/_cluster.tpl
+++ b/library/common-library/templates/_cluster.tpl
@@ -2,12 +2,15 @@
 Return the cluster
 */}}
 {{- define "common.cluster" -}}
-    {{- if .Values.cluster -}}
-        {{- .Values.cluster -}}
-    {{- else if .Values.global -}}
-        {{- if .Values.global.cluster -}}
-            {{- .Values.global.cluster -}}
-        {{- end -}}
-    {{- end -}}
+{{- /* This allows us to use `$global` as an empty dict directly in case `Values.global` does not exists */ -}}
+{{- $global := index .Values "global" | default dict -}}
+
+{{- if .Values.cluster -}}
+    {{- .Values.cluster -}}
+{{- else if $global.cluster -}}
+    {{- $global.cluster -}}
+{{- else -}}
+    {{ fail "There is not cluster name definition set neither in `.global.cluster' nor `.cluster' in your values.yaml. Cluster name is required." }}
+{{- end -}}
 {{- end -}}
 

--- a/library/common-library/templates/_cluster.tpl
+++ b/library/common-library/templates/_cluster.tpl
@@ -9,8 +9,16 @@ Return the cluster
     {{- .Values.cluster -}}
 {{- else if $global.cluster -}}
     {{- $global.cluster -}}
-{{- else -}}
+{{- else if (include "common.cluster.failIfEmpty" . ) -}}
     {{ fail "There is not cluster name definition set neither in `.global.cluster' nor `.cluster' in your values.yaml. Cluster name is required." }}
 {{- end -}}
 {{- end -}}
 
+
+
+{{/*
+Return the default behaviour if "common.cluster" helper does not find one in the values
+*/}}
+{{- define "common.cluster.failIfEmpty" -}}
+true
+{{- end -}}


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

`cluster` helper gets cluster correctly but does not fail when it is not defined. Charts using this library should rely on helpers who will always give the value they need. 

#### Special notes for your reviewer:

If you feel a bit overwhelmed by the number of changes go commit by commit as I also sanitized the tests in this PR removing useless things that they were not working.

#### Checklist
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
