### PR TITLE
Bump newrelic-infrastructure to version 3.6.2

### DIFF
--- a/charts/nri-bundle/Chart.lock
+++ b/charts/nri-bundle/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: newrelic-infrastructure
   repository: https://newrelic.github.io/nri-kubernetes
-  version: 3.5.3
+  version: 3.6.2
 - name: nri-prometheus
   repository: https://newrelic.github.io/nri-prometheus
   version: 2.1.5
@@ -29,5 +29,5 @@ dependencies:
 - name: newrelic-infra-operator
   repository: https://newrelic.github.io/newrelic-infra-operator
   version: 1.0.3
-digest: sha256:da939dba3aaa3d3a45ac2ab2ca7f428f8e0cd5b75d5ad94e408e89429465c3be
-generated: "2022-06-08T15:28:27.151164868Z"
+digest: sha256:58f46ec42b24ceb50860eca6377ce2ef881451e875252730a943cf9c69ace15c
+generated: "2022-06-20T15:13:19.896815+02:00"

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -15,7 +15,7 @@ sources:
   - https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie
   - https://github.com/newrelic/newrelic-infra-operator/tree/master/charts/newrelic-infra-operator
 
-version: 4.5.9
+version: 4.6.0
 
 dependencies:
   - name: newrelic-infrastructure

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -15,13 +15,13 @@ sources:
   - https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie
   - https://github.com/newrelic/newrelic-infra-operator/tree/master/charts/newrelic-infra-operator
 
-version: 4.5.8
+version: 4.5.9
 
 dependencies:
   - name: newrelic-infrastructure
     repository: https://newrelic.github.io/nri-kubernetes
     condition: infrastructure.enabled,newrelic-infrastructure.enabled
-    version: 3.5.3
+    version: 3.6.2
 
   - name: nri-prometheus
     repository: https://newrelic.github.io/nri-prometheus

--- a/charts/nri-bundle/README.md
+++ b/charts/nri-bundle/README.md
@@ -1,6 +1,6 @@
 # nri-bundle
 
-![Version: 4.5.8](https://img.shields.io/badge/Version-4.5.8-informational?style=flat-square)
+![Version: 4.6.0](https://img.shields.io/badge/Version-4.6.0-informational?style=flat-square)
 
 Groups together the individual charts for the New Relic Kubernetes solution for a more comfortable deployment.
 


### PR DESCRIPTION
Bump newrelic-infrastructure to version 3.6.2 that includes namespace filtering.
