### PR TITLE
[synthetics-job-manager] fix: enable dependencies in parent chart

### DIFF
--- a/charts/synthetics-job-manager/Chart.yaml
+++ b/charts/synthetics-job-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: synthetics-job-manager
 description: New Relic Synthetics Containerized Job Manager
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: release-155
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:

--- a/charts/synthetics-job-manager/values.yaml
+++ b/charts/synthetics-job-manager/values.yaml
@@ -195,7 +195,7 @@ ping-runtime:
 
 
 node-api-runtime:
-  enabled: false
+  enabled: true
 
   # Set this to the maximum number of node-api-runtime jobs you expect to run per minute
   parallelism: 1
@@ -256,7 +256,7 @@ node-api-runtime:
 
 
 node-browser-runtime:
-  enabled: false
+  enabled: true
 
   # Set this to the maximum number of node-browser-runtime jobs you expect to run per minute
   parallelism: 1


### PR DESCRIPTION
#### Is this a new chart
No
#### What this PR does / why we need it:
This enables the two dependencies that the synthetics-job-manager needs to be able to run Browser and API jobs out-of-the-box. Currently customers must explicitly enable them, which makes the helm install command more confusing.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
