### PR TITLE
[newrelic-pixie] Use v2 of the Pixie integration

### DIFF
--- a/charts/newrelic-pixie/Chart.yaml
+++ b/charts/newrelic-pixie/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart for the New Relic Pixie integration.
 name: newrelic-pixie
-version: 1.5.1
-appVersion: 1.5.0
+version: 2.0.0
+appVersion: 2.0.0
 home: https://hub.docker.com/u/newrelic
 sources:
   - https://github.com/newrelic/

--- a/charts/newrelic-pixie/README.md
+++ b/charts/newrelic-pixie/README.md
@@ -4,9 +4,7 @@
 
 This chart will deploy the New Relic Pixie Integration.
 
-IMPORTANT: make sure you deploy this chart in the same namespace as Pixie.
-It needs to access the cluster id inside the Pixie secrets.
-By default, Pixie is installed in the `pl` namespace.
+IMPORTANT: In order to retrieve the Pixie cluster id from the `pl-cluster-secrets` the integration needs to be deployed in the same namespace as Pixie. By default, Pixie is installed in the `pl` namespace. Alternatively the `clusterId` can be configured manually when installing the chart. In this case the integration can be deployed to any namespace.
 
 ## Configuration
 
@@ -17,16 +15,20 @@ By default, Pixie is installed in the `pl` namespace.
 | `global.lowDataMode` - `lowDataMode`                       | If `true`, the integration performs heavier sampling on the Pixie span data and sets the collect interval to 15 seconds instead of 10 seconds.                                                     | false                 |
 | `global.nrStaging` - `nrStaging`                           | Send data to staging (requires a staging license key).                                                                                                                                             | false                 |
 | `apiKey`                                                   | The Pixie API key (stored in a secret). Required.                                                                                                                                                  |                       |
+| `clusterId`                                                | The Pixie cluster id. Optional. Read from the `pl-cluster-secrets` secret if empty.                                                                                                                |                       |
+| `endpoint`                                                 | The Pixie endpoint. Required when using Pixie Open Source.                                                                                                                                         |                       |
 | `verbose`                                                  | Whether the integration should run in verbose mode or not.                                                                                                                                         | false                 |
 | `global.customSecretName` - `customSecretName`             | Name of an existing Secret object, not created by this chart, where the New Relic license is stored                                                                                                |                       |
 | `global.customSecretLicenseKey` - `customSecretLicenseKey` | Key in the existing Secret object, indicated by `customSecretName`, where the New Relic license key is stored.                                                                                     |                       |
 | `image.pullSecrets`                                        | Image pull secrets.                                                                                                                                                                                | `nil`                 |
 | `customSecretApiKeyName`                                   | Name of an existing Secret object, not created by this chart, where the Pixie API key is stored.                                                                                                   |                       |
 | `customSecretApiKeyKey`                                    | Key in the existing Secret object, indicated by `customSecretApiKeyName`, where the Pixie API key is stored.                                                                                       |                       |
-| `nodeSelector`                                             | Node label to use for scheduling                                                                                                                                                                                                      | `{}`                                   |
-| `tolerations`                                              | List of node taints to tolerate (requires Kubernetes >= 1.6)                                                                                                                                                                          | `[]`                                   |
-| `affinity`                                                 | Node affinity to use for scheduling                                                                                                                                                                                            | `{}`                  |
+| `nodeSelector`                                             | Node label to use for scheduling.                                                                                                                                                                  | `{}`                  |
+| `tolerations`                                              | List of node taints to tolerate (requires Kubernetes >= 1.6).                                                                                                                                      | `[]`                  |
+| `affinity`                                                 | Node affinity to use for scheduling.                                                                                                                                                               | `{}`                  |
 | `proxy`                                                    | Set proxy to connect to Pixie Cloud and New Relic.                                                                                                                                                 |                       |
