### PR TITLE
[nri-bundle] Fix bad UX with chart toggles

### DIFF
--- a/charts/nri-bundle/Chart.lock
+++ b/charts/nri-bundle/Chart.lock
@@ -29,5 +29,5 @@ dependencies:
 - name: newrelic-infra-operator
   repository: https://newrelic.github.io/newrelic-infra-operator
   version: 1.0.3
-digest: sha256:baf5a67970fc44a1d933ff3dae13bee8a22d6829e5e6310eb6477c3754dcc39c
-generated: "2022-05-19T13:24:32.6334139Z"
+digest: sha256:bb610d361c2464678fbe09284637482e69c8db8b2f0a1921b6d561676a2b56fc
+generated: "2022-05-20T14:18:01.004404+02:00"

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -20,37 +20,37 @@ version: 4.4.8
 dependencies:
   - name: newrelic-infrastructure
     repository: https://newrelic.github.io/nri-kubernetes
-    condition: infrastructure.enabled
+    condition: infrastructure.enabled,newrelic-infrastructure.enabled
     version: 3.5.1
 
   - name: nri-prometheus
     repository: https://newrelic.github.io/nri-prometheus
-    condition: prometheus.enabled
+    condition: prometheus.enabled,nri-prometheus.enabled
     version: 2.1.2
 
   - name: nri-metadata-injection
     repository: https://newrelic.github.io/k8s-metadata-injection
-    condition: webhook.enabled
+    condition: webhook.enabled,nri-metadata-injection.enabled
     version: 3.0.4
 
   - name: newrelic-k8s-metrics-adapter
     repository: https://newrelic.github.io/newrelic-k8s-metrics-adapter
-    condition: metrics-adapter.enabled
+    condition: metrics-adapter.enabled,newrelic-k8s-metrics-adapter.enabled
     version: 0.7.5
 
   - name: kube-state-metrics
     repository: https://kubernetes.github.io/kube-state-metrics
-    condition: ksm.enabled
+    condition: ksm.enabled,kube-state-metrics.enabled
     version: 2.13.2
 
   - name: nri-kube-events
     repository: https://newrelic.github.io/nri-kube-events
-    condition: kubeEvents.enabled
+    condition: kubeEvents.enabled,nri-kube-events.enabled
     version: 2.2.4
 
   - name: newrelic-logging
     repository: https://newrelic.github.io/helm-charts
-    condition: logging.enabled
+    condition: logging.enabled,newrelic-logging.enabled
     version: 1.10.9
 
   - name: newrelic-pixie

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -15,7 +15,7 @@ sources:
   - https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie
   - https://github.com/newrelic/newrelic-infra-operator/tree/master/charts/newrelic-infra-operator
 
-version: 4.4.8
+version: 4.5.0
 
 dependencies:
   - name: newrelic-infrastructure

--- a/charts/nri-bundle/README.md
+++ b/charts/nri-bundle/README.md
@@ -1,6 +1,6 @@
 # nri-bundle
 
