### PR TITLE
[CI] Test `nri-bundle` integrity

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,11 +13,12 @@
   ],
   "packageRules": [
     {
-      // Group all GHA bumps together in a single PR.
-      "matchManagers": [
-        "github-actions"
+      // Group all nri-bundle dependencies together in a single PR.
+      "matchPackageNames": [
+        "newrelic-infrastructure"
       ],
-      "groupName": "Github Actions"
+      "groupName": "Bundle dependencies",
+      "groupSlug": "nri-bundle-dependencies"
     },
     {
       // Disable major updates of Kube State Metrics.
@@ -50,5 +51,5 @@
       ],
       "enabled": true
     }
-  ],
+  ]
 }

--- a/.github/workflows/lint_test_charts.yaml
+++ b/.github/workflows/lint_test_charts.yaml
@@ -19,25 +19,26 @@ jobs:
   lint-test:
     name: Lint and test charts
     runs-on: ubuntu-latest
+    outputs:
+      charts-changed: ${{ steps.changed.outputs.charts }}
+      bundle-changed: ${{ steps.changed.outputs.bundle }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
-      - uses: azure/setup-helm@v1
       - uses: actions/setup-python@v2
-
-      - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.1.0
+      - uses: helm/chart-testing-action@v2.1.0
+      - uses: azure/setup-helm@v3
+        with:
+          version: 'v3.0.0'
 
       - name: Set up helm-unittest
-        run: |
-          helm plugin install https://github.com/quintush/helm-unittest
+        run: helm plugin install https://github.com/quintush/helm-unittest
 
       - name: Lint charts
-        run: |
-          ct lint --config .github/ct-lint.yaml
+        run: ct lint --config .github/ct-lint.yaml
 
       - name: Run unit tests
         run: |
@@ -48,12 +49,34 @@ jobs:
           done
 
       - name: Check for changed installable charts
-        id: list-changed
+        id: changed
         run: |
-          changed=$(ct list-changed --config .github/ct-install.yaml)
-          if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+          set -x
+          charts=$(ct list-changed --config .github/ct-install.yaml)
+
+          if [[ -n "$charts" ]]; then
+            echo "::set-output name=charts::true"
           fi
+          if [[ -n "$(echo -n "$charts" | grep charts/nri-bundle)" ]]; then
+            echo "::set-output name=bundle-changed::true"
+          fi
+
+  install-test:
+    name: Test chart installability
+    runs-on: ubuntu-latest
+    if: ${{ needs.lint-test.outputs.charts-changed == 'true' }}
+    needs: [ lint-test ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v2
+      - uses: helm/chart-testing-action@v2.1.0
+      - uses: azure/setup-helm@v3
+        with:
+          version: 'v3.0.0'
 
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'
@@ -66,3 +89,56 @@ jobs:
         run: ct install --namespace ct --config .github/ct-install.yaml
       - name: Test upgrade charts
         run: ct install --namespace ct --config .github/ct-install.yaml --upgrade
+
+  bundle-integrity:
+    name: Test nri-bundle dependencies has the same version of the common-library
+    runs-on: ubuntu-latest
+    if: ${{ needs.lint-test.outputs.bundle-changed == 'true' }}
+    needs: [ lint-test ]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/setup-helm@v3
+        with:
+          version: 'v3.0.0'
+
+      - name: Add helm repositories
+        run: |
+          helm repo add newrelic-helm-charts https://newrelic.github.io/helm-charts
+          helm repo add newrelic-cdn-helm-charts https://helm-charts.newrelic.com
+          helm repo add newrelic-infrastructure https://newrelic.github.io/nri-kubernetes
+          helm repo add nri-prometheus https://newrelic.github.io/nri-prometheus
+          helm repo add nri-metadata-injection https://newrelic.github.io/k8s-metadata-injection
+          helm repo add newrelic-k8s-metrics-adapter https://newrelic.github.io/newrelic-k8s-metrics-adapter
+          helm repo add kube-state-metrics https://kubernetes.github.io/kube-state-metrics
+          helm repo add nri-kube-events https://newrelic.github.io/nri-kube-events
+          helm repo add pixie-operator-chart https://pixie-operator-charts.storage.googleapis.com
+          helm repo add newrelic-infra-operator https://newrelic.github.io/newrelic-infra-operator
+
+      - name: Build nri-bundle dependencies
+        run: helm dependency update ./charts/nri-bundle
+
+      - name: Decompress nri-bundle and all its dependencies recursively
+        run: |
+          while [ `find charts/nri-bundle -name \*.tgz -or -name \*.tar.gz | wc -l` -gt 0 ]; do
+            find charts/nri-bundle -name \*.tgz -or -name \*.tar.gz | while read line; do
+              echo "Decompressing $line..."
+              tar xzf "$line" -C $(dirname "$line")
+              echo "Removing $line..."
+              rm "$line"
+            done
+          done
+
+      - name: Find versions of the common library
+        run: |
+          (
+            echo CHART NAME: common-library VERSION
+            find charts/nri-bundle -name Chart.yaml | \
+              xargs yq eval-all '{ .name: (.dependencies | map(select(contains({"name": "common-library"}))) | .[].version ) }' | \
+              tee versions.txt;
+          ) | column -t -s:
+
+          echo ""
+          echo Versions of the common library detected:
+          cut -d\  -f2 versions.txt | sort -u
+
+          [ $(cut -d\  -f2 versions.txt | sort -u | wc -l) -eq 1 ] || exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Add helm repositories
         run: |
           helm repo add newrelic-helm-charts https://newrelic.github.io/helm-charts
-          helm repo add ewrelic-cdn-helm-charts https://helm-charts.newrelic.com
+          helm repo add newrelic-cdn-helm-charts https://helm-charts.newrelic.com
           helm repo add newrelic-infrastructure https://newrelic.github.io/nri-kubernetes
           helm repo add nri-prometheus https://newrelic.github.io/nri-prometheus
           helm repo add nri-metadata-injection https://newrelic.github.io/k8s-metadata-injection


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
We need that all the dependencies of the `nri-bundle` have the same version of the `common-library`. For that, the PRs of dependencies of the `nri-bundle` must be grouped in the same PR by renovatebot and we should parse the dependencies for the versions and compare them.

#### Which issue this PR fixes
  - fixes #883

#### Checklist
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
