### PR TITLE
[nri-bundle] Update newrelic-pixie-integration to 2.0.0

### DIFF
--- a/charts/nri-bundle/Chart.lock
+++ b/charts/nri-bundle/Chart.lock
@@ -22,12 +22,12 @@ dependencies:
   version: 1.10.11
 - name: newrelic-pixie
   repository: https://newrelic.github.io/helm-charts
-  version: 1.5.1
+  version: 2.0.0
 - name: pixie-operator-chart
   repository: https://pixie-operator-charts.storage.googleapis.com
   version: 0.0.26
 - name: newrelic-infra-operator
   repository: https://newrelic.github.io/newrelic-infra-operator
   version: 1.0.3
-digest: sha256:fa01a04d0952052e60ba897d9c6a3343e1d7fb0ba222b41d14e9b9c3bd42325f
-generated: "2022-05-25T13:34:05.331131554Z"
+digest: sha256:6ae10333808adc2dcb34457f345f050d86c4e4d4b10bf00064024a83359add1d
+generated: "2022-05-26T16:42:42.215595+02:00"

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -15,7 +15,7 @@ sources:
   - https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie
   - https://github.com/newrelic/newrelic-infra-operator/tree/master/charts/newrelic-infra-operator
 
-version: 4.5.1
+version: 4.6.0
 
 dependencies:
   - name: newrelic-infrastructure
@@ -56,7 +56,7 @@ dependencies:
   - name: newrelic-pixie
     repository: https://newrelic.github.io/helm-charts
     condition: newrelic-pixie.enabled
-    version: 1.5.1
+    version: 2.0.0
 
   - name: pixie-operator-chart
     alias: pixie-chart


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Bumps the version of the newrelic-pixie-integration chart to 2.0.0

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
