### PR TITLE
[nri-bundle-legacy] Fix stuck CI pipeline

### DIFF
--- a/charts/nri-bundle-legacy/Chart.yaml
+++ b/charts/nri-bundle-legacy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: "DEPRECATED: A Helm chart to deploy New Relic integrations bundled together"
 name: nri-bundle
-version: 3.6.2
+version: 3.6.3
 home: https://github.com/newrelic/helm-charts
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 deprecated: true


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:
The pipeline is failing this error:
```
Error: error creating GitHub release nri-bundle-3.6.2: POST https://api.github.com/repos/newrelic/helm-charts/releases: 422 Validation Failed [{Resource:Release Field:tag_name Code:already_exists Message:}]
```

It is true, it already exists.

Charts that were already tagged but there is no update in the `gh-pages` branch so I had to delete them manually:
```shell
git push --delete origin newrelic-infra-operator-0.6.1
git push --delete origin newrelic-infrastructure-2.10.1
git push --delete origin newrelic-k8s-metrics-adapter-0.3.3
```

So in the next run everything should be tagged and released properly.

#### Checklist
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
