### PR TITLE
common.library: include helper to handle dns-valid names with suffixes

### DIFF
--- a/library/CHART-TEMPLATE/Chart.lock
+++ b/library/CHART-TEMPLATE/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: file://../common-library
-  version: 1.0.1
-digest: sha256:8392f0dc14b0ebec31256a510a34fedc4c77faf97cd64b9ca2274d4fb977ecbd
-generated: "2022-04-13T16:10:12.313925+02:00"
+  version: 1.0.2
+digest: sha256:f6136514534720d55c8c12867ee82481c337f5f767ae5f8dd4d37be021869b89
+generated: "2022-04-14T09:32:09.145497+02:00"

--- a/library/CHART-TEMPLATE/Chart.yaml
+++ b/library/CHART-TEMPLATE/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,7 +25,7 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: common-library
-    version: 1.0.1
+    version: 1.0.2
     repository: file://../common-library
 
 keywords:

--- a/library/CHART-TEMPLATE/templates/job.yaml
+++ b/library/CHART-TEMPLATE/templates/job.yaml
@@ -1,0 +1,13 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" ( dict "name" (include "newrelic.common.naming.fullname" .) "suffix" (.Values.jobSuffix | default "job-suffix") ) }}
+spec:
+  template:
+    spec:
+      containers:
+      - name: echo-job
+        image: alpine
+        command: ["echo",  "Hi there!"]
+      restartPolicy: Never
+  backoffLimit: 4

--- a/library/CHART-TEMPLATE/tests/common_library_naming_suffix_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_naming_suffix_test.yaml
@@ -1,0 +1,30 @@
+suite: test suffix naming helper
+templates:
+  - templates/job.yaml
+release:
+  name: release
+tests:
+
+  - it: suffix is included
+    set:
+      fullnameOverride: fno
+    asserts:
+      - equal:
+          path: metadata.name
+          value: fno-job-suffix
+
+  - it: name is truncated but suffix included
+    set:
+      fullnameOverride: including-full-name-as-it-is-would-way-be-longer-than-limit
+    asserts:
+      - equal:
+          path: metadata.name
+          value: including-full-name-as-it-is-would-way-be-longer-than-job-suffix
+
+  - it: fails when suffix is too long
+    set:
+      fullnameOverride: fno
+      jobSuffix: this-job-suffix-is-too-long-so-it-is-not-possible-to-include-at-it-is
+    asserts:
+      - failedTemplate:
+          errorMessage: (newrelic.common.naming.truncateToDNSWithSuffix) suffix length is too long to compose a valid name

--- a/library/CHART-TEMPLATE/tests/common_library_naming_suffix_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_naming_suffix_test.yaml
@@ -21,10 +21,11 @@ tests:
           path: metadata.name
           value: including-full-name-as-it-is-would-way-be-longer-than-job-suffix
 
-  - it: fails when suffix is too long
+  - it: suffix is longer than maximum length supported
     set:
       fullnameOverride: fno
       jobSuffix: this-job-suffix-is-too-long-so-it-is-not-possible-to-include-at-it-is
     asserts:
-      - failedTemplate:
-          errorMessage: The suffix chosen (this-job-suffix-is-too-long-so-it-is-not-possible-to-include-at-it-is) is hitting the Kubernetes limit of 63 chars for the object name. We cannot create fno-this-job-suffix-is-too-long-so-it-is-not-possible-to-include-at-it-is
+      - equal:
+          path: metadata.name
+          value: this-job-suffix-is-too-long-so-it-is-not-possible-to-include-at

--- a/library/CHART-TEMPLATE/tests/common_library_naming_suffix_test.yaml
+++ b/library/CHART-TEMPLATE/tests/common_library_naming_suffix_test.yaml
@@ -27,4 +27,4 @@ tests:
       jobSuffix: this-job-suffix-is-too-long-so-it-is-not-possible-to-include-at-it-is
     asserts:
       - failedTemplate:
