### PR TITLE
[nri-bundle] Update Pixie integration to 1.5.1 and pixie operator to …

### DIFF
--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to deploy New Relic integrations bundled together
 name: nri-bundle
-version: 3.6.1
+version: 3.6.2
 home: https://github.com/newrelic/helm-charts
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:

--- a/charts/nri-bundle/requirements.lock
+++ b/charts/nri-bundle/requirements.lock
@@ -22,12 +22,12 @@ dependencies:
   version: 1.10.9
 - name: newrelic-pixie
   repository: file://../newrelic-pixie
-  version: 1.5.0
+  version: 1.5.1
 - name: pixie-operator-helm2-chart
   repository: https://pixie-operator-charts.storage.googleapis.com
-  version: 0.0.24
+  version: 0.0.25
 - name: newrelic-infra-operator
   repository: file://../newrelic-infra-operator
   version: 0.6.0
-digest: sha256:f7a0f6591d96b71321973f9052eeba785c26b62a8e48443054bc691b8b71b7dc
-generated: "2022-04-21T17:20:25.138688+02:00"
+digest: sha256:75a984b4cacb9cdd9212873a992c8f2c9597ef61ec25693412697ac7bca5cd4e
+generated: "2022-04-25T12:12:30.719211+02:00"

--- a/charts/nri-bundle/requirements.yaml
+++ b/charts/nri-bundle/requirements.yaml
@@ -37,13 +37,13 @@ dependencies:
   - name: newrelic-pixie
     repository: file://../newrelic-pixie
     condition: newrelic-pixie.enabled
-    version: 1.5.0
+    version: 1.5.1
 
   - name: pixie-operator-helm2-chart
     alias: pixie-chart
     repository: https://pixie-operator-charts.storage.googleapis.com
     condition: pixie-chart.enabled
-    version: 0.0.24
+    version: 0.0.25
 
   - name: newrelic-infra-operator
     repository: file://../newrelic-infra-operator


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Update Pixie integration to 1.5.1 and pixie operator to 0.0.25

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
