### PR TITLE
[nri-bundle] enable KSM and kube-events by default, use custom labels for bundled KSM

### DIFF
--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -16,7 +16,8 @@ sources:
   - https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie
   - https://github.com/newrelic/newrelic-infra-operator/tree/master/charts/newrelic-infra-operator
 
-version: 5.0.2
+
+version: 5.0.3
 
 dependencies:
   - name: newrelic-infrastructure

--- a/charts/nri-bundle/values.yaml
+++ b/charts/nri-bundle/values.yaml
@@ -1,6 +1,10 @@
 newrelic-infrastructure:
   # newrelic-infrastructure.enabled -- Install the [`newrelic-infrastructure` chart](https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure)
   enabled: true
+  ksm:
+    config:
+      # newrelic-infrastructure.ksm.config.selector -- Use the following selector to discover an instance of kube-state-metrics in the cluster.
+      selector: "app.kubernetes.io/name=nrk8s-kube-state-metrics"
 
 nri-prometheus:
   # nri-prometheus.enabled -- Install the [`nri-prometheus` chart](https://github.com/newrelic/nri-prometheus/tree/main/charts/nri-prometheus)
@@ -13,7 +17,9 @@ nri-metadata-injection:
 kube-state-metrics:
   # kube-state-metrics.enabled -- Install the [`kube-state-metrics` chart](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics) from the stable helm charts repository.
   # This is mandatory if `infrastructure.enabled` is set to `true` and the user does not provide its own instance of KSM version >=1.8 and <=2.0
-  enabled: false
+  enabled: true
+  # -- Use the following name and app label for NR-bundled KSM.
+  nameOverride: nrk8s-kube-state-metrics
 
 nri-kube-events:
   # nri-kube-events.enabled -- Install the [`nri-kube-events` chart](https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events)

--- a/charts/nri-bundle/values.yaml
+++ b/charts/nri-bundle/values.yaml
@@ -23,7 +23,7 @@ kube-state-metrics:
 
 nri-kube-events:
   # nri-kube-events.enabled -- Install the [`nri-kube-events` chart](https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events)
-  enabled: true
+  enabled: false
 
 newrelic-logging:
   # newrelic-logging.enabled -- Install the [`newrelic-logging` chart](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging)

--- a/charts/nri-bundle/values.yaml
+++ b/charts/nri-bundle/values.yaml
@@ -23,7 +23,7 @@ kube-state-metrics:
 
 nri-kube-events:
   # nri-kube-events.enabled -- Install the [`nri-kube-events` chart](https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events)
-  enabled: false
+  enabled: true
 
 newrelic-logging:
   # newrelic-logging.enabled -- Install the [`newrelic-logging` chart](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging)


### PR DESCRIPTION
KSM is a mandatory dependency of the infrastructure chart, which is enabled by default. Despite this, KSM was not. This PR makes two changes:
1. Enable KSM by default
2. Change the name of the bundled KSM to a `nrk8s` specific one. This will make autodiscovery to pick the KSM we bundle by default, rather than other KSMs in the cluster.

## ⚠️ Breaking changes

### KSM

Users who were using their own KSM will need to adjust the selector to the default KSM label:

```yaml
newrelic-infrastructure:
  ksm:
    config:
      selector: "app.kubernetes.io/name=kube-state-metrics"
```

### `nri-kube-events`

`nri-kube-events` is now enabled by default, following what the guided install was already doing.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
