### PR TITLE
[nri-bundle] removing collector to address noisy log

### DIFF
--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -15,7 +15,7 @@ sources:
   - https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie
   - https://github.com/newrelic/newrelic-infra-operator/tree/master/charts/newrelic-infra-operator
 
-version: 4.4.7
+version: 4.4.8
 
 dependencies:
   - name: newrelic-infrastructure

--- a/charts/nri-bundle/README.md
+++ b/charts/nri-bundle/README.md
@@ -1,6 +1,6 @@
 # nri-bundle
 
-![Version: 4.4.6](https://img.shields.io/badge/Version-4.4.6-informational?style=flat-square)
+![Version: 4.4.8](https://img.shields.io/badge/Version-4.4.8-informational?style=flat-square)
 
 A chart groups together the individual charts for the New Relic Kubernetes solution for more comfortable deployment.
 
@@ -116,6 +116,8 @@ honors global options as described below.
 | global.verboseLog | bool | false | Sets the debug logs to this integration or all integrations if it is set globally |
 | infrastructure.enabled | bool | `true` | Install the [`newrelic-infrastructure` chart](https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure) |
 | ksm.enabled | bool | `false` | Install the [`kube-state-metrics` chart from the stable helm charts repository](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics) This is mandatory if `infrastructure.enabled` is set to `true` and the user does not provide its own instance of KSM version >=1.8 and <=2.0 |
+| kube-state-metrics.collectors.certificatesigningrequests | bool | `false` |  |
+| kube-state-metrics.collectors.ingresses | bool | `false` |  |
 | kubeEvents.enabled | bool | `false` | Install the [`nri-kube-events` chart](https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events) |
 | logging.enabled | bool | `false` | Install the [`newrelic-logging` chart](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging) |
 | metrics-adapter.enabled | bool | `false` | Install the [`newrelic-k8s-metrics-adapter.` chart](https://github.com/newrelic/newrelic-k8s-metrics-adapter/tree/main/charts/newrelic-k8s-metrics-adapter) (Beta) |

--- a/charts/nri-bundle/README.md
+++ b/charts/nri-bundle/README.md
@@ -116,8 +116,7 @@ honors global options as described below.
 | global.verboseLog | bool | false | Sets the debug logs to this integration or all integrations if it is set globally |
 | infrastructure.enabled | bool | `true` | Install the [`newrelic-infrastructure` chart](https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure) |
 | ksm.enabled | bool | `false` | Install the [`kube-state-metrics` chart from the stable helm charts repository](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics) This is mandatory if `infrastructure.enabled` is set to `true` and the user does not provide its own instance of KSM version >=1.8 and <=2.0 |
-| kube-state-metrics.collectors.certificatesigningrequests | bool | `false` |  |
-| kube-state-metrics.collectors.ingresses | bool | `false` |  |
+| kube-state-metrics.collectors | object | See [`values.yaml`](values.yaml) of the kube-state-metric chart | Collectors configuration of kube-state-metric |
 | kubeEvents.enabled | bool | `false` | Install the [`nri-kube-events` chart](https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events) |
 | logging.enabled | bool | `false` | Install the [`newrelic-logging` chart](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging) |
 | metrics-adapter.enabled | bool | `false` | Install the [`newrelic-k8s-metrics-adapter.` chart](https://github.com/newrelic/newrelic-k8s-metrics-adapter/tree/main/charts/newrelic-k8s-metrics-adapter) (Beta) |

--- a/charts/nri-bundle/values.yaml
+++ b/charts/nri-bundle/values.yaml
@@ -125,6 +125,15 @@ global:
   # @default -- false
   verboseLog:
 
+# The version we are currently running of KSM is 1.x and it is not fully compatible with newer versions of K8s and a annoying log is generated
+# The k8s integration is not relying on the following collectors that can be disabled
+# https://github.com/newrelic/helm-charts/issues/582
+kube-state-metrics:
+  collectors:
+    certificatesigningrequests: false
+    ingresses: false
+
+
 # To add values to the subcharts. Follow Helm's guide: https://helm.sh/docs/chart_template_guide/subcharts_and_globals
 
 # If you wish to monitor services running on Kubernetes you can provide integrations

--- a/charts/nri-bundle/values.yaml
+++ b/charts/nri-bundle/values.yaml
@@ -125,10 +125,10 @@ global:
   # @default -- false
   verboseLog:
 
-# The version we are currently running of KSM is 1.x and it is not fully compatible with newer versions of K8s and a annoying log is generated
-# The k8s integration is not relying on the following collectors that can be disabled
-# https://github.com/newrelic/helm-charts/issues/582
+# The k8s integration is not relying on the following collectors and therefore can be disabled
 kube-state-metrics:
+  # -- Collectors configuration of kube-state-metric
+  # @default -- See [`values.yaml`](values.yaml) of the kube-state-metric chart
   collectors:
     certificatesigningrequests: false
     ingresses: false


### PR DESCRIPTION

#### Is this a new chart
no
#### What this PR does / why we need it:
In order to remove an annoying log from KSM:
```
I0524 07:33:23.082532       1 builder.go:146] Active collectors: certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
E0524 07:33:23.150180       1 reflector.go:156] pkg/mod/k8s.io/client-go@v0.0.0-20191109102209-3c0d1af94be5/tools/cache/reflector.go:108: Failed to list *v1beta1.CertificateSigningRequest: the server could not find the requested resource
E0524 07:33:23.165645       1 reflector.go:156] pkg/mod/k8s.io/client-go@v0.0.0-20191109102209-3c0d1af94be5/tools/cache/reflector.go:108: Failed to list *v1beta1.Ingress: the server could not find the requested resource (get ingresses.extensions)
E0524 07:33:24.159165       1 reflector.go:156] pkg/mod/k8s.io/client-go@v0.0.0-20191109102209-3c0d1af94be5/tools/cache/reflector.go:108: Failed to list *v1beta1.CertificateSigningRequest: the server could not find the requested resource

```

#### Which issue this PR fixes
fix  https://github.com/newrelic/helm-charts/issues/582


#### Special notes for your reviewer:
Superseeds https://github.com/newrelic/helm-charts/pull/604

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