+| `customScripts`                                            | YAML containing custom scripts for long-term data retention. The results of the custom scripts will be stored in New Relic. See [custom scripts](#custom-scripts) for YAML format.                 | `{}`                  |
+| `customScriptsConfigMap`                                   | Name of an existing ConfigMap object containing custom script for long-term data retention. This configuration takes precedence over `customScripts`.                                              |                       |
 | `excludeNamespacesRegex`                                   | Observability data for namespaces matching this RE2 regex is not sent to New Relic. If empty, observability data for all namespaces is sent to New Relic.                                          |                       |
 | `excludePodsRegex`                                         | Observability data for pods (across all namespaces) matching this RE2 regex is not sent to New Relic. If empty, observability data for all pods (in non-excluded namespaces) is sent to New Relic. |                       |
 
@@ -62,6 +64,88 @@ More information on globals and subcharts can be found at [Helm's official docum
 | `global.customSecretLicenseKey` |
 | `global.lowDataMode`            |
 | `global.nrStaging`              |
+
+## Custom scripts
+
+Custom scripts can either be configured directly in `customScripts` or be provided through an existing ConfigMap `customScriptsConfigMap`.
+
+The entries in the ConfigMap should contain file-like keys with the `.yaml` extension. Each file in the ConfigMap should be valid YAML and contain the following keys:
+
+ * name (string): the name of the script
+ * description (string): description of the script
+ * frequencyS (int): frequency to execute the script in seconds
+ * scripts (string): the actual PXL script to execute
+ * addExcludes (optional boolean, `false` by default): add pod and namespace excludes to the custom script
+
+For more detailed information about the custom scripts see [the New Relic Pixie integration repo](https://github.com/newrelic/newrelic-pixie-integration/).
+
+```yaml
+customScripts:
+  custom1.yaml: |
+    name: "custom1"
+    description: "Custom script 1"
+    frequencyS: 60
+    script: |
+      import px
+
+      df = px.DataFrame(table='http_events', start_time=px.plugin.start_time)
+
+      ns_prefix = df.ctx['namespace'] + '/'
+      df.container = df.ctx['container_name']
+      df.pod = px.strip_prefix(ns_prefix, df.ctx['pod'])
+      df.service = px.strip_prefix(ns_prefix, df.ctx['service'])
+      df.namespace = df.ctx['namespace']
+
+      df.status_code = df.resp_status
+
+      df = df.groupby(['status_code', 'pod', 'container','service', 'namespace']).agg(
+          latency_min=('latency', px.min),
+          latency_max=('latency', px.max),
+          latency_sum=('latency', px.sum),
+          latency_count=('latency', px.count),
+          time_=('time_', px.max),
+      )
+
+      df.latency_min = df.latency_min / 1000000
+      df.latency_max = df.latency_max / 1000000
+      df.latency_sum = df.latency_sum / 1000000
+
+      df.cluster_name = px.vizier_name()
+      df.cluster_id = px.vizier_id()
+      df.pixie = 'pixie'
+
+      px.export(
+        df, px.otel.Data(
+          resource={
+            'service.name': df.service,
+            'k8s.container.name': df.container,
+            'service.instance.id': df.pod,
+            'k8s.pod.name': df.pod,
+            'k8s.namespace.name': df.namespace,
+            'px.cluster.id': df.cluster_id,
+            'k8s.cluster.name': df.cluster_name,
+            'instrumentation.provider': df.pixie,
+          },
+          data=[
+            px.otel.metric.Summary(
+              name='http.server.duration',
+              description='measures the duration of the inbound HTTP request',
+              # Unit is not supported yet
+              # unit='ms',
+              count=df.latency_count,
+              sum=df.latency_sum,
+              quantile_values={
+                0.0: df.latency_min,
+                1.0: df.latency_max,
+              },
+              attributes={
+                'http.status_code': df.status_code,
+              },
+          )],
+        ),
+      )
+```
+
 
 ## Resources
 

--- a/charts/newrelic-pixie/ci/test-values.yaml
+++ b/charts/newrelic-pixie/ci/test-values.yaml
@@ -2,4 +2,4 @@ global:
   licenseKey: 1234567890abcdef1234567890abcdef12345678
   apiKey: 1234567890abcdef
   cluster: test-cluster
-pixieClusterId: foobar
+clusterId: foobar

--- a/charts/newrelic-pixie/templates/NOTES.txt
+++ b/charts/newrelic-pixie/templates/NOTES.txt
@@ -3,7 +3,7 @@
 Your deployment of the New Relic Pixie integration is complete.
 
 Please ensure this integration is deployed in the same namespace
-as Pixie.
+as Pixie or manually specify the clusterId.
 {{- else -}}
 ###############################################################
 ####    ERROR: You did not set all the required values.    ####

--- a/charts/newrelic-pixie/templates/configmap.yaml
+++ b/charts/newrelic-pixie/templates/configmap.yaml
@@ -1,0 +1,12 @@
+{{- if (include "newrelic-pixie.areValuesValid" .) }}
+{{- if .Values.customScripts }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ template "newrelic-pixie.namespace" . }}
+  labels: {{ include "newrelic-pixie.labels" . | indent 4 }}
+  name: {{ template "newrelic-pixie.fullname" . }}-scripts
+data:
+{{- toYaml .Values.customScripts | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/newrelic-pixie/templates/job.yaml
+++ b/charts/newrelic-pixie/templates/job.yaml
@@ -1,17 +1,13 @@
 {{- if (include "newrelic-pixie.areValuesValid" .) }}
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: {{ template "newrelic-pixie.fullname" . }}
   namespace: {{ template "newrelic-pixie.namespace" . }}
   labels:
     {{- include "newrelic-pixie.labels" . | nindent 4 }}
 spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: {{ template "newrelic-pixie.name" . }}
-      release: {{.Release.Name }}
+  backoffLimit: 4
   template:
     metadata:
       labels:
@@ -22,6 +18,7 @@ spec:
       imagePullSecrets:
         {{- toYaml .Values.image.pullSecrets | nindent 8 }}
       {{- end }}
+      restartPolicy: Never
       containers:
       - name: {{ template "newrelic-pixie.name" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -50,8 +47,8 @@ spec:
               key: {{ include "newrelic-pixie.customSecretApiKeyKey" . }}
           {{- end }}
         - name: PIXIE_CLUSTER_ID
-          {{- if .Values.pixieClusterId }}
-          value: {{ .Values.pixieClusterId -}}
+          {{- if .Values.clusterId }}
+          value: {{ .Values.clusterId -}}
           {{- else }}
           valueFrom:
             secretKeyRef:
@@ -74,9 +71,13 @@ spec:
         - name: NR_OTLP_HOST
           value: "staging-otlp.nr-data.net:4317"
         {{- end }}
-        {{- if (include "newrelic-pixie.nrStaging" .) }}
+        {{- if or .Values.endpoint (include "newrelic-pixie.nrStaging" .) }}
         - name: PIXIE_ENDPOINT
+          {{- if .Values.endpoint }}
+          value: {{ .Values.endpoint | quote }}
+          {{- else }}
           value: "staging.withpixie.dev:443"
+          {{- end }}
         {{- end }}
         {{- if .Values.proxy }}
         - name: HTTP_PROXY
@@ -96,6 +97,20 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         {{- end }}
+      {{- if or .Values.customScriptsConfigMap .Values.customScripts }}
+        volumeMounts:
+          - name: scripts
+            mountPath: "/scripts"
+            readOnly: true
+      volumes:
+        - name: scripts
+          configMap:
+            {{- if .Values.customScriptsConfigMap }}
+            name: {{ .Values.customScriptsConfigMap }}
+            {{- else }}
+            name: {{ template "newrelic-pixie.fullname" . }}-scripts
+            {{- end}}
+      {{- end }}
       {{- if $.Values.nodeSelector }}
       nodeSelector:
         {{- toYaml $.Values.nodeSelector | nindent 8 }}

--- a/charts/newrelic-pixie/tests/configmap.yaml
+++ b/charts/newrelic-pixie/tests/configmap.yaml
@@ -1,0 +1,44 @@
+suite: test custom scripts ConfigMap
+templates:
+  - templates/configmap.yaml
+tests:
+  - it: ConfigMap is created
+    set:
+      cluster: "test-cluster"
+      licenseKey: "license123"
+      apiKey: "api123"
+      customScripts:
+        custom1.yaml: |
+          name: "custom1"
+          description: "Custom script 1"
+          frequencyS: 60
+          script: |
+            import px
+            df = px.DataFrame(table='http_events', start_time=px.plugin.start_time)
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.custom1\.yaml
+          value: |-
+            name: "custom1"
+            description: "Custom script 1"
+            frequencyS: 60
+            script: |
+              import px
+              df = px.DataFrame(table='http_events', start_time=px.plugin.start_time)
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-newrelic-pixie-scripts
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+  - it: ConfigMap is empty
+    set:
+      cluster: "test-cluster"
+      licenseKey: "license123"
+      apiKey: "api123"
+      customScripts: {}
+    asserts:
+      - hasDocuments:
+          count: 0 

--- a/charts/newrelic-pixie/tests/jobs.yaml
+++ b/charts/newrelic-pixie/tests/jobs.yaml
@@ -1,0 +1,138 @@
+suite: test job
+templates:
+  - templates/job.yaml
+tests:
+  - it: Test primary fields of job
+    set:
+      cluster: "test-cluster"
+      licenseKey: "license123"
+      apiKey: "api123"
+      image:
+        tag: "latest"
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: "metadata.name"
+          value: "RELEASE-NAME-newrelic-pixie"
+      - equal:
+          path: "metadata.namespace"
+          value: "NAMESPACE"
+      - equal:
+          path: "spec.template.spec.containers[0].image"
+          value: "newrelic/newrelic-pixie-integration:latest"
+      - equal:
+          path: "spec.template.spec.containers[0].env"
+          value:
+            - name: CLUSTER_NAME
+              value: test-cluster
+            - name: NR_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: newrelicLicenseKey
+                  name: RELEASE-NAME-newrelic-pixie-secrets
+            - name: PIXIE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: pixieApiKey
+                  name: RELEASE-NAME-newrelic-pixie-secrets
+            - name: PIXIE_CLUSTER_ID
+              valueFrom:
+                secretKeyRef:
+                  key: cluster-id
+                  name: pl-cluster-secrets
+      - isEmpty:
+          path: "spec.template.spec.containers[0].volumeMounts"
+      - isEmpty:
+          path: "spec.template.spec.volumes"
+  - it: Job with clusterId
+    set:
+      cluster: "test-cluster"
+      licenseKey: "license123"
+      apiKey: "api123"
+      clusterId: "cid123"
+    asserts:
+      - equal:
+          path: "spec.template.spec.containers[0].env"
+          value:
+            - name: CLUSTER_NAME
+              value: test-cluster
+            - name: NR_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: newrelicLicenseKey
+                  name: RELEASE-NAME-newrelic-pixie-secrets
+            - name: PIXIE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: pixieApiKey
+                  name: RELEASE-NAME-newrelic-pixie-secrets
+            - name: PIXIE_CLUSTER_ID
+              value: "cid123"
+  - it: Job with Pixie endpoint
+    set:
+      cluster: "test-cluster"
+      licenseKey: "license123"
+      apiKey: "api123"
+      clusterId: "cid123"
+      endpoint: "withpixie.ai:443"
+    asserts:
+      - equal:
+          path: "spec.template.spec.containers[0].env"
+          value:
+            - name: CLUSTER_NAME
+              value: test-cluster
+            - name: NR_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: newrelicLicenseKey
+                  name: RELEASE-NAME-newrelic-pixie-secrets
+            - name: PIXIE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: pixieApiKey
+                  name: RELEASE-NAME-newrelic-pixie-secrets
+            - name: PIXIE_CLUSTER_ID
+              value: "cid123"
+            - name: PIXIE_ENDPOINT
+              value: "withpixie.ai:443"
+  - it: Job with custom scripts
+    set:
+      cluster: "test-cluster"
+      licenseKey: "license123"
+      apiKey: "api123"
+      customScripts:
+        custom1.yaml: |
+          name: "custom1"
+    asserts:
+      - equal:
+          path: "spec.template.spec.containers[0].volumeMounts"
+          value:
+            - name: scripts
+              mountPath: "/scripts"
+              readOnly: true
+      - equal:
+          path: "spec.template.spec.volumes[0]"
+          value:
+            name: scripts
+            configMap:
+              name: RELEASE-NAME-newrelic-pixie-scripts
+  - it: Job with custom script in defined ConfigMap
+    set:
+      cluster: "test-cluster"
+      licenseKey: "license123"
+      apiKey: "api123"
+      customScriptsConfigMap: "myconfigmap"
+    asserts:
+      - equal:
+          path: "spec.template.spec.containers[0].volumeMounts"
+          value:
+            - name: scripts
+              mountPath: "/scripts"
+              readOnly: true
+      - equal:
+          path: "spec.template.spec.volumes[0]"
+          value:
+            name: scripts
+            configMap:
+              name: myconfigmap

--- a/charts/newrelic-pixie/values.yaml
+++ b/charts/newrelic-pixie/values.yaml
@@ -8,6 +8,12 @@
 # The Pixie API key
 # apiKey: ""
 
+# The Pixie Cluster Id
+# clusterId:
+
+# The Pixie endpoint
+# endpoint:
+
 # If you already have a secret where the New Relic license key is stored, indicate its name here
 # customSecretName:
 # The key in the customSecretName secret that contains the New Relic license key
@@ -38,6 +44,10 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+customScripts: {}
+# Optionally the scripts can be provided in an already existing ConfigMap:
+# customScriptsConfigMap:
 
 excludeNamespacesRegex:
 excludePodsRegex:


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
This PR bumps the Pixie integration to version 2. This version is using a short-running integration that registers the PXL script to run using a New Relic Pixie plugin.

Significant changes:
* The deployment has been replaced by a job
* The ability to add custom scripts was added

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
