### PR TITLE
[nri-bundle] Update bundle dependencies

### DIFF
--- a/charts/nri-bundle-legacy/Chart.yaml
+++ b/charts/nri-bundle-legacy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: "DEPRECATED: A Helm chart to deploy New Relic integrations bundled together"
 name: nri-bundle
-version: 3.6.5
+version: 3.6.6
 home: https://github.com/newrelic/helm-charts
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 deprecated: true

--- a/charts/nri-bundle-legacy/requirements.lock
+++ b/charts/nri-bundle-legacy/requirements.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: newrelic-infrastructure
-  repository: https://newrelic.github.io/helm-charts
-  version: 2.10.1
+  repository: https://newrelic.github.io/nri-kubernetes
+  version: 2.10.3
 - name: nri-prometheus
   repository: https://newrelic.github.io/helm-charts
   version: 1.14.1
@@ -29,5 +29,5 @@ dependencies:
 - name: newrelic-infra-operator
   repository: https://newrelic.github.io/helm-charts
   version: 0.6.1
-digest: sha256:f50918360870d3a842a8d59f08fb54f9384ec30fd9f0fe457ad0310bb83bf621
-generated: "2022-05-09T11:39:36.48361+02:00"
+digest: sha256:58a9b0fc94b815eded6ec8aff350d1262b4410b13db6f22cfd9a774896962bb0
+generated: "2022-05-13T14:35:32.853274+02:00"

--- a/charts/nri-bundle-legacy/requirements.yaml
+++ b/charts/nri-bundle-legacy/requirements.yaml
@@ -1,8 +1,8 @@
 dependencies:
   - name: newrelic-infrastructure
-    repository: https://newrelic.github.io/helm-charts
+    repository: https://newrelic.github.io/nri-kubernetes
     condition: infrastructure.enabled
-    version: 2.10.1
+    version: 2.10.3
 
   - name: nri-prometheus
     repository: https://newrelic.github.io/helm-charts

--- a/charts/nri-bundle/Chart.lock
+++ b/charts/nri-bundle/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: newrelic-infrastructure
   repository: https://newrelic.github.io/nri-kubernetes
-  version: 3.3.4
+  version: 3.3.6
 - name: nri-prometheus
   repository: https://newrelic.github.io/nri-prometheus
   version: 2.1.2
@@ -29,5 +29,5 @@ dependencies:
 - name: newrelic-infra-operator
   repository: https://newrelic.github.io/newrelic-infra-operator
   version: 1.0.3
-digest: sha256:5f165286d614d0e0c5a60d801b98d76c9db912b775560d86a4d4f1c0279d2cd5
-generated: "2022-05-13T14:44:08.865294+02:00"
+digest: sha256:4f93c782015577b49e70e2b72c45133d2649c8cad47a6e534df964ff70a3d991
+generated: "2022-05-13T16:16:32.722361+02:00"

--- a/charts/nri-bundle/Chart.lock
+++ b/charts/nri-bundle/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 2.1.2
 - name: nri-metadata-injection
   repository: https://newrelic.github.io/k8s-metadata-injection
-  version: 3.0.3
+  version: 3.0.4
 - name: newrelic-k8s-metrics-adapter
   repository: https://newrelic.github.io/newrelic-k8s-metrics-adapter
   version: 0.7.5
@@ -16,7 +16,7 @@ dependencies:
   version: 2.13.2
 - name: nri-kube-events
   repository: https://newrelic.github.io/nri-kube-events
-  version: 2.2.3
+  version: 2.2.4
 - name: newrelic-logging
   repository: https://newrelic.github.io/helm-charts
   version: 1.10.9
@@ -28,6 +28,6 @@ dependencies:
   version: 0.0.26
 - name: newrelic-infra-operator
   repository: https://newrelic.github.io/newrelic-infra-operator
-  version: 1.0.2
-digest: sha256:12f9a3176141a3d9bbec836bd6191c1f408232b69daae0f29d8d2a1b07dd5a24
-generated: "2022-05-11T13:07:59.379100781Z"
+  version: 1.0.3
+digest: sha256:5f165286d614d0e0c5a60d801b98d76c9db912b775560d86a4d4f1c0279d2cd5
+generated: "2022-05-13T14:44:08.865294+02:00"

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -15,7 +15,7 @@ sources:
   - https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie
   - https://github.com/newrelic/newrelic-infra-operator/tree/master/charts/newrelic-infra-operator
 
-version: 4.4.5
+version: 4.4.6
 
 dependencies:
   - name: newrelic-infrastructure
@@ -31,7 +31,7 @@ dependencies:
   - name: nri-metadata-injection
     repository: https://newrelic.github.io/k8s-metadata-injection
     condition: webhook.enabled
-    version: 3.0.3
+    version: 3.0.4
 
   - name: newrelic-k8s-metrics-adapter
     repository: https://newrelic.github.io/newrelic-k8s-metrics-adapter
@@ -46,7 +46,7 @@ dependencies:
   - name: nri-kube-events
     repository: https://newrelic.github.io/nri-kube-events
     condition: kubeEvents.enabled
-    version: 2.2.3
+    version: 2.2.4
 
   - name: newrelic-logging
     repository: https://newrelic.github.io/helm-charts
@@ -67,7 +67,7 @@ dependencies:
   - name: newrelic-infra-operator
     repository: https://newrelic.github.io/newrelic-infra-operator
     condition: newrelic-infra-operator.enabled
-    version: 1.0.2
+    version: 1.0.3
 
 maintainers:
   - name: alvarocabanas

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   - name: newrelic-infrastructure
     repository: https://newrelic.github.io/nri-kubernetes
     condition: infrastructure.enabled
-    version: 3.3.4
+    version: 3.3.6
 
   - name: nri-prometheus
     repository: https://newrelic.github.io/nri-prometheus

--- a/charts/nri-bundle/README.md
+++ b/charts/nri-bundle/README.md
@@ -1,6 +1,6 @@
 # nri-bundle
 
-![Version: 4.3.3](https://img.shields.io/badge/Version-4.3.3-informational?style=flat-square)
+![Version: 4.4.6](https://img.shields.io/badge/Version-4.4.6-informational?style=flat-square)
 
 A chart groups together the individual charts for the New Relic Kubernetes solution for more comfortable deployment.
 


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
 - Updates `nri-bundle-legacy` from 3.6.5 to 3.6.6
   - `newrelic-infrastructure` changes its upstream to https://newrelic.github.io/nri-kubernetes 
   - `newrelic-infrastructure` upgrades its chart version from `2.10.1` to `2.10.3`
 - Updates `nri-bundle` from 4.4.5 to 4.4.6
   - `newrelic-infrastructure` upgrades its chart version from `3.3.4` to `3.3.6`
   - `nri-metadata-injection` upgrades its chart version from `3.0.3` to `3.0.4`
   - `nri-kube-events` upgrades its chart version from `2.2.3` to `2.2.4`
   - `newrelic-infra-operator` upgrades its chart version from `1.0.2` to `1.0.3`

Fixes #818 

#### Checklist
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
