### PR TITLE
[nri-bundle] Update dependencies

### DIFF
--- a/charts/nri-bundle/Chart.lock
+++ b/charts/nri-bundle/Chart.lock
@@ -4,10 +4,10 @@ dependencies:
   version: 3.3.3
 - name: nri-prometheus
   repository: https://newrelic.github.io/nri-prometheus
-  version: 2.1.1
+  version: 2.1.2
 - name: nri-metadata-injection
   repository: https://newrelic.github.io/k8s-metadata-injection
-  version: 3.0.1
+  version: 3.0.2
 - name: newrelic-k8s-metrics-adapter
   repository: https://newrelic.github.io/newrelic-k8s-metrics-adapter
   version: 0.7.4
@@ -28,6 +28,6 @@ dependencies:
   version: 0.0.26
 - name: newrelic-infra-operator
   repository: https://newrelic.github.io/newrelic-infra-operator
-  version: 0.6.0
-digest: sha256:991e5176a2233cedb6eb1fbf49cd38ce52d2123a2fadf5a352e96cc42a672e8e
-generated: "2022-05-04T13:51:43.981149+02:00"
+  version: 1.0.1
+digest: sha256:535b751be9a9d7d4da30b39460786d5efb38a282b0a25581d2de213fc066ec37
+generated: "2022-05-10T12:43:37.748351+02:00"

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -15,7 +15,7 @@ sources:
   - https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie
   - https://github.com/newrelic/newrelic-infra-operator/tree/master/charts/newrelic-infra-operator
 
-version: 4.3.3
+version: 4.4.0
 
 dependencies:
   - name: newrelic-infrastructure
@@ -26,12 +26,12 @@ dependencies:
   - name: nri-prometheus
     repository: https://newrelic.github.io/nri-prometheus
     condition: prometheus.enabled
-    version: 2.1.1
+    version: 2.1.2
 
   - name: nri-metadata-injection
     repository: https://newrelic.github.io/k8s-metadata-injection
     condition: webhook.enabled
-    version: 3.0.1
+    version: 3.0.2
 
   - name: newrelic-k8s-metrics-adapter
     repository: https://newrelic.github.io/newrelic-k8s-metrics-adapter
@@ -67,7 +67,7 @@ dependencies:
   - name: newrelic-infra-operator
     repository: https://newrelic.github.io/newrelic-infra-operator
     condition: newrelic-infra-operator.enabled
-    version: 0.6.0
+    version: 1.0.1
 
 maintainers:
   - name: alvarocabanas


### PR DESCRIPTION
#### Is this a new chart

No.

#### What this PR does / why we need it:

We have a couple of PRs pending from renovate bot that I would like to merge in the same PR as it still is not able to bump the version of the `nri-bundle` chart.

#### Checklist
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
