### PR TITLE
[common-library] fix truncate to dns corner case

### DIFF
--- a/library/CHART-TEMPLATE/Chart.lock
+++ b/library/CHART-TEMPLATE/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: file://../common-library
-  version: 1.0.5
-digest: sha256:df42094293c21493f7710b00599b18b2f93a2c0f07ea5837fbed968ff32a31ef
-generated: "2022-07-13T09:22:20.095674+02:00"
+  version: 1.0.6
+digest: sha256:f76cedabc329ad14befdc86dec7f968db42cbdcbc4959189652a824297d93e9a
+generated: "2022-08-29T08:57:22.453876+02:00"

--- a/library/CHART-TEMPLATE/Chart.yaml
+++ b/library/CHART-TEMPLATE/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,7 +25,7 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: common-library
-    version: 1.0.5
+    version: 1.0.6
     repository: file://../common-library  # We keep this as a file to test things immediately locally/in the pipeline
 
 keywords:

--- a/library/CHART-TEMPLATE/tests/cl-naming_suffix_test.yaml
+++ b/library/CHART-TEMPLATE/tests/cl-naming_suffix_test.yaml
@@ -15,11 +15,11 @@ tests:
 
   - it: name is truncated but suffix included
     set:
-      fullnameOverride: including-full-name-as-it-is-would-be-way-be-longer-than-limit
+      fullnameOverride: including-full-name-as-it-is-would-be-way-longer-than-limit
     asserts:
       - equal:
           path: metadata.name
-          value: including-full-name-as-it-is-would-be-way-be-longer-job-suffix
+          value: including-full-name-as-it-is-would-be-way-longer-tha-job-suffix
 
   - it: suffix is longer than maximum length supported
     set:

--- a/library/CHART-TEMPLATE/tests/cl-naming_suffix_test.yaml
+++ b/library/CHART-TEMPLATE/tests/cl-naming_suffix_test.yaml
@@ -15,17 +15,17 @@ tests:
 
   - it: name is truncated but suffix included
     set:
-      fullnameOverride: including-full-name-as-it-is-would-way-be-longer-than-limit
+      fullnameOverride: including-full-name-as-it-is-would-be-way-be-longer-than-limit
     asserts:
       - equal:
           path: metadata.name
-          value: including-full-name-as-it-is-would-way-be-longer-than-job-suffix
+          value: including-full-name-as-it-is-would-be-way-be-longer-job-suffix
 
   - it: suffix is longer than maximum length supported
     set:
       fullnameOverride: fno
-      jobSuffix: this-job-suffix-is-too-long-so-it-is-not-possible-to-include-at-it-is
+      jobSuffix: this-job-suffix-is-too-long-so-it-is-not-possible-to-include-as-it-is
     asserts:
       - equal:
           path: metadata.name
-          value: this-job-suffix-is-too-long-so-it-is-not-possible-to-include-at
+          value: this-job-suffix-is-too-long-so-it-is-not-possible-to-include-as

--- a/library/CHART-TEMPLATE/tests/cl-naming_suffix_test.yaml
+++ b/library/CHART-TEMPLATE/tests/cl-naming_suffix_test.yaml
@@ -29,3 +29,39 @@ tests:
       - equal:
           path: metadata.name
           value: this-job-suffix-is-too-long-so-it-is-not-possible-to-include-as
+
+  - it: name has 62 chars
+    set:
+      fullnameOverride: name-with-sixty-two-chars-to-check-possible-edge-case-included
+      jobSuffix: regular-suffix
+    asserts:
+      - equal:
+          path: metadata.name
+          value: name-with-sixty-two-chars-to-check-possible-edge-regular-suffix
+
+  - it: name has 63 chars
+    set:
+      fullnameOverride: another-name-with-sixty-three-chars-to-check-possible-edge-case
+      jobSuffix: regular-suffix
+    asserts:
+      - equal:
+          path: metadata.name
+          value: another-name-with-sixty-three-chars-to-check-pos-regular-suffix
+
+  - it: suffix has 62 characters (only suffix is taken because a hyphen would be also included)
+    set:
+      fullnameOverride: another-name-with-sixty-three-chars-to-check-possible-edge-case
+      jobSuffix: superb-suffix-with-sixty-two-chars-to-check-possible-edge-case
+    asserts:
+      - equal:
+          path: metadata.name
+          value: superb-suffix-with-sixty-two-chars-to-check-possible-edge-case
+
+  - it: suffix has 63 characters (only suffix is taken)
+    set:
+      fullnameOverride: another-name-with-sixty-three-chars-to-check-possible-edge-case
+      jobSuffix: there-suffix-with-sixty-three-chars-to-check-possible-edge-case
+    asserts:
+      - equal:
+          path: metadata.name
+          value: there-suffix-with-sixty-three-chars-to-check-possible-edge-case

--- a/library/common-library/Chart.yaml
+++ b/library/common-library/Chart.yaml
@@ -3,7 +3,7 @@ name: common-library
 description: Provides helpers to provide consistency on all the charts
 
 type: library
-version: 1.0.5
+version: 1.0.6
 
 keywords:
   - newrelic

--- a/library/common-library/templates/_naming.tpl
+++ b/library/common-library/templates/_naming.tpl
@@ -17,7 +17,7 @@ Usage:
 */ -}}
 {{- define "newrelic.common.naming.truncateToDNSWithSuffix" -}}
 {{- $suffix := (include "newrelic.common.naming.truncateToDNS" .suffix) -}}
-{{- $maxLen := (sub 63 (len $suffix)) -}}
+{{- $maxLen := (max (sub 63 (add1 (len $suffix))) 0) -}} {{- /* We prepend "-" to the suffix so an additional character is needed */ -}}
 
 {{- $newName := .name | trunc ($maxLen | int) | trimSuffix "-"  -}}
 {{- if $newName -}}

--- a/library/common-library/templates/_serviceaccount.tpl
+++ b/library/common-library/templates/_serviceaccount.tpl
@@ -9,7 +9,7 @@
         {{- if .Values.serviceAccount.create -}}
             {{- /*
                 We want only to return when this is true, returning `false` here will template "false" (string) when doing
-                an `(include "newrelic-logging.serviceAccount" .)`, which is not an "empty string" so it is `true` if it is used
+                an `(include "newrelic.common.serviceAccount.name" .)`, which is not an "empty string" so it is `true` if it is used
                 as an evaluation somewhere else.
             */ -}}
             {{- .Values.serviceAccount.create -}}


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
It fixes a bug in the common.library's  `truncateToDNSWithSuffix` helper.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #902 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
