### PR TITLE
[CI/CD] Fix pipeline to add missing origin

### DIFF
--- a/.github/ct-install.yaml
+++ b/.github/ct-install.yaml
@@ -16,6 +16,7 @@ chart-dirs:
 
 chart-repos:
   - newrelic-helm-charts=https://newrelic.github.io/helm-charts
+  - newrelic-cdn-helm-charts=https://helm-charts.newrelic.com
   - newrelic-infrastructure=https://newrelic.github.io/nri-kubernetes
   - nri-prometheus=https://newrelic.github.io/nri-prometheus
   - nri-metadata-injection=https://newrelic.github.io/k8s-metadata-injection

--- a/.github/ct-lint.yaml
+++ b/.github/ct-lint.yaml
@@ -16,6 +16,7 @@ chart-dirs:
 
 chart-repos:
   - newrelic-helm-charts=https://newrelic.github.io/helm-charts
+  - newrelic-cdn-helm-charts=https://helm-charts.newrelic.com
   - newrelic-infrastructure=https://newrelic.github.io/nri-kubernetes
   - nri-prometheus=https://newrelic.github.io/nri-prometheus
   - nri-metadata-injection=https://newrelic.github.io/k8s-metadata-injection

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Add helm repositories
         run: |
           helm repo add newrelic-helm-charts https://newrelic.github.io/helm-charts
+          helm repo add ewrelic-cdn-helm-charts https://helm-charts.newrelic.com
           helm repo add newrelic-infrastructure https://newrelic.github.io/nri-kubernetes
           helm repo add nri-prometheus https://newrelic.github.io/nri-prometheus
           helm repo add nri-metadata-injection https://newrelic.github.io/k8s-metadata-injection


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Fix pipeline to add missing helm chart origin. Tests are failing on the PR #762. This change should fix it.

#### Checklist
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
