### PR TITLE
[CI] Fix step detection for `nri-bundle` and installability tests

### DIFF
--- a/.github/workflows/lint_test_charts.yaml
+++ b/.github/workflows/lint_test_charts.yaml
@@ -58,7 +58,7 @@ jobs:
             echo "::set-output name=charts::true"
           fi
           if [[ -n "$(echo -n "$charts" | grep charts/nri-bundle)" ]]; then
-            echo "::set-output name=bundle-changed::true"
+            echo "::set-output name=bundle::true"
           fi
 
   install-test:
@@ -79,10 +79,8 @@ jobs:
           version: 'v3.0.0'
 
       - name: Create kind cluster
-        if: steps.list-changed.outputs.changed == 'true'
         uses: helm/kind-action@v1.2.0
       - name: Create test ns
-        if: steps.list-changed.outputs.changed == 'true'
         run: kubectl create ns ct
 
       - name: Test install charts


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
I YOLOed and failed in PR #927

So this time I did proper testing:
 - A PR that triggers a [change in the logging chart](https://github.com/newrelic/helm-charts/pull/927) ([workflow run](https://github.com/newrelic/helm-charts/runs/8091326290?check_suite_focus=true))
 - A PR that triggers a [change in the bundle](https://github.com/newrelic/helm-charts/pull/926) ([workflow run](https://github.com/newrelic/helm-charts/runs/8091342518?check_suite_focus=true))

Both of the PRs include the hotfix commit I did in this branch.

About renovatebot, I triggered a re-run in all open PRs that involve the `common-library` and it seems that it is not grouping them or will not update the PR that is already open. I will cover that fix in other PR to ease the review.