### PR TITLE
[synthetics-job-manager]: Adding resource limits and request for runtimes

### DIFF
--- a/charts/synthetics-job-manager/Chart.yaml
+++ b/charts/synthetics-job-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: synthetics-job-manager
 description: New Relic Synthetics Containerized Job Manager
 type: application
-version: 1.0.3
+version: 1.0.4
 appVersion: release-155
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
@@ -26,8 +26,8 @@ dependencies:
     version: 1.0.1
     condition: ping-runtime.enabled
   - name: node-api-runtime
-    version: 1.0.3
+    version: 1.0.4
     condition: node-api-runtime.enabled
   - name: node-browser-runtime
-    version: 1.0.3
+    version: 1.0.4
     condition: node-browser-runtime.enabled

--- a/charts/synthetics-job-manager/README.md
+++ b/charts/synthetics-job-manager/README.md
@@ -85,7 +85,7 @@ This chart will deploy the New Relic Synthetics Containerized Private Job Manage
 | `node-api-runtime.image.repository`    | The container to pull.                                                                                                 | `newrelic/synthetics-node-api-runtime` |
 | `node-api-runtime.image.pullPolicy`    | The pull policy.                                                                                                       | `IfNotPresent`                         |
 | `node-api-runtime.appArmorProfileName` | *(Not yet supported)* Name of an AppArmor profile to load.                                                             |                                        |
-| `node-api-runtime.resources`           | Resource requests and limits.                                                                                          |                                        |
+| `node-api-runtime.resources`           | Resource requests and limits.             | See the [Resources](#Resources) section below                                                                                                                        |                                                                              |                                        |
 | `node-api-runtime.podAnnotations`      | Annotations to be added to the node-api-runtime pod                                                                    |                                        |
 | `node-api-runtime.podSecurityContext`  | Custom security context for the node-api-runtime pod                                                                   |                                        |
 | `node-api-runtime.securityContext`     | Custom security context for the node-api-runtime containers                                                            |                                        |
@@ -109,7 +109,7 @@ This chart will deploy the New Relic Synthetics Containerized Private Job Manage
 | `node-browser-runtime.image.repository`    | The container to pull.                                                                                                     | `newrelic/synthetics-node-browser-runtime` |
 | `node-browser-runtime.image.pullPolicy`    | The pull policy.                                                                                                           | `IfNotPresent`                             |
 | `node-browser-runtime.appArmorProfileName` | *(Not yet supported)* Name of an AppArmor profile to load.                                                                 |                                            |
-| `node-browser-runtime.resources`           | Resource requests and limits.                                                                                              |                                            |
+| `node-browser-runtime.resources`           | Resource requests and limits.                          | See the [Resources](#Resources) section below                                                                                                                        |                                                                     |                                            |
 | `node-browser-runtime.podAnnotations`      | Annotations to be added to the node-browser-runtime pod                                                                    |                                            |
 | `node-browser-runtime.podSecurityContext`  | Custom security context for the node-browser-runtime pod                                                                   |                                            |
 | `node-browser-runtime.securityContext`     | Custom security context for the node-browser-runtime containers                                                            |                                            |
@@ -151,4 +151,24 @@ resources:
   limits:
     cpu: 0.75
     memory: 1.6Gi
+```
+The default set of resources assignmed to the node-api runtime is shown below: 
+```yaml
+resources:
+  requests:
+    cpu: 0.5
+    memory: 1250Mi
+  limits:
+    cpu: 0.75
+    memory: 2500Mi
+```
+The default set of resources assignmed to the node-browser runtime is shown below: 
+```yaml
+resources:
+  requests:
+    cpu: 0.5
+    memory: 2000Mi
+  limits:
+    cpu: 0.75
+    memory: 3000Mi
 ```

--- a/charts/synthetics-job-manager/charts/node-api-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/node-api-runtime/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node-api-runtime
 description: New Relic Synthetics Api Runtime
 type: application
-version: 1.0.3
+version: 1.0.4
 appVersion: 1.1.15
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:

--- a/charts/synthetics-job-manager/charts/node-api-runtime/values.yaml
+++ b/charts/synthetics-job-manager/charts/node-api-runtime/values.yaml
@@ -31,7 +31,13 @@ image:
 ## The AppArmor profile name that will be applied to the pods. If set, then the AppArmor profile must exist on the Kubernetes node(s) for this to work.
 # appArmorProfileName: ""
 
-resources: {}
+resources:
+  requests:
+    cpu: "500m"
+    memory: "1250Mi"
+  limits:
+    cpu: "750m"
+    memory: "2500Mi"
 
 podAnnotations: {}
 

--- a/charts/synthetics-job-manager/charts/node-browser-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/node-browser-runtime/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node-browser-runtime
 description: New Relic Synthetics Browser Runtime
 type: application
-version: 1.0.3
+version: 1.0.4
 appVersion: 1.1.30
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:

--- a/charts/synthetics-job-manager/charts/node-browser-runtime/values.yaml
+++ b/charts/synthetics-job-manager/charts/node-browser-runtime/values.yaml
@@ -31,7 +31,13 @@ image:
 ## The AppArmor profile name that will be applied to the pods. If set, then the AppArmor profile must exist on the Kubernetes node(s) for this to work.
 # appArmorProfileName: ""
 
-resources: {}
+resources:
+  requests:
+    cpu: "500m"
+    memory: "2000Mi"
+  limits:
+    cpu: "750m"
+    memory: "3000Mi"
 
 podAnnotations: {}
 

--- a/charts/synthetics-job-manager/values.yaml
+++ b/charts/synthetics-job-manager/values.yaml
@@ -239,7 +239,13 @@ node-api-runtime:
   # Number of seconds after which the liveness probe times out.
   livenessProbeTimeoutSeconds: 10
 
-  resources: {}
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "1250Mi"
+    limits:
+      cpu: "750m"
+      memory: "2500Mi"
 
   podAnnotations: {}
 
@@ -303,7 +309,13 @@ node-browser-runtime:
   # Number of seconds after which the liveness probe times out.
   livenessProbeTimeoutSeconds: 10
 
-  resources: {}
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "2000Mi"
+    limits:
+      cpu: "750m"
+      memory: "3000Mi"
 
   podAnnotations: {}
 


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart? 
NO

#### What this PR does / why we need it:

Adds resource request and limits to runtimes. This is a bug ticket that was reported by ANZ: [NR-46521](https://issues.newrelic.com/browse/NR-46521).

**Promise these numbers didn't come out of thin air!!!! These are actually the old minion request / limit configs based on job type. I used them as a jumping off point and didn't need to increase them because they are working.**

Node Runtime: 
![7FB5B327-7991-43E3-99EA-2152986D17EA_1_201_a](https://user-images.githubusercontent.com/51135822/190214179-34cf8917-0d13-4429-ba10-6297c737f9ca.jpeg)
API Runtime: 
![6F9EB60D-A869-4C91-9DA2-4BBFFB8E1C15_1_201_a](https://user-images.githubusercontent.com/51135822/190214233-83b18df1-03f4-4ce4-ad4c-dfbe889e548a.jpeg)


Proof of concept: 

These two are run on the eks cluster with the new resource limits and request I implemented in this PR and it shows that the values defined here will pass checks without any problem.

Monitor 1 (Scripted Browser Monitor) : https://staging.onenr.io/0PoR87rG6wG
Monitor 2 (Scripted API Monitor): https://staging.onenr.io/09MR2NvX2RY

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)