### PR TITLE
[newrelic-logging] Upgrade to latest image tag version (1.14.0)

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,18 +1,15 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.10.11
-appVersion: 1.10.0
+version: 1.11.0
+appVersion: 1.14.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:
   - name: jsubirat
     email: logging-team@newrelic.com
-  - name: tejunior
-  - name: jodstrcil
-  - name: edmocosta
-  - name: Noly
   - name: danybmx
+  - name: sdaubin
 keywords:
   - logging
   - newrelic


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
- Upgrades `newrelic-logging` to use the latest available image tag `1.14.0`, which includes Fluent Bit 1.9.4.

#### Which issue this PR fixes
Kubernetes 1.21+ enforces Service Account tokens to be refreshed every hour, as explained [here](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-1.21).

The `newrelic-logging` DaemonSet is based on the `newrelic/newrelic-fluent-bit-output` image, which in turn is based on the `fluent/fluent-bit` one. We basically run Fluent Bit and we use its `kubernetes` filter [plugin](https://docs.fluentbit.io/manual/pipeline/filters/kubernetes), which basically asks the K8s for pod metadata each time a new pod is launched. This metadata is used to enrich the forwarded logs.

Fluent Bit versions prior to 1.9.4 did not perform the ServiceAccount token refresh by default. This caused that our current version of the plugin, which uses `newrelic/newrelic-fluent-bit-output:1.10.0`, gets the following warnings in the K8s API audit logs when running in an EKS cluster for more than 1 hour:

![Screen Shot 2022-06-22 at 7 52 16 PM](https://user-images.githubusercontent.com/6243832/175104053-36822f93-4327-472f-bf35-71bfc9b1b2d2.png)

With Fluent Bit 1.9.4 (included in `newrelic/newrelic-fluent-bit-output:1.14.0`), this token gets refreshed automatically. I tested it by deploying the helm chart to two separate clusters running Kubernetes 1.22. After running for more than 1 hour, I deployed a new pod and observed how the current version of the Helm chart displayed the previous message in the K8s API Audit logs, while the new one didn't.

#### Special notes for your reviewer:
Also took the chance to update the code owners of the Helm chart

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
