### PR TITLE
[synthetics-minion] Fix environment variable private location key name

### DIFF
--- a/charts/synthetics-minion/Chart.yaml
+++ b/charts/synthetics-minion/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: synthetics-minion
 description: New Relic Synthetics Containerized Private Minion (CPM)
 type: application
-version: 1.0.52
+version: 1.0.53
 appVersion: 3.0.65
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:

--- a/charts/synthetics-minion/templates/statefulset.yaml
+++ b/charts/synthetics-minion/templates/statefulset.yaml
@@ -118,7 +118,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: PRIVATE_LOCATION_KEY
+            - name: MINION_PRIVATE_LOCATION_KEY
               {{- include "synthetics-minion.privateLocationKey" . | nindent 14 }}
             - name: MINION_LOG_LEVEL
               value: {{ .Values.synthetics.minionLogLevel | quote }}


### PR DESCRIPTION
This is fixing the env variable PRIVATE_LOCATION_KEY -> MINION_PRIVATE_LOCATION_KEY

- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
