### PR TITLE
[synthetics-job-manager] Allow configuration of `completions` for node-api-runtime and node-browser-runtime jobs

### DIFF
--- a/charts/synthetics-job-manager/Chart.yaml
+++ b/charts/synthetics-job-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: synthetics-job-manager
 description: New Relic Synthetics Containerized Job Manager
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: release-155
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
@@ -26,8 +26,8 @@ dependencies:
     version: 1.0.1
     condition: ping-runtime.enabled
   - name: node-api-runtime
-    version: 1.0.2
+    version: 1.0.3
     condition: node-api-runtime.enabled
   - name: node-browser-runtime
-    version: 1.0.2
+    version: 1.0.3
     condition: node-browser-runtime.enabled

--- a/charts/synthetics-job-manager/README.md
+++ b/charts/synthetics-job-manager/README.md
@@ -74,48 +74,50 @@ This chart will deploy the New Relic Synthetics Containerized Private Job Manage
 
 ### Node API Runtime Configuration
 
-| Parameter                              | Description                                                                                                   | Default                                |
-|----------------------------------------|---------------------------------------------------------------------------------------------------------------|----------------------------------------|
-| `node-api-runtime.parallelism`         | Number of node-api-runtime replicas to maintain                                                               | `1`                                    |
-| `node-api-runtime.imagePullSecrets`    | The name of a Secret object used to pull an image from a specified container registry                         |                                        |
-| `node-api-runtime.nameOverride`        | The nameOverride replaces the name of the chart in the Chart.yaml file.                                       |                                        |
-| `node-api-runtime.fullnameOverride`    | Name override used for your installation in place of the default                                              |                                        |
-| `node-api-runtime.appVersionOverride`  | Release version of node-api-runtime to use in place of the version specified in [Chart.yaml](Chart.yaml)      |                                        |
-| `node-api-runtime.image.repository`    | The container to pull.                                                                                        | `newrelic/synthetics-node-api-runtime` |
-| `node-api-runtime.image.pullPolicy`    | The pull policy.                                                                                              | `IfNotPresent`                         |
-| `node-api-runtime.appArmorProfileName` | *(Not yet supported)* Name of an AppArmor profile to load.                                                                          |                                        |
-| `node-api-runtime.resources`           | Resource requests and limits.                                                                                 |                                        |
-| `node-api-runtime.podAnnotations`      | Annotations to be added to the node-api-runtime pod                                                           |                                        |
-| `node-api-runtime.podSecurityContext`  | Custom security context for the node-api-runtime pod                                                          |                                        |
-| `node-api-runtime.securityContext`     | Custom security context for the node-api-runtime containers                                                   |                                        |
-| `node-api-runtime.labels`              | labels to be added to all node-api-runtime resources                                                          |                                        |
-| `node-api-runtime.annotations`         | Annotations to be added to the node-api-runtime pod                                                           |                                        |
-| `node-api-runtime.nodeSelector`        | Node labels for node-api-runtime pod assignment                                                               |                                        |
-| `node-api-runtime.tolerations`         | Node taints to tolerate for node-api-runtime                                                                  |                                        |
-| `node-api-runtime.affinity`            | Pod affinity for node-api-runtime                                                                             |                                        |
+| Parameter                              | Description                                                                                                            | Default                                |
+|----------------------------------------|------------------------------------------------------------------------------------------------------------------------|----------------------------------------|
+| `node-api-runtime.parallelism`         | Number of node-api-runtime jobs to execute in parallel                                                                 | `1`                                    |
+| `node-api-runtime.completions`         | Number of node-api-runtime jobs that you expect to execute per minute (multiplied by the value of `parallelism` above) | `6`                                    |
+| `node-api-runtime.imagePullSecrets`    | The name of a Secret object used to pull an image from a specified container registry                                  |                                        |
+| `node-api-runtime.nameOverride`        | The nameOverride replaces the name of the chart in the Chart.yaml file.                                                |                                        |
+| `node-api-runtime.fullnameOverride`    | Name override used for your installation in place of the default                                                       |                                        |
+| `node-api-runtime.appVersionOverride`  | Release version of node-api-runtime to use in place of the version specified in [Chart.yaml](Chart.yaml)               |                                        |
+| `node-api-runtime.image.repository`    | The container to pull.                                                                                                 | `newrelic/synthetics-node-api-runtime` |
+| `node-api-runtime.image.pullPolicy`    | The pull policy.                                                                                                       | `IfNotPresent`                         |
+| `node-api-runtime.appArmorProfileName` | *(Not yet supported)* Name of an AppArmor profile to load.                                                             |                                        |
+| `node-api-runtime.resources`           | Resource requests and limits.                                                                                          |                                        |
+| `node-api-runtime.podAnnotations`      | Annotations to be added to the node-api-runtime pod                                                                    |                                        |
+| `node-api-runtime.podSecurityContext`  | Custom security context for the node-api-runtime pod                                                                   |                                        |
+| `node-api-runtime.securityContext`     | Custom security context for the node-api-runtime containers                                                            |                                        |
+| `node-api-runtime.labels`              | labels to be added to all node-api-runtime resources                                                                   |                                        |
+| `node-api-runtime.annotations`         | Annotations to be added to the node-api-runtime pod                                                                    |                                        |
+| `node-api-runtime.nodeSelector`        | Node labels for node-api-runtime pod assignment                                                                        |                                        |
+| `node-api-runtime.tolerations`         | Node taints to tolerate for node-api-runtime                                                                           |                                        |
+| `node-api-runtime.affinity`            | Pod affinity for node-api-runtime                                                                                      |                                        |
 
 
 ### Node Browser Runtime Configuration
 
