### PR TITLE
fix fullname to ensure that the release name is included

### DIFF
--- a/library/CHART-TEMPLATE/Chart.lock
+++ b/library/CHART-TEMPLATE/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: file://../common-library
-  version: 1.0.0
-digest: sha256:5a7bb0f389189fb7fc37c4dbf5c0e4fbc41a78be6aa9f1ec6562260ae0ad10d4
-generated: "2022-04-12T14:58:57.342678+02:00"
+  version: 1.0.1
+digest: sha256:8392f0dc14b0ebec31256a510a34fedc4c77faf97cd64b9ca2274d4fb977ecbd
+generated: "2022-04-13T16:10:12.313925+02:00"

--- a/library/CHART-TEMPLATE/Chart.yaml
+++ b/library/CHART-TEMPLATE/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,7 +25,7 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: common-library
-    version: 1.0.0
+    version: 1.0.1
     repository: file://../common-library
 
 keywords:

--- a/library/common-library/Chart.yaml
+++ b/library/common-library/Chart.yaml
@@ -3,7 +3,7 @@ name: common-library
 description: Provides helpers to provide consistency on all the charts
 
 type: library
-version: 1.0.0
+version: 1.0.1
 
 keywords:
   - newrelic

--- a/library/common-library/templates/_naming.tpl
+++ b/library/common-library/templates/_naming.tpl
@@ -1,6 +1,6 @@
 {{/*
-This is an auxilir funtion to be called directly with a string just to truncate strings to
-63 chars because some Kubernetes name fields are limited by the DNS naming spec.
+This is an function to be called directly with a string just to truncate strings to
+63 chars because some Kubernetes name fields are limited to that.
 */}}
 {{- define "newrelic.common.naming.trucateToDNS" -}}
 {{- . | trunc 63 | trimSuffix "-" }}
@@ -33,7 +33,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- else -}}
     {{- $name = include "newrelic.common.naming.name" .  -}}
     {{- if not ( contains $name .Release.Name ) -}}
-        {{- $name = printf "%s-%s" .Release.Name (include "newrelic.common.naming.name" .)}}
+        {{- $name = printf "%s-%s" .Release.Name $name .}}
     {{- end -}}
 {{- end -}}
 

--- a/library/common-library/templates/_naming.tpl
+++ b/library/common-library/templates/_naming.tpl
@@ -14,7 +14,8 @@ Uses the Chart name by default if nameOverride is not set.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "newrelic.common.naming.name" -}}
-{{- include "newrelic.common.naming.trucateToDNS" ( .Values.nameOverride | default .Chart.Name ) -}}
+{{- $name := .Values.nameOverride | default .Chart.Name -}}
+{{- include "newrelic.common.naming.trucateToDNS" $name -}}
 {{- end }}
 
 
@@ -26,20 +27,17 @@ nameOverride are set.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "newrelic.common.naming.fullname" -}}
-{{- $name := "" }}
+{{- $name := include "newrelic.common.naming.name" . -}}
 
 {{- if .Values.fullnameOverride -}}
     {{- $name = .Values.fullnameOverride  -}}
-{{- else -}}
-    {{- $name = include "newrelic.common.naming.name" .  -}}
-    {{- if not ( contains $name .Release.Name ) -}}
-        {{- $name = printf "%s-%s" .Release.Name $name .}}
-    {{- end -}}
+{{- else if not (contains $name .Release.Name) -}}
+    {{- $name = printf "%s-%s" .Release.Name $name -}}
 {{- end -}}
 
 {{- include "newrelic.common.naming.trucateToDNS" $name -}}
 
-{{- end }}
+{{- end -}}
 
 
 
@@ -48,5 +46,5 @@ Create chart name and version as used by the chart label.
 This function should not be used for naming objects. Use "common.naming.{name,fullname}" instead.
 */}}
 {{- define "newrelic.common.naming.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end }}

--- a/library/common-library/templates/_naming.tpl
+++ b/library/common-library/templates/_naming.tpl
@@ -22,7 +22,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 {{/*
 Create a default fully qualified app name.
-By default the full name will be "<release_name>-<chart_chart>". This could change if fullnameOverride or
+By default the full name will be "<release_name>" just in if it has the chart name included in that, if not
+it will be concatenated like "<release_name>-<chart_chart>". This could change if fullnameOverride or
 nameOverride are set.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/library/common-library/templates/_naming.tpl
+++ b/library/common-library/templates/_naming.tpl
@@ -1,10 +1,20 @@
 {{/*
+This is an auxilir funtion to be called directly with a string just to truncate strings to
+63 chars because some Kubernetes name fields are limited by the DNS naming spec.
+*/}}
+{{- define "newrelic.common.naming.trucateToDNS" -}}
+{{- . | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+
+
+{{/*
 Expand the name of the chart.
 Uses the Chart name by default if nameOverride is not set.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "newrelic.common.naming.name" -}}
-{{- .Values.nameOverride | default .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- include "newrelic.common.naming.trucateToDNS" ( .Values.nameOverride | default .Chart.Name ) -}}
 {{- end }}
 
 
@@ -18,13 +28,16 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "newrelic.common.naming.fullname" -}}
 {{- $name := "" }}
 
-{{- if .Values.fullnameOverride }}
-    {{- $name = .Values.fullnameOverride  }}
-{{- else }}
-    {{- $name = printf "%s-%s" .Release.Name (include "newrelic.common.naming.name" .)}}
-{{- end }}
+{{- if .Values.fullnameOverride -}}
+    {{- $name = .Values.fullnameOverride  -}}
+{{- else -}}
+    {{- $name = include "newrelic.common.naming.name" .  -}}
+    {{- if not ( contains $name .Release.Name ) -}}
+        {{- $name = printf "%s-%s" .Release.Name (include "newrelic.common.naming.name" .)}}
+    {{- end -}}
+{{- end -}}
 
-{{- $name | trunc 63 | trimSuffix "-" }}
+{{- include "newrelic.common.naming.trucateToDNS" $name -}}
 
 {{- end }}
 


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

There is an issue in the `naming.fullname` function where we do not test if `Release` was in the name or not at concatenate it.

It is an idiomatic behavior that `helm` creates while `helm create example-chart`.

This PR also adds a useful function to truncate long names

#### Checklist
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