-          errorMessage: (newrelic.common.naming.truncateToDNSWithSuffix) suffix length is too long to compose a valid name
+          errorMessage: The suffix chosen (this-job-suffix-is-too-long-so-it-is-not-possible-to-include-at-it-is) is hitting the Kubernetes limit of 63 chars for the object name. We cannot create fno-this-job-suffix-is-too-long-so-it-is-not-possible-to-include-at-it-is

--- a/library/common-library/Chart.yaml
+++ b/library/common-library/Chart.yaml
@@ -3,7 +3,7 @@ name: common-library
 description: Provides helpers to provide consistency on all the charts
 
 type: library
-version: 1.0.1
+version: 1.0.2
 
 keywords:
   - newrelic
@@ -18,7 +18,11 @@ maintainers:
     url: https://github.com/gsanchezgavier
   - name: kang-makes
     url: https://github.com/kang-makes
+  - name: marcsanmi
+    url: https://github.com/marcsanmi
   - name: paologallinaharbur
     url: https://github.com/paologallinaharbur
   - name: roobre
     url: https://github.com/roobre
+  - name: sigilioso
+    url: https://github.com/sigilioso

--- a/library/common-library/templates/_naming.tpl
+++ b/library/common-library/templates/_naming.tpl
@@ -8,6 +8,27 @@ This is an function to be called directly with a string just to truncate strings
 
 
 
+{{- /*
+Given a name and a suffix returns a 'DNS Valid' which always include the suffix, truncating the name if needed.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+It fails if suffix is too long to fint in the limit set.
+Usage:
+{{ include "newrelic.common.naming.truncateToDNSWithSuffix" ( dict "name" "<my-name>" "suffix" "my-suffix" ) }}
+*/ -}}
+{{- define "newrelic.common.naming.truncateToDNSWithSuffix" -}}
+{{- $maxLen := (sub 63 (len .suffix)) -}}
+
+{{- if (lt $maxLen 1) -}}
+    {{ fail "(newrelic.common.naming.truncateToDNSWithSuffix) suffix length is too long to compose a valid name" }}
+{{- end -}}
+
+{{- $newName := .name | trunc ($maxLen | int) | trimSuffix "-"  -}}
+{{- printf "%s-%s" $newName .suffix -}}
+
+{{- end -}}
+
+
+
 {{/*
 Expand the name of the chart.
 Uses the Chart name by default if nameOverride is not set.

--- a/library/common-library/templates/_naming.tpl
+++ b/library/common-library/templates/_naming.tpl
@@ -11,7 +11,7 @@ This is an function to be called directly with a string just to truncate strings
 {{- /*
 Given a name and a suffix returns a 'DNS Valid' which always include the suffix, truncating the name if needed.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If suffix is too long it gets truncated but it al`ays takes precedence over name, so a 63 chars suffix would suppress the name.
+If suffix is too long it gets truncated but it always takes precedence over name, so a 63 chars suffix would suppress the name.
 Usage:
 {{ include "newrelic.common.naming.truncateToDNSWithSuffix" ( dict "name" "<my-name>" "suffix" "my-suffix" ) }}
 */ -}}

--- a/library/common-library/templates/_naming.tpl
+++ b/library/common-library/templates/_naming.tpl
@@ -19,7 +19,7 @@ Usage:
 {{- $maxLen := (sub 63 (len .suffix)) -}}
 
 {{- if (lt $maxLen 1) -}}
-    {{ fail "(newrelic.common.naming.truncateToDNSWithSuffix) suffix length is too long to compose a valid name" }}
+    {{ fail (printf "The suffix chosen (%s) is hitting the Kubernetes limit of 63 chars for the object name. We cannot create %s-%s" .suffix .name .suffix) }}
 {{- end -}}
 
 {{- $newName := .name | trunc ($maxLen | int) | trimSuffix "-"  -}}


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

#### What this PR does / why we need it:

#### Which issue this PR fixes

#### Special notes for your reviewer:

Include a naming helper to handle names with prefixes. See potential usage example [here](https://github.com/newrelic/k8s-metadata-injection/blob/bb45f8a0c1d49fd47fa96bb95cd14b8603ce327f/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-createSecret.yaml#L5)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