-| Parameter                                  | Description                                                                                                   | Default                                    |
-|--------------------------------------------|---------------------------------------------------------------------------------------------------------------|--------------------------------------------|
-| `node-browser-runtime.parallelism`         | Number of node-browser-runtime replicas to maintain                                                           | `1`                                        |
-| `node-browser-runtime.imagePullSecrets`    | The name of a Secret object used to pull an image from a specified container registry                         |                                            |
-| `node-browser-runtime.nameOverride`        | The nameOverride replaces the name of the chart in the Chart.yaml file.                                       |                                            |
-| `node-browser-runtime.fullnameOverride`    | Name override used for your installation in place of the default                                              |                                            |
-| `node-browser-runtime.appVersionOverride`  | Release version of node-browser-runtime to use in place of the version specified in [Chart.yaml](Chart.yaml)  |                                            |
-| `node-browser-runtime.image.repository`    | The container to pull.                                                                                        | `newrelic/synthetics-node-browser-runtime` |
-| `node-browser-runtime.image.pullPolicy`    | The pull policy.                                                                                              | `IfNotPresent`                             |
-| `node-browser-runtime.appArmorProfileName` | *(Not yet supported)* Name of an AppArmor profile to load.                                                                          |                                            |
-| `node-browser-runtime.resources`           | Resource requests and limits.                                                                                 |                                            |
-| `node-browser-runtime.podAnnotations`      | Annotations to be added to the node-browser-runtime pod                                                       |                                            |
-| `node-browser-runtime.podSecurityContext`  | Custom security context for the node-browser-runtime pod                                                      |                                            |
-| `node-browser-runtime.securityContext`     | Custom security context for the node-browser-runtime containers                                               |                                            |
-| `node-browser-runtime.labels`              | labels to be added to all node-browser-runtime resources                                                      |                                            |
-| `node-browser-runtime.annotations`         | Annotations to be added to the node-browser-runtime pod                                                       |                                            |
-| `node-browser-runtime.nodeSelector`        | Node labels for node-browser-runtime pod assignment                                                           |                                            |
-| `node-browser-runtime.tolerations`         | Node taints to tolerate for node-browser-runtime                                                              |                                            |
-| `node-browser-runtime.affinity`            | Pod affinity for node-browser-runtime                                                                         |                                            |
+| Parameter                                  | Description                                                                                                                | Default                                    |
+|--------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|--------------------------------------------|
+| `node-browser-runtime.parallelism`         | Number of node-browser-runtime jobs to execute in parallel                                                                 | `1`                                        |
+| `node-browser-runtime.completions`         | Number of node-browser-runtime jobs that you expect to execute per minute (multiplied by the value of `parallelism` above) | `6`                                        |
+| `node-browser-runtime.imagePullSecrets`    | The name of a Secret object used to pull an image from a specified container registry                                      |                                            |
+| `node-browser-runtime.nameOverride`        | The nameOverride replaces the name of the chart in the Chart.yaml file.                                                    |                                            |
+| `node-browser-runtime.fullnameOverride`    | Name override used for your installation in place of the default                                                           |                                            |
+| `node-browser-runtime.appVersionOverride`  | Release version of node-browser-runtime to use in place of the version specified in [Chart.yaml](Chart.yaml)               |                                            |
+| `node-browser-runtime.image.repository`    | The container to pull.                                                                                                     | `newrelic/synthetics-node-browser-runtime` |
+| `node-browser-runtime.image.pullPolicy`    | The pull policy.                                                                                                           | `IfNotPresent`                             |
+| `node-browser-runtime.appArmorProfileName` | *(Not yet supported)* Name of an AppArmor profile to load.                                                                 |                                            |
+| `node-browser-runtime.resources`           | Resource requests and limits.                                                                                              |                                            |
+| `node-browser-runtime.podAnnotations`      | Annotations to be added to the node-browser-runtime pod                                                                    |                                            |
+| `node-browser-runtime.podSecurityContext`  | Custom security context for the node-browser-runtime pod                                                                   |                                            |
+| `node-browser-runtime.securityContext`     | Custom security context for the node-browser-runtime containers                                                            |                                            |
+| `node-browser-runtime.labels`              | labels to be added to all node-browser-runtime resources                                                                   |                                            |
+| `node-browser-runtime.annotations`         | Annotations to be added to the node-browser-runtime pod                                                                    |                                            |
+| `node-browser-runtime.nodeSelector`        | Node labels for node-browser-runtime pod assignment                                                                        |                                            |
+| `node-browser-runtime.tolerations`         | Node taints to tolerate for node-browser-runtime                                                                           |                                            |
+| `node-browser-runtime.affinity`            | Pod affinity for node-browser-runtime                                                                                      |                                            |
 
 
 ## Example

