### PR TITLE
[ci/cd] Fix stuck CI

### DIFF
--- a/charts/nri-bundle-legacy/Chart.yaml
+++ b/charts/nri-bundle-legacy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: "DEPRECATED: A Helm chart to deploy New Relic integrations bundled together"
 name: nri-bundle
-version: 3.6.4
+version: 3.6.5
 home: https://github.com/newrelic/helm-charts
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 deprecated: true


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
The CI didn't see any conflict because a previous PR did the same change. so we finished with a changed chart with an already released version: 
> `Error: error creating GitHub release nri-bundle-3.6.4: POST https://api.github.com/repos/newrelic/helm-charts/releases: 422 Validation Failed [{Resource:Release Field:tag_name Code:already_exists Message:}]`

#### Checklist
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
