### PR TITLE
Bump chart and newrelic-infrastructure versions

### DIFF
--- a/charts/nri-bundle/Chart.lock
+++ b/charts/nri-bundle/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: newrelic-infrastructure
   repository: https://newrelic.github.io/nri-kubernetes
-  version: 3.6.2
+  version: 3.7.0
 - name: nri-prometheus
   repository: https://newrelic.github.io/nri-prometheus
   version: 2.1.6
@@ -29,5 +29,5 @@ dependencies:
 - name: newrelic-infra-operator
   repository: https://newrelic.github.io/newrelic-infra-operator
   version: 1.0.3
-digest: sha256:b463566e38953d1ccb4f03238c736f02631b1e7299b30912df7f86e448d2b4c0
-generated: "2022-06-24T01:10:57.997963179Z"
+digest: sha256:26b9a1751a349225491b28ee7849e11eb1ffed0858904d80957ad4801bc60c64
+generated: "2022-07-05T16:58:58.043711+02:00"

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -15,13 +15,13 @@ sources:
   - https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie
   - https://github.com/newrelic/newrelic-infra-operator/tree/master/charts/newrelic-infra-operator
 
-version: 4.6.2
+version: 4.7.0
 
 dependencies:
   - name: newrelic-infrastructure
     repository: https://newrelic.github.io/nri-kubernetes
     condition: infrastructure.enabled,newrelic-infrastructure.enabled
-    version: 3.6.2
+    version: 3.7.0
 
   - name: nri-prometheus
     repository: https://newrelic.github.io/nri-prometheus

--- a/charts/nri-bundle/README.md
+++ b/charts/nri-bundle/README.md
@@ -1,6 +1,6 @@
 # nri-bundle
 
-![Version: 4.6.0](https://img.shields.io/badge/Version-4.6.0-informational?style=flat-square)
+![Version: 4.7.0](https://img.shields.io/badge/Version-4.7.0-informational?style=flat-square)
 
 Groups together the individual charts for the New Relic Kubernetes solution for a more comfortable deployment.
 


### PR DESCRIPTION
Bump chart & newrelic-infrastructure to version 3.7.0 including new metrics added in k8s v1.23 & v.1.24.

Related to https://github.com/newrelic/nri-kubernetes/pull/510.