--- a/charts/synthetics-job-manager/charts/node-api-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/node-api-runtime/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node-api-runtime
 description: New Relic Synthetics Api Runtime
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: 1.1.15
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:

--- a/charts/synthetics-job-manager/charts/node-api-runtime/README.md
+++ b/charts/synthetics-job-manager/charts/node-api-runtime/README.md
@@ -4,22 +4,23 @@
 
 ## Configuration
 
-| Parameter             | Description                                                                                                   | Default                                |
-|-----------------------|---------------------------------------------------------------------------------------------------------------|----------------------------------------|
-| `parallelism`         | Number of node-api-runtime replicas to maintain                                                               | `1`                                    |
-| `imagePullSecrets`    | The name of a Secret object used to pull an image from a specified container registry                         |                                        |
-| `nameOverride`        | The nameOverride replaces the name of the chart in the Chart.yaml file.                                       |                                        |
-| `fullnameOverride`    | Name override used for your installation in place of the default                                              |                                        |
-| `appVersionOverride`  | Release version of node-api-runtime to use in place of the version specified in [Chart.yaml](Chart.yaml)      |                                        |
-| `image.repository`    | The container to pull.                                                                                        | `newrelic/synthetics-node-api-runtime` |
-| `image.pullPolicy`    | The pull policy.                                                                                              | `IfNotPresent`                         |
-| `appArmorProfileName` | Name of an AppArmor profile to load.                                                                          |                                        |
-| `resources`           | Resource requests and limits.                                                                                 |                                        |
-| `podAnnotations`      | Annotations to be added to the node-api-runtime pod                                                           |                                        |
-| `podSecurityContext`  | Custom security context for the node-api-runtime pod                                                          |                                        |
-| `securityContext`     | Custom security context for the node-api-runtime containers                                                   |                                        |
-| `labels`              | labels to be added to all node-api-runtime resources                                                          |                                        |
-| `annotations`         | Annotations to be added to the node-api-runtime pod                                                           |                                        |
-| `nodeSelector`        | Node labels for node-api-runtime pod assignment                                                               |                                        |
-| `tolerations`         | Node taints to tolerate for node-api-runtime                                                                  |                                        |
-| `affinity`            | Pod affinity for node-api-runtime                                                                             |                                        |
+| Parameter             | Description                                                                                                            | Default                                |
+|-----------------------|------------------------------------------------------------------------------------------------------------------------|----------------------------------------|
+| `parallelism`         | Number of node-api-runtime jobs to execute in parallel                                                                 | `1`                                    |
+| `completions`         | Number of node-api-runtime jobs that you expect to execute per minute (multiplied by the value of `parallelism` above) | `6`                                    |
+| `imagePullSecrets`    | The name of a Secret object used to pull an image from a specified container registry                                  |                                        |
+| `nameOverride`        | The nameOverride replaces the name of the chart in the Chart.yaml file.                                                |                                        |
+| `fullnameOverride`    | Name override used for your installation in place of the default                                                       |                                        |
+| `appVersionOverride`  | Release version of node-api-runtime to use in place of the version specified in [Chart.yaml](Chart.yaml)               |                                        |
+| `image.repository`    | The container to pull.                                                                                                 | `newrelic/synthetics-node-api-runtime` |
+| `image.pullPolicy`    | The pull policy.                                                                                                       | `IfNotPresent`                         |
+| `appArmorProfileName` | Name of an AppArmor profile to load.                                                                                   |                                        |
+| `resources`           | Resource requests and limits.                                                                                          |                                        |
+| `podAnnotations`      | Annotations to be added to the node-api-runtime pod                                                                    |                                        |
+| `podSecurityContext`  | Custom security context for the node-api-runtime pod                                                                   |                                        |
+| `securityContext`     | Custom security context for the node-api-runtime containers                                                            |                                        |
+| `labels`              | labels to be added to all node-api-runtime resources                                                                   |                                        |
+| `annotations`         | Annotations to be added to the node-api-runtime pod                                                                    |                                        |
+| `nodeSelector`        | Node labels for node-api-runtime pod assignment                                                                        |                                        |
+| `tolerations`         | Node taints to tolerate for node-api-runtime                                                                           |                                        |
+| `affinity`            | Pod affinity for node-api-runtime                                                                                      |                                        |

