### PR TITLE
[common-library] Removes chartnameOverride and simplify full naming logic

### DIFF
--- a/library/CHART-TEMPLATE/Chart.lock
+++ b/library/CHART-TEMPLATE/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: file://../common-library
-  version: 0.17.2
-digest: sha256:55cf8624b98bfc103dac7bc84e157a08c51f2b6f929dd20b6bee8f90bce57ee6
-generated: "2022-04-08T14:41:23.170492+02:00"
+  version: 0.18.0
+digest: sha256:2cb84755001ad511a79e810e407d050f8bdd96082390eb4f791f45cd48420775
+generated: "2022-04-12T09:37:53.067581+02:00"

--- a/library/CHART-TEMPLATE/Chart.yaml
+++ b/library/CHART-TEMPLATE/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.17.2
+version: 0.18.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,7 +25,7 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: common-library
-    version: 0.17.2
+    version: 0.18.0
     repository: file://../common-library
 
 keywords:

--- a/library/CHART-TEMPLATE/tests/common_library_license_helpers_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_license_helpers_test.yaml
@@ -11,7 +11,7 @@ tests:
     asserts:
       - equal:
           path: data.licensekey-secret-name
-          value: nri-my-release-CHART-TEMPLATE-license
+          value: my-release-CHART-TEMPLATE-license
       - equal:
           path: data.licensekey-secret-key-name
           value: licenseKey
@@ -22,7 +22,7 @@ tests:
     asserts:
       - equal:
           path: data.licensekey-secret-name
-          value: nri-my-release-CHART-TEMPLATE-license
+          value: my-release-CHART-TEMPLATE-license
       - equal:
           path: data.licensekey-secret-key-name
           value: licenseKey

--- a/library/CHART-TEMPLATE/tests/common_library_naming_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_naming_test.yaml
@@ -4,51 +4,42 @@ templates:
   - templates/sidecar-deployment.yaml
   - templates/service.yaml
 release:
-  name: my-release
-  namespace: my-namespace
+  name: release
 tests:
-  - it: default values has its name correctly defined
+  - it: uses <release_name>-<chart_name> by default
     asserts:
       - equal:
           path: metadata.name
-          value: nri-my-release-CHART-TEMPLATE
+          value: release-CHART-TEMPLATE
 
-  - it: name of the release is not duplicated
-    release:
-      name: chart-template  # Must be lowercase
-    asserts:
-      - equal:
-          path: metadata.name
-          value: nri-CHART-TEMPLATE
-
-  - it: name of the release is overridable
+  - it: uses nameOverride as <chart_name>
     set:
-      nameOverride: test
+      nameOverride: custom_chart_name
     asserts:
       - equal:
           path: metadata.name
-          value: nri-my-release-test
+          value: release-custom_chart_name
 
-  - it: name of the release is overridable with the release name
+  - it: uses nameOverride as <chart_name>
     set:
-      nameOverride: my-release
+      nameOverride: custom_chart_name
     asserts:
       - equal:
           path: metadata.name
-          value: nri-my-release
+          value: release-custom_chart_name
 
-  - it: nri- preffix does not duplicate
-    release:
-      name: nri-bundle
-    asserts:
-      - equal:
-          path: metadata.name
-          value: nri-bundle-CHART-TEMPLATE
-
-  - it: full name override
+  - it: uses fullnameOverride
     set:
       fullnameOverride: fno
     asserts:
       - equal:
           path: metadata.name
           value: fno
+
+  - it: truncates the name
+    set:
+      fullnameOverride: this_name_has_more_than_63_characters_long_until_this_last_char_this_is_will_be_truncated
+    asserts:
+      - equal:
+          path: metadata.name
+          value: this_name_has_more_than_63_characters_long_until_this_last_char

--- a/library/CHART-TEMPLATE/tests/common_library_serviceaccount_create_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_serviceaccount_create_test.yaml
@@ -11,7 +11,7 @@ tests:
           count: 1
       - equal:
           path: metadata.name
-          value: nri-my-release-CHART-TEMPLATE
+          value: my-release-CHART-TEMPLATE
 
   - it: no global values template a service account
     set:
@@ -21,7 +21,7 @@ tests:
           count: 1
       - equal:
           path: metadata.name
-          value: nri-my-release-CHART-TEMPLATE
+          value: my-release-CHART-TEMPLATE
 
   - it: create (globally) a service account
     set:
@@ -33,7 +33,7 @@ tests:
           count: 1
       - equal:
           path: metadata.name
-          value: nri-my-release-CHART-TEMPLATE
+          value: my-release-CHART-TEMPLATE
 
   - it: create (locally) a service account
     set:
@@ -44,7 +44,7 @@ tests:
           count: 1
       - equal:
           path: metadata.name
-          value: nri-my-release-CHART-TEMPLATE
+          value: my-release-CHART-TEMPLATE
 
   - it: disable (globally) a service account
     set:
