### PR TITLE
[nri-bundle] Bump Pixie operator version to 0.0.24

### DIFF
--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to deploy New Relic integrations bundled together
 name: nri-bundle
-version: 3.5.0
+version: 3.5.1
 home: https://github.com/newrelic/helm-charts
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:

--- a/charts/nri-bundle/requirements.lock
+++ b/charts/nri-bundle/requirements.lock
@@ -25,9 +25,9 @@ dependencies:
   version: 1.5.0
 - name: pixie-operator-helm2-chart
   repository: https://pixie-operator-charts.storage.googleapis.com
-  version: 0.0.21
+  version: 0.0.24
 - name: newrelic-infra-operator
   repository: file://../newrelic-infra-operator
   version: 0.6.0
-digest: sha256:445ffa29ccc2a24cfb170be02357fa786f597d8ce830a77c97a6f98ea8b2a2ae
-generated: "2022-04-12T11:13:57.241908+02:00"
+digest: sha256:f47bb98312fa79545e97418824e89794f2283f98233efb18007555c4c936c921
+generated: "2022-04-18T14:12:45.721890761-07:00"

--- a/charts/nri-bundle/requirements.yaml
+++ b/charts/nri-bundle/requirements.yaml
@@ -43,7 +43,7 @@ dependencies:
     alias: pixie-chart
     repository: https://pixie-operator-charts.storage.googleapis.com
     condition: pixie-chart.enabled
-    version: 0.0.21
+    version: 0.0.24
 
   - name: newrelic-infra-operator
     repository: file://../newrelic-infra-operator


### PR DESCRIPTION
Signed-off-by: Michelle Nguyen <michellenguyen@pixielabs.ai>

<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
This updates Pixie's operator version, to pull in some operator helm chart changes which allow users to further customize the memory usage of Pixie.

#### Which issue this PR fixes
None

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