--- a/charts/synthetics-job-manager/charts/node-api-runtime/templates/job.yaml
+++ b/charts/synthetics-job-manager/charts/node-api-runtime/templates/job.yaml
@@ -14,6 +14,7 @@ spec:
   jobTemplate:
     spec:
       parallelism: {{ .Values.parallelism }}
+      completions: {{ .Values.completions }}
       ttlSecondsAfterFinished: {{ .Values.ttlSecondsAfterFinished }}
       template:
         metadata:

--- a/charts/synthetics-job-manager/charts/node-api-runtime/values.yaml
+++ b/charts/synthetics-job-manager/charts/node-api-runtime/values.yaml
@@ -5,7 +5,7 @@
 parallelism: 1
 
 # Set this to the maximum number of node-api-runtime jobs you expect to execute per minute (multiplied by the value of `parallelism` above)
-completions: 1
+completions: 6
 
 # The number of seconds after job execution to wait before cleaning up a finished job. The default value of 0 cleans up jobs immediately after they finish.
 ttlSecondsAfterFinished: 0

--- a/charts/synthetics-job-manager/charts/node-api-runtime/values.yaml
+++ b/charts/synthetics-job-manager/charts/node-api-runtime/values.yaml
@@ -1,8 +1,11 @@
 # This is a YAML-formatted file that contains default values for node-api-runtime.
 # Declare variables to be passed into your templates.
 
-# Set this to the maximum number of node-api-runtime jobs you expect to run per minute
+# Set this to the maximum number of node-api-runtime jobs you want to run in parallel
 parallelism: 1
+
+# Set this to the maximum number of node-api-runtime jobs you expect to execute per minute (multiplied by the value of `parallelism` above)
+completions: 1
 
 # The number of seconds after job execution to wait before cleaning up a finished job. The default value of 0 cleans up jobs immediately after they finish.
 ttlSecondsAfterFinished: 0

--- a/charts/synthetics-job-manager/charts/node-browser-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/node-browser-runtime/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node-browser-runtime
 description: New Relic Synthetics Browser Runtime
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: 1.1.30
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:

