### PR TITLE
Update Helm release kube-state-metrics to 4.0.1 (#860)

### DIFF
--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -15,7 +15,7 @@ sources:
   - https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie
   - https://github.com/newrelic/newrelic-infra-operator/tree/master/charts/newrelic-infra-operator
 
-version: 4.6.1
+version: 4.6.2
 
 dependencies:
   - name: newrelic-infrastructure
@@ -39,9 +39,9 @@ dependencies:
     version: 0.7.5
 
   - name: kube-state-metrics
-    repository: https://kubernetes.github.io/kube-state-metrics
+    repository: https://prometheus-community.github.io/helm-charts
     condition: ksm.enabled,kube-state-metrics.enabled
-    version: 2.13.2
+    version: 4.0.1
 
   - name: nri-kube-events
     repository: https://newrelic.github.io/nri-kube-events

--- a/charts/nri-bundle/README.md
+++ b/charts/nri-bundle/README.md
@@ -18,7 +18,7 @@ here is a list of components that this chart installs and where you can find mor
 |------------------------------|-----------------------|-------------|
 | [newrelic-infrastructure](https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure) | Yes | Sends metrics about nodes, cluster objects (e.g. Deployments, Pods), and the control plane to New Relic. |
 | [nri-metadata-injection](https://github.com/newrelic/k8s-metadata-injection/tree/main/charts/nri-metadata-injection) | Yes | Enriches New Relic-instrumented applications (APM) with Kubernetes information. |
-| [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics) | | Required for `newrelic-infrastructure` to gather cluster-level metrics. |
+| [kube-state-metrics](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics) | | Required for `newrelic-infrastructure` to gather cluster-level metrics. |
 | [nri-kube-events](https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events) | | Reports Kubernetes events to New Relic. |
 | [newrelic-infra-operator](https://github.com/newrelic/newrelic-infra-operator/tree/main/charts/newrelic-infra-operator) | | (Beta) Used with Fargate or serverless environments to inject `newrelic-infrastructure` as a sidecar instead of the usual DaemonSet. |
 | [newrelic-k8s-metrics-adapter](https://github.com/newrelic/newrelic-k8s-metrics-adapter/tree/main/charts/newrelic-k8s-metrics-adapter) |  | (Beta) Provides a source of data for Horizontal Pod Autoscalers (HPA) based on a NRQL query from New Relic. |

--- a/charts/nri-bundle/values.yaml
+++ b/charts/nri-bundle/values.yaml
@@ -11,7 +11,7 @@ nri-metadata-injection:
   enabled: true
 
 kube-state-metrics:
-  # kube-state-metrics.enabled -- Install the [`kube-state-metrics` chart](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics) from the stable helm charts repository.
+  # kube-state-metrics.enabled -- Install the [`kube-state-metrics` chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics) from the stable helm charts repository.
   # This is mandatory if `infrastructure.enabled` is set to `true` and the user does not provide its own instance of KSM version >=1.8 and <=2.0
   enabled: false
   # kube-state-metrics.collectors -- Collectors configuration of kube-state-metric

--- a/docs/review_guidelines.md
+++ b/docs/review_guidelines.md
@@ -39,7 +39,7 @@ Breaking (backwards incompatible) changes to a chart must:
 
 We officially support compatibility with the current and the previous minor version of Kubernetes. Generated resources should use the latest possible API versions compatible with these versions.
 
-For extended backwards compatibility, conditional logic based on capabilities may be used (see [built-in objects](https://github.com/helm/helm/blob/master/docs/chart_template_guide/builtin_objects.md)).
+For extended backwards compatibility, conditional logic based on capabilities may be used (see [built-in objects](https://helm.sh/docs/chart_template_guide/builtin_objects)).
 
 ##  4. <a name='Chartmetadata'></a>Chart metadata
 


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR updates `kube-state-metrics` Helm chart to version `4.0.1` which supports Kubernetes from version 1.18 to 1.22

Current chart version supports Kubernetes up to version 1.16

Chart | Update
-- | --
[kube-state-metrics](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics) | 2.13.2 -> 4.0.1

#### Which issue this PR fixes
* #860 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)