### PR TITLE
[newrelic-logging] DaemonSet - Set HOSTNAME explicitely

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.11.3
+version: 1.11.4
 appVersion: 1.14.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/templates/daemonset.yaml
+++ b/charts/newrelic-logging/templates/daemonset.yaml
@@ -148,7 +148,7 @@ spec:
         # We add this only if Windows is enabled to keep backwards-compatibility. Prior to version 1.14, this label was
         # named beta.kubernetes.io/os. In version 1.14, it was deprecated and replaced by this one. Version 1.14 also
         # introduces Windows support. Therefore, anyone wishing to use Windows containers must bet at version >=1.14 and
-        # are going to need this label, in order to avoid placing a linux container on a windows node, and viceversa.
+        # are going to need this label, in order to avoid placing a linux container on a windows node, and vice-versa.
         kubernetes.io/os: linux
         {{- end }}
       {{- if .Values.tolerations }}

--- a/charts/newrelic-logging/templates/daemonset.yaml
+++ b/charts/newrelic-logging/templates/daemonset.yaml
@@ -94,6 +94,10 @@ spec:
               value: {{ .Values.fluentBit.k8sLoggingExclude | quote }}
             - name: LOW_DATA_MODE
               value: {{ include "newrelic-logging.lowDataMode" . | default "false" | quote }}
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             {{- range .Values.fluentBit.additionalEnvVariables }}
             - name: {{ .name }}
               value: {{ .value }}


### PR DESCRIPTION
https://github.com/newrelic/helm-charts/issues/81

  - Since `hostNetwork` is set to `true`, the env var `HOSTNAME` needs to also
  be explicitely set

https://github.com/fluent/fluent-bit/issues/850#issuecomment-536249449

- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] Bump version