--- a/charts/synthetics-job-manager/charts/node-browser-runtime/README.md
+++ b/charts/synthetics-job-manager/charts/node-browser-runtime/README.md
@@ -4,22 +4,23 @@
 
 ## Configuration
 
-| Parameter             | Description                                                                                                   | Default                                    |
-|-----------------------|---------------------------------------------------------------------------------------------------------------|--------------------------------------------|
-| `parallelism`         | Number of node-browser-runtime replicas to maintain                                                           | `1`                                        |
-| `imagePullSecrets`    | The name of a Secret object used to pull an image from a specified container registry                         |                                            |
-| `nameOverride`        | The nameOverride replaces the name of the chart in the Chart.yaml file.                                       |                                            |
-| `fullnameOverride`    | Name override used for your installation in place of the default                                              |                                            |
-| `appVersionOverride`  | Release version of node-browser-runtime to use in place of the version specified in [Chart.yaml](Chart.yaml)  |                                            |
-| `image.repository`    | The container to pull.                                                                                        | `newrelic/synthetics-node-browser-runtime` |
-| `image.pullPolicy`    | The pull policy.                                                                                              | `IfNotPresent`                             |
-| `appArmorProfileName` | Name of an AppArmor profile to load.                                                                          |                                            |
-| `resources`           | Resource requests and limits.                                                                                 |                                            |
-| `podAnnotations`      | Annotations to be added to the node-browser-runtime pod                                                       |                                            |
-| `podSecurityContext`  | Custom security context for the node-browser-runtime pod                                                      |                                            |
-| `securityContext`     | Custom security context for the node-browser-runtime containers                                               |                                            |
-| `labels`              | labels to be added to all node-browser-runtime resources                                                      |                                            |
-| `annotations`         | Annotations to be added to the node-browser-runtime pod                                                       |                                            |
-| `nodeSelector`        | Node labels for node-browser-runtime pod assignment                                                           |                                            |
-| `tolerations`         | Node taints to tolerate for node-browser-runtime                                                              |                                            |
-| `affinity`            | Pod affinity for node-browser-runtime                                                                         |                                            |
+| Parameter             | Description                                                                                                                | Default                                    |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------------|--------------------------------------------|
+| `parallelism`         | Number of node-browser-runtime jobs to execute in parallel                                                                 | `1`                                        |
+| `completions`         | Number of node-browser-runtime jobs that you expect to execute per minute (multiplied by the value of `parallelism` above) | `6`                                        |
+| `imagePullSecrets`    | The name of a Secret object used to pull an image from a specified container registry                                      |                                            |
+| `nameOverride`        | The nameOverride replaces the name of the chart in the Chart.yaml file.                                                    |                                            |
+| `fullnameOverride`    | Name override used for your installation in place of the default                                                           |                                            |
+| `appVersionOverride`  | Release version of node-browser-runtime to use in place of the version specified in [Chart.yaml](Chart.yaml)               |                                            |
+| `image.repository`    | The container to pull.                                                                                                     | `newrelic/synthetics-node-browser-runtime` |
+| `image.pullPolicy`    | The pull policy.                                                                                                           | `IfNotPresent`                             |
+| `appArmorProfileName` | Name of an AppArmor profile to load.                                                                                       |                                            |
+| `resources`           | Resource requests and limits.                                                                                              |                                            |
+| `podAnnotations`      | Annotations to be added to the node-browser-runtime pod                                                                    |                                            |
+| `podSecurityContext`  | Custom security context for the node-browser-runtime pod                                                                   |                                            |
+| `securityContext`     | Custom security context for the node-browser-runtime containers                                                            |                                            |
+| `labels`              | labels to be added to all node-browser-runtime resources                                                                   |                                            |
+| `annotations`         | Annotations to be added to the node-browser-runtime pod                                                                    |                                            |
+| `nodeSelector`        | Node labels for node-browser-runtime pod assignment                                                                        |                                            |
+| `tolerations`         | Node taints to tolerate for node-browser-runtime                                                                           |                                            |
+| `affinity`            | Pod affinity for node-browser-runtime                                                                                      |                                            |

