### PR TITLE
[newrelic-logging] Add global service account

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.11.2
+version: 1.11.3
 appVersion: 1.14.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/templates/_helpers.tpl
+++ b/charts/newrelic-logging/templates/_helpers.tpl
@@ -36,17 +36,6 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{/*
-Create the name of the service account to use
-*/}}
-{{- define "newrelic-logging.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{ default (include "newrelic-logging.fullname" .) .Values.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
-
 
 {{/*
 Create the name of the fluent bit config

--- a/charts/newrelic-logging/templates/clusterrolebinding.yaml
+++ b/charts/newrelic-logging/templates/clusterrolebinding.yaml
@@ -10,6 +10,6 @@ roleRef:
   name: {{ template "newrelic-logging.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "newrelic-logging.serviceAccountName" . }}
+  name: {{ include "newrelic.common.serviceAccount.name" . }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/charts/newrelic-logging/templates/daemonset-windows.yaml
+++ b/charts/newrelic-logging/templates/daemonset-windows.yaml
@@ -35,7 +35,7 @@ spec:
 {{ toYaml $.Values.podLabels | indent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ template "newrelic-logging.serviceAccountName" $ }}
+      serviceAccountName: {{ include "newrelic.common.serviceAccount.name" $ }}
       hostNetwork: false
       dnsPolicy: ClusterFirst
       terminationGracePeriodSeconds: 10

--- a/charts/newrelic-logging/templates/daemonset.yaml
+++ b/charts/newrelic-logging/templates/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         {{ toYaml .Values.podLabels }}
         {{- end }}
     spec:
-      serviceAccountName: {{ template "newrelic-logging.serviceAccountName" . }}
+      serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}
       hostNetwork: true # This option is a requirement for the Infrastructure Agent to report the proper hostname in New Relic.
       dnsPolicy: ClusterFirstWithHostNet
       terminationGracePeriodSeconds: 10

--- a/charts/newrelic-logging/templates/serviceaccount.yaml
+++ b/charts/newrelic-logging/templates/serviceaccount.yaml
@@ -1,16 +1,17 @@
-{{- if .Values.serviceAccount.create }}
+{{- if include "newrelic.common.serviceAccount.create" . -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: {{ .Release.Namespace }}
+  {{- if include "newrelic.common.serviceAccount.annotations" . }}
+  annotations:
+    {{- include "newrelic.common.serviceAccount.annotations" . | nindent 4 }}
+  {{- end }}
   labels:
     app: {{ template "newrelic-logging.name" . }}
     chart: {{ template "newrelic-logging.chart" . }}
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-  annotations:
-  {{- if .Values.serviceAccount.annotations }}
-{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
-  {{- end }}
-  name: {{ template "newrelic-logging.serviceAccountName" . }}
-{{- end -}}
+    {{- /*include "newrelic.common.labels" . | nindent 4  /!\ Breaking change /!\ */}}
+  name: {{ include "newrelic.common.serviceAccount.name" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/newrelic-logging/tests/rbac_test.yaml
+++ b/charts/newrelic-logging/tests/rbac_test.yaml
@@ -38,7 +38,7 @@ tests:
           path: subjects[0].name
           value: sa-test
 
-  - it: RBAC points to the service account the user supplies when serviceAccount is disabled
+  - it: RBAC points to the default service account when serviceAccount is disabled
     set:
       rbac.create: true
       serviceAccount.create: false

--- a/charts/newrelic-logging/tests/rbac_test.yaml
+++ b/charts/newrelic-logging/tests/rbac_test.yaml
@@ -1,0 +1,48 @@
+suite: test RBAC creation
+templates:
+  - templates/clusterrolebinding.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+tests:
+  - it: template rbac if it is configured to do it
+    set:
+      rbac.create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: don't template rbac if it is disabled
+    set:
+      rbac.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: RBAC points to the service account that is created by default
+    set:
+      rbac.create: true
+      serviceAccount.create: true
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: my-release-newrelic-logging
+
+  - it: RBAC points to the service account the user supplies when serviceAccount is disabled
+    set:
+      rbac.create: true
+      serviceAccount.create: false
+      serviceAccount.name: sa-test
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: sa-test
+
+  - it: RBAC points to the service account the user supplies when serviceAccount is disabled
+    set:
+      rbac.create: true
+      serviceAccount.create: false
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: default

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -169,7 +169,7 @@ rbac:
 
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
-  create: true
+  create:
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
There is an issue open by GTS saying that not all the charts honor the flag `.global.serviceAccount.create` and `.global.serviceAccount.name`: #875

So at the same time I was reviewing all the charts we maintain, I made also the PR to support the logging chart too.

Enjoy :)

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
