### PR TITLE
[newrelic-logging] Fix missing K8S_BUFFER_SIZE on Windows Helm chart

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.11.0
+version: 1.11.1
 appVersion: 1.14.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/templates/daemonset-windows.yaml
+++ b/charts/newrelic-logging/templates/daemonset-windows.yaml
@@ -85,6 +85,8 @@ spec:
               value: {{ $.Values.fluentBit.windowsDb | quote }}
             - name: PATH
               value: {{ $.Values.fluentBit.windowsPath | quote }}
+            - name: K8S_BUFFER_SIZE
+              value: {{ $.Values.fluentBit.k8sBufferSize | quote }}
             - name: K8S_LOGGING_EXCLUDE
               value: {{ $.Values.fluentBit.k8sLoggingExclude | quote }}
             - name: LOW_DATA_MODE


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Fixes a warning message present in the Windows DaemonSet, due to a leftover of [this previous PR](https://github.com/newrelic/helm-charts/pull/621).

#### Which issue this PR fixes
None

#### Special notes for your reviewer:
Harmless change, just propagating an additional env variable to the Windows containers.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