-![Version: 4.4.8](https://img.shields.io/badge/Version-4.4.8-informational?style=flat-square)
+![Version: 4.5.0](https://img.shields.io/badge/Version-4.5.0-informational?style=flat-square)
 
 A chart groups together the individual charts for the New Relic Kubernetes solution for more comfortable deployment.
 
@@ -114,17 +114,17 @@ honors global options as described below.
 | global.serviceAccount.name | string | `nil` | Change the name of the service account. This is honored if you disable on this chart the creation of the service account so you can use your own |
 | global.tolerations | list | `[]` | Sets pod's tolerations to node taints |
 | global.verboseLog | bool | false | Sets the debug logs to this integration or all integrations if it is set globally |
-| infrastructure.enabled | bool | `true` | Install the [`newrelic-infrastructure` chart](https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure) |
-| ksm.enabled | bool | `false` | Install the [`kube-state-metrics` chart from the stable helm charts repository](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics) This is mandatory if `infrastructure.enabled` is set to `true` and the user does not provide its own instance of KSM version >=1.8 and <=2.0 |
 | kube-state-metrics.collectors | object | See [`values.yaml`](values.yaml) of the kube-state-metric chart | Collectors configuration of kube-state-metric |
-| kubeEvents.enabled | bool | `false` | Install the [`nri-kube-events` chart](https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events) |
-| logging.enabled | bool | `false` | Install the [`newrelic-logging` chart](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging) |
-| metrics-adapter.enabled | bool | `false` | Install the [`newrelic-k8s-metrics-adapter.` chart](https://github.com/newrelic/newrelic-k8s-metrics-adapter/tree/main/charts/newrelic-k8s-metrics-adapter) (Beta) |
+| kube-state-metrics.enabled | bool | `false` | Install the [`kube-state-metrics` chart from the stable helm charts repository](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics) This is mandatory if `infrastructure.enabled` is set to `true` and the user does not provide its own instance of KSM version >=1.8 and <=2.0 |
 | newrelic-infra-operator.enabled | bool | `false` | Install the [`newrelic-infra-operator` chart](https://github.com/newrelic/newrelic-infra-operator/tree/main/charts/newrelic-infra-operator) (Beta) |
+| newrelic-infrastructure.enabled | bool | `true` | Install the [`newrelic-infrastructure` chart](https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure) |
+| newrelic-k8s-metrics-adapter.enabled | bool | `false` | Install the [`newrelic-k8s-metrics-adapter.` chart](https://github.com/newrelic/newrelic-k8s-metrics-adapter/tree/main/charts/newrelic-k8s-metrics-adapter) (Beta) |
+| newrelic-logging.enabled | bool | `false` | Install the [`newrelic-logging` chart](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging) |
 | newrelic-pixie.enabled | bool | `false` | Install the [`newrelic-pixie`](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie) |
+| nri-kube-events.enabled | bool | `false` | Install the [`nri-kube-events` chart](https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events) |
+| nri-metadata-injection.enabled | bool | `true` | Install the [`nri-metadata-injection` chart](https://github.com/newrelic/k8s-metadata-injection/tree/main/charts/nri-metadata-injection) |
+| nri-prometheus.enabled | bool | `false` | Install the [`nri-prometheus` chart](https://github.com/newrelic/nri-prometheus/tree/main/charts/nri-prometheus) |
 | pixie-chart.enabled | bool | `false` | Install the [`pixie-chart` chart](https://docs.pixielabs.ai/installing-pixie/install-schemes/helm/#3.-deploy) |
-| prometheus.enabled | bool | `false` | Install the [`nri-prometheus` chart](https://github.com/newrelic/nri-prometheus/tree/main/charts/nri-prometheus) |
-| webhook.enabled | bool | `true` | Install the [`nri-metadata-injection` chart](https://github.com/newrelic/k8s-metadata-injection/tree/main/charts/nri-metadata-injection) |
 
 ## Maintainers
 

--- a/charts/nri-bundle/values.yaml
+++ b/charts/nri-bundle/values.yaml
@@ -1,26 +1,26 @@
-infrastructure:
-  # infrastructure.enabled -- Install the [`newrelic-infrastructure` chart](https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure)
+newrelic-infrastructure:
+  # newrelic-infrastructure.enabled -- Install the [`newrelic-infrastructure` chart](https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure)
   enabled: true
 
-prometheus:
-  # prometheus.enabled -- Install the [`nri-prometheus` chart](https://github.com/newrelic/nri-prometheus/tree/main/charts/nri-prometheus)
+nri-prometheus:
+  # nri-prometheus.enabled -- Install the [`nri-prometheus` chart](https://github.com/newrelic/nri-prometheus/tree/main/charts/nri-prometheus)
   enabled: false
 
-webhook:
-  # webhook.enabled -- Install the [`nri-metadata-injection` chart](https://github.com/newrelic/k8s-metadata-injection/tree/main/charts/nri-metadata-injection)
+nri-metadata-injection:
+  # nri-metadata-injection.enabled -- Install the [`nri-metadata-injection` chart](https://github.com/newrelic/k8s-metadata-injection/tree/main/charts/nri-metadata-injection)
   enabled: true
 
-ksm:
-  # ksm.enabled -- Install the [`kube-state-metrics` chart from the stable helm charts repository](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics)
+kube-state-metrics:
+  # kube-state-metrics.enabled -- Install the [`kube-state-metrics` chart from the stable helm charts repository](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics)
   # This is mandatory if `infrastructure.enabled` is set to `true` and the user does not provide its own instance of KSM version >=1.8 and <=2.0
   enabled: false
 
-kubeEvents:
-  # kubeEvents.enabled -- Install the [`nri-kube-events` chart](https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events)
+nri-kube-events:
+  # nri-kube-events.enabled -- Install the [`nri-kube-events` chart](https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events)
   enabled: false
 
-logging:
-  # logging.enabled -- Install the [`newrelic-logging` chart](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging)
+newrelic-logging:
+  # newrelic-logging.enabled -- Install the [`newrelic-logging` chart](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging)
   enabled: false
 
 newrelic-pixie:
@@ -35,8 +35,8 @@ newrelic-infra-operator:
   # newrelic-infra-operator.enabled -- Install the [`newrelic-infra-operator` chart](https://github.com/newrelic/newrelic-infra-operator/tree/main/charts/newrelic-infra-operator) (Beta)
   enabled: false
 
-metrics-adapter:
-  # metrics-adapter.enabled -- Install the [`newrelic-k8s-metrics-adapter.` chart](https://github.com/newrelic/newrelic-k8s-metrics-adapter/tree/main/charts/newrelic-k8s-metrics-adapter) (Beta)
+newrelic-k8s-metrics-adapter:
+  # newrelic-k8s-metrics-adapter.enabled -- Install the [`newrelic-k8s-metrics-adapter.` chart](https://github.com/newrelic/newrelic-k8s-metrics-adapter/tree/main/charts/newrelic-k8s-metrics-adapter) (Beta)
   enabled: false
 
 

--- a/charts/nri-bundle/values.yaml
+++ b/charts/nri-bundle/values.yaml
@@ -14,6 +14,11 @@ kube-state-metrics:
   # kube-state-metrics.enabled -- Install the [`kube-state-metrics` chart from the stable helm charts repository](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics)
   # This is mandatory if `infrastructure.enabled` is set to `true` and the user does not provide its own instance of KSM version >=1.8 and <=2.0
   enabled: false
+  # kube-state-metrics.collectors -- Collectors configuration of kube-state-metric
+  # @default -- See [`values.yaml`](values.yaml) of the kube-state-metric chart
+  collectors:
+    certificatesigningrequests: false
+    ingresses: false
 
 nri-kube-events:
   # nri-kube-events.enabled -- Install the [`nri-kube-events` chart](https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events)
@@ -124,14 +129,6 @@ global:
   # -- (bool) Sets the debug logs to this integration or all integrations if it is set globally
   # @default -- false
   verboseLog:
-
-# The k8s integration is not relying on the following collectors and therefore can be disabled
-kube-state-metrics:
-  # -- Collectors configuration of kube-state-metric
-  # @default -- See [`values.yaml`](values.yaml) of the kube-state-metric chart
-  collectors:
-    certificatesigningrequests: false
-    ingresses: false
 
 
 # To add values to the subcharts. Follow Helm's guide: https://helm.sh/docs/chart_template_guide/subcharts_and_globals


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
It changes the UX on how to enable and configure the charts.
From:
```yaml
infrastructure:
  enabled: true
  
newrelic-infrastructure:
  privileged: true
```
To:
```yaml
newrelic-infrastructure:
  enabled: true
  privileged: true
```


#### Special notes for your reviewer:
This behavior is documented here: https://helm.sh/docs/topics/charts/#tags-and-condition-fields-in-dependencies

As only the first value is evaluated, there is no possibility of doing any type of compatibility layer. That is the reason the legacy value is first for it to be evaluated in case the user changed the value before upgrading.

You cannot test that it does not render. Asserting `hasDocuments.count=0` or using `failedTemplate` in `helm unittest` always return this error:
```
 FAIL  Check defaults	tests/newrelic-infrastructure_test.yaml
	- newrelic-infrastructure do not template with toggles disabled

		- asserts[0] `hasDocuments` fail
			Error:
				template "nri-bundle/charts/newrelic-infrastructure/templates/secret.yaml" not exists or not selected in test suite

	- newrelic-infrastructure old toogle takes precedence

		- asserts[0] `failedTemplate` fail
			Error:
				template "nri-bundle/charts/newrelic-infrastructure/templates/secret.yaml" not exists or not selected in test suite
```

#### Checklist
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