--- a/charts/synthetics-job-manager/charts/node-browser-runtime/templates/job.yaml
+++ b/charts/synthetics-job-manager/charts/node-browser-runtime/templates/job.yaml
@@ -14,6 +14,7 @@ spec:
   jobTemplate:
     spec:
       parallelism: {{ .Values.parallelism }}
+      completions: {{ .Values.completions }}
       ttlSecondsAfterFinished: {{ .Values.ttlSecondsAfterFinished }}
       template:
         metadata:

--- a/charts/synthetics-job-manager/charts/node-browser-runtime/values.yaml
+++ b/charts/synthetics-job-manager/charts/node-browser-runtime/values.yaml
@@ -1,8 +1,11 @@
 # This is a YAML-formatted file that contains default values for node-browser-runtime.
 # Declare variables to be passed into your templates.
 
-# Set this to the maximum number of node-browser-runtime jobs you expect to run per minute
+# Set this to the maximum number of node-browser-runtime jobs you want to run in parallel
 parallelism: 1
+
+# Set this to the maximum number of node-browser-runtime jobs you expect to execute per minute (multiplied by the value of `parallelism` above)
+completions: 1
 
 # The number of seconds after job execution to wait before cleaning up a finished job. The default value of 0 cleans up jobs immediately after they finish.
 ttlSecondsAfterFinished: 0

--- a/charts/synthetics-job-manager/charts/node-browser-runtime/values.yaml
+++ b/charts/synthetics-job-manager/charts/node-browser-runtime/values.yaml
@@ -5,7 +5,7 @@
 parallelism: 1
 
 # Set this to the maximum number of node-browser-runtime jobs you expect to execute per minute (multiplied by the value of `parallelism` above)
-completions: 1
+completions: 6
 
 # The number of seconds after job execution to wait before cleaning up a finished job. The default value of 0 cleans up jobs immediately after they finish.
 ttlSecondsAfterFinished: 0

--- a/charts/synthetics-job-manager/values.yaml
+++ b/charts/synthetics-job-manager/values.yaml
@@ -197,8 +197,11 @@ ping-runtime:
 node-api-runtime:
   enabled: true
 
-  # Set this to the maximum number of node-api-runtime jobs you expect to run per minute
+  # Set this to the maximum number of node-api-runtime jobs you want to run in parallel
   parallelism: 1
+
+  # Set this to the maximum number of node-api-runtime jobs you expect to execute per minute (multiplied by the value of `parallelism` above)
+  completions: 1
 
   # The imagePullSecrets stores Docker credentials that are used for accessing a registry.
   imagePullSecrets: []
@@ -258,8 +261,11 @@ node-api-runtime:
 node-browser-runtime:
   enabled: true
 
-  # Set this to the maximum number of node-browser-runtime jobs you expect to run per minute
+  # Set this to the maximum number of node-browser-runtime jobs you want to run in parallel
   parallelism: 1
+
+  # Set this to the maximum number of node-browser-runtime jobs you expect to execute per minute (multiplied by the value of `parallelism` above)
+  completions: 1
 
   # The imagePullSecrets stores Docker credentials that are used for accessing a registry.
   imagePullSecrets: []

--- a/charts/synthetics-job-manager/values.yaml
+++ b/charts/synthetics-job-manager/values.yaml
@@ -201,7 +201,7 @@ node-api-runtime:
   parallelism: 1
 
   # Set this to the maximum number of node-api-runtime jobs you expect to execute per minute (multiplied by the value of `parallelism` above)
-  completions: 1
+  completions: 6
 
   # The imagePullSecrets stores Docker credentials that are used for accessing a registry.
   imagePullSecrets: []
@@ -265,7 +265,7 @@ node-browser-runtime:
   parallelism: 1
 
   # Set this to the maximum number of node-browser-runtime jobs you expect to execute per minute (multiplied by the value of `parallelism` above)
-  completions: 1
+  completions: 6
 
   # The imagePullSecrets stores Docker credentials that are used for accessing a registry.
   imagePullSecrets: []


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

Adds the ability for customers to configure the `completions` parameter for CronJob types which will mitigate a potential issue where long running jobs may prevent enough jobs from executing each minute. This gives customers the ability to modify this value to suit their particular job workloads.

#### Which issue this PR fixes
- Fixes NR-47917

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