@@ -86,4 +86,4 @@ tests:
           count: 1
       - equal:
           path: metadata.name
-          value: nri-my-release-CHART-TEMPLATE
+          value: my-release-CHART-TEMPLATE

--- a/library/CHART-TEMPLATE/tests/common_library_serviceaccount_name_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_serviceaccount_name_test.yaml
@@ -23,7 +23,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.serviceAccountName
-          value: nri-my-release-CHART-TEMPLATE
+          value: my-release-CHART-TEMPLATE
 
   - it: creating (locally) a serviceAccount will change the serviceAccount used in the deployment
     set:
@@ -32,7 +32,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.serviceAccountName
-          value: nri-my-release-CHART-TEMPLATE
+          value: my-release-CHART-TEMPLATE
 
   - it: allow to override locally the creation of a global service account
     set:

--- a/library/common-library/Chart.yaml
+++ b/library/common-library/Chart.yaml
@@ -3,7 +3,7 @@ name: common-library
 description: Provides helpers to provide consistency on all the charts
 
 type: library
-version: 0.17.2
+version: 0.18.0
 
 keywords:
   - newrelic

--- a/library/common-library/templates/_naming.tpl
+++ b/library/common-library/templates/_naming.tpl
@@ -9,8 +9,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 {{/*
 Create a default fully qualified app name.
+By default the full name will be "<release_name>-<chart_chart>". This could change if fullnameOverride or
+nameOverride are set.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
 */}}
 {{- define "common.naming.fullname" -}}
 
@@ -20,18 +21,7 @@ If release name contains chart name it will be used as a full name.
     {{- $name = .Values.fullnameOverride  }}
 
 {{- else }}
-    {{- $name = (include "common.naming.name" .) }}
-
-    {{- if contains (lower $name) (lower .Release.Name) }}
-        {{- $name = $name }}
-    {{- else }} 
-        {{- $name = printf "%s-%s" .Release.Name $name }}
-    {{- end }}
-
-    {{- if not (hasPrefix "nri-" $name) }}
-        {{- /* In case the name is not prefixed with "nri-", add it */}}
-        {{- $name = printf "nri-%s" $name }}
-    {{- end }}
+    {{- $name = printf "%s-%s" .Release.Name (include "common.naming.name" .)}}
 
 {{- end }}
 

--- a/library/common-library/templates/_naming.tpl
+++ b/library/common-library/templates/_naming.tpl
@@ -1,20 +1,11 @@
 {{/*
-Allow the chart using this library to override naming function
-*/}}
-{{- define "common.naming.chartnameOverride" -}}
-{{- .Chart.Name }}
-{{- end }}
-
-
-
-{{/*
 Expand the name of the chart.
+Uses the Chart name by default if nameOverride is not set.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "common.naming.name" -}}
-{{- (include "common.naming.chartnameOverride" .) | default .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- .Values.nameOverride | default .Chart.Name | trunc 63 | trimSuffix "-" }}
 {{- end }}
-
-
 
 {{/*
 Create a default fully qualified app name.
@@ -22,33 +13,36 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "common.naming.fullname" -}}
+
+{{- $name := "" }}
+
 {{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+    {{- $name = .Values.fullnameOverride  }}
+
 {{- else }}
+    {{- $name = (include "common.naming.name" .) }}
 
-{{- $name := .Values.nameOverride | default (include "common.naming.chartnameOverride" .) }}
+    {{- if contains (lower $name) (lower .Release.Name) }}
+        {{- $name = $name }}
+    {{- else }} 
+        {{- $name = printf "%s-%s" .Release.Name $name }}
+    {{- end }}
 
-{{- if contains (lower $name) (lower .Release.Name) }}
-{{- $name = $name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name = printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{- if not (hasPrefix "nri-" $name) }}
-{{- /* In case the name is not prefixed with "nri-", add it */}}
-{{- $name = printf "nri-%s" $name }}
-{{- end }}
-
-{{- $name -}}
+    {{- if not (hasPrefix "nri-" $name) }}
+        {{- /* In case the name is not prefixed with "nri-", add it */}}
+        {{- $name = printf "nri-%s" $name }}
+    {{- end }}
 
 {{- end }}
+
+{{- $name | trunc 63 | trimSuffix "-" }}
+
 {{- end }}
 
 
 
 {{/*
 Create chart name and version as used by the chart label.
-Here we do not use (include "common.naming.chartnameOverride" .) because is only used for the labels.
 This function should not be used for naming objects. Use "common.naming.{name,fullname}" instead.
 */}}
 {{- define "common.naming.chart" -}}


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
no
#### What this PR does / why we need it:

Previous to this the fullname of resources had a logic to add the `nri-` prefix and use release name if collisions with the chart name.

The goal of this was to standardize naming across different charts but more logic should have been needed to cover cases like chart starting with `nri-` or `newrelic` to avoid replications in the name.

But since all charts using the library will be using the common naming helpers , the standardization will take place anyway and all charts will start with the release name, followed by the chart name.


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
