### PR TITLE
[nri-bundle] Update `newrelic-logging` version to `v1.11.5`

### DIFF
--- a/charts/nri-bundle/Chart.lock
+++ b/charts/nri-bundle/Chart.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 2.2.5
 - name: newrelic-logging
   repository: https://newrelic.github.io/helm-charts
-  version: 1.11.3
+  version: 1.11.5
 - name: newrelic-pixie
   repository: https://newrelic.github.io/helm-charts
   version: 2.0.1
@@ -29,5 +29,5 @@ dependencies:
 - name: newrelic-infra-operator
   repository: https://newrelic.github.io/newrelic-infra-operator
   version: 1.0.5
-digest: sha256:dd83b4c99b71ce664228dde5087ee9f3d899ed60d63b253adaeb9d0be44f9f88
-generated: "2022-08-22T07:46:37.312932948Z"
+digest: sha256:47bdd4028bc5c3cebd3408f300b484227d9d7b454c8362a8f3d42083f1cc95b1
+generated: "2022-08-29T14:49:00.555795+02:00"

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -15,7 +15,7 @@ sources:
   - https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie
   - https://github.com/newrelic/newrelic-infra-operator/tree/master/charts/newrelic-infra-operator
 
-version: 4.8.2
+version: 4.8.3
 
 dependencies:
   - name: newrelic-infrastructure
@@ -51,7 +51,7 @@ dependencies:
   - name: newrelic-logging
     repository: https://newrelic.github.io/helm-charts
     condition: logging.enabled,newrelic-logging.enabled
-    version: 1.11.3
+    version: 1.11.5
 
   - name: newrelic-pixie
     repository: https://newrelic.github.io/helm-charts


### PR DESCRIPTION
Update `newrelic-logging` dependency in `nri-bundle` and bump version

#### Checklist

- [x] Chart Version bumped
