### PR TITLE
[nri-bundle] Add the public preview of the Prometheus Configurator (NR-55440)

### DIFF
--- a/.github/ct-install.yaml
+++ b/.github/ct-install.yaml
@@ -19,6 +19,7 @@ chart-repos:
   - newrelic-cdn-helm-charts=https://helm-charts.newrelic.com
   - newrelic-infrastructure=https://newrelic.github.io/nri-kubernetes
   - nri-prometheus=https://newrelic.github.io/nri-prometheus
+  - newrelic-prometheus-configurator=https://newrelic.github.io/newrelic-prometheus-configurator
   - nri-metadata-injection=https://newrelic.github.io/k8s-metadata-injection
   - newrelic-k8s-metrics-adapter=https://newrelic.github.io/newrelic-k8s-metrics-adapter
   - kube-state-metrics=https://kubernetes.github.io/kube-state-metrics

--- a/.github/ct-lint.yaml
+++ b/.github/ct-lint.yaml
@@ -19,6 +19,7 @@ chart-repos:
   - newrelic-cdn-helm-charts=https://helm-charts.newrelic.com
   - newrelic-infrastructure=https://newrelic.github.io/nri-kubernetes
   - nri-prometheus=https://newrelic.github.io/nri-prometheus
+  - newrelic-prometheus-configurator=https://newrelic.github.io/newrelic-prometheus-configurator
   - nri-metadata-injection=https://newrelic.github.io/k8s-metadata-injection
   - newrelic-k8s-metrics-adapter=https://newrelic.github.io/newrelic-k8s-metrics-adapter
   - kube-state-metrics=https://kubernetes.github.io/kube-state-metrics

--- a/.github/workflows/lint_test_charts.yaml
+++ b/.github/workflows/lint_test_charts.yaml
@@ -105,6 +105,7 @@ jobs:
           helm repo add newrelic-cdn-helm-charts https://helm-charts.newrelic.com
           helm repo add newrelic-infrastructure https://newrelic.github.io/nri-kubernetes
           helm repo add nri-prometheus https://newrelic.github.io/nri-prometheus
+          helm repo add newrelic-prometheus-configurator https://newrelic.github.io/newrelic-prometheus-configurator
           helm repo add nri-metadata-injection https://newrelic.github.io/k8s-metadata-injection
           helm repo add newrelic-k8s-metrics-adapter https://newrelic.github.io/newrelic-k8s-metrics-adapter
           helm repo add kube-state-metrics https://kubernetes.github.io/kube-state-metrics

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
           helm repo add newrelic-cdn-helm-charts https://helm-charts.newrelic.com
           helm repo add newrelic-infrastructure https://newrelic.github.io/nri-kubernetes
           helm repo add nri-prometheus https://newrelic.github.io/nri-prometheus
+          helm repo add newrelic-prometheus-configurator https://newrelic.github.io/newrelic-prometheus-configurator
           helm repo add nri-metadata-injection https://newrelic.github.io/k8s-metadata-injection
           helm repo add newrelic-k8s-metrics-adapter https://newrelic.github.io/newrelic-k8s-metrics-adapter
           helm repo add kube-state-metrics https://kubernetes.github.io/kube-state-metrics

--- a/charts/nri-bundle/Chart.lock
+++ b/charts/nri-bundle/Chart.lock
@@ -5,6 +5,9 @@ dependencies:
 - name: nri-prometheus
   repository: https://newrelic.github.io/nri-prometheus
   version: 2.1.14
+- name: newrelic-prometheus-agent
+  repository: https://newrelic.github.io/newrelic-prometheus-configurator
+  version: 0.0.6
 - name: nri-metadata-injection
   repository: https://newrelic.github.io/k8s-metadata-injection
   version: 3.0.9
@@ -29,5 +32,5 @@ dependencies:
 - name: newrelic-infra-operator
   repository: https://newrelic.github.io/newrelic-infra-operator
   version: 1.0.10
-digest: sha256:096417cac3382ae0a8122971efdc42c925316b1de50711853766a99e0c465ddc
-generated: "2022-10-14T12:09:17.805216128Z"
+digest: sha256:b827d2a89c3e407cf33a1419a6c127fde1117af39d5cceafa1e470fd6a047525
+generated: "2022-10-14T14:36:27.640683+02:00"

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -8,6 +8,7 @@ sources:
   - https://github.com/newrelic/nri-bundle/tree/master/charts/nri-bundle
   - https://github.com/newrelic/nri-kubernetes/tree/master/charts/newrelic-infrastructure
   - https://github.com/newrelic/nri-prometheus/tree/master/charts/nri-prometheus
+  - https://github.com/newrelic/newrelic-prometheus-configurator/tree/master/charts/newrelic-prometheus-agent
   - https://github.com/newrelic/k8s-metadata-injection/tree/master/charts/nri-metadata-injection
   - https://github.com/newrelic/newrelic-k8s-metrics-adapter/tree/master/charts/newrelic-k8s-metrics-adapter
   - https://github.com/newrelic/nri-kube-events/tree/master/charts/nri-kube-events

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -15,7 +15,7 @@ sources:
   - https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie
   - https://github.com/newrelic/newrelic-infra-operator/tree/master/charts/newrelic-infra-operator
 
-version: 4.8.12
+version: 4.9.0
 
 dependencies:
   - name: newrelic-infrastructure
@@ -27,6 +27,11 @@ dependencies:
     repository: https://newrelic.github.io/nri-prometheus
     condition: prometheus.enabled,nri-prometheus.enabled
     version: 2.1.14
+
+  - name: newrelic-prometheus-agent
+    repository: https://newrelic.github.io/newrelic-prometheus-configurator
+    condition: newrelic-prometheus-configurator.enabled
+    version: 0.0.6
 
   - name: nri-metadata-injection
     repository: https://newrelic.github.io/k8s-metadata-injection

--- a/charts/nri-bundle/README.md
+++ b/charts/nri-bundle/README.md
@@ -22,6 +22,7 @@ here is a list of components that this chart installs and where you can find mor
 | [newrelic-k8s-metrics-adapter](https://github.com/newrelic/newrelic-k8s-metrics-adapter/tree/main/charts/newrelic-k8s-metrics-adapter) |  | (Beta) Provides a source of data for Horizontal Pod Autoscalers (HPA) based on a NRQL query from New Relic. |
 | [newrelic-logging](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging) |  | Sends logs for Kubernetes components and workloads running on the cluster to New Relic. |
 | [nri-prometheus](https://github.com/newrelic/nri-prometheus/tree/main/charts/nri-prometheus) |  | Sends metrics from applications exposing Prometheus metrics to New Relic. |
+| [newrelic-prometheus-configurator](https://github.com/newrelic/newrelic-prometheus-configurator/tree/master/charts/newrelic-prometheus-agent) |  | Configures instances of Prometheus in Agent mode to send metrics to the New Relic Prometheus endpoint. |
 | [newrelic-pixie](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie) |  | Connects to the Pixie API and enables the New Relic plugin in Pixie. The plugin allows you to export data from Pixie to New Relic for long-term data retention. |
 | [Pixie](https://docs.pixielabs.ai/installing-pixie/install-schemes/helm/#3.-deploy) |  | Is an open source observability tool for Kubernetes applications that uses eBPF to automatically capture telemetry data without the need for manual instrumentation. |
 

--- a/charts/nri-bundle/README.md
+++ b/charts/nri-bundle/README.md
@@ -181,6 +181,7 @@ honors global options as described below.
 | newrelic-k8s-metrics-adapter.enabled | bool | `false` | Install the [`newrelic-k8s-metrics-adapter.` chart](https://github.com/newrelic/newrelic-k8s-metrics-adapter/tree/main/charts/newrelic-k8s-metrics-adapter) (Beta) |
 | newrelic-logging.enabled | bool | `false` | Install the [`newrelic-logging` chart](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging) |
 | newrelic-pixie.enabled | bool | `false` | Install the [`newrelic-pixie`](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie) |
+| newrelic-prometheus-agent.enabled | bool | `false` | Install the [`newrelic-prometheus-agent` chart](https://github.com/newrelic/newrelic-prometheus-configurator/tree/main/charts/newrelic-prometheus-agent) (Public preview) |
 | nri-kube-events.enabled | bool | `false` | Install the [`nri-kube-events` chart](https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events) |
 | nri-metadata-injection.enabled | bool | `true` | Install the [`nri-metadata-injection` chart](https://github.com/newrelic/k8s-metadata-injection/tree/main/charts/nri-metadata-injection) |
 | nri-prometheus.enabled | bool | `false` | Install the [`nri-prometheus` chart](https://github.com/newrelic/nri-prometheus/tree/main/charts/nri-prometheus) |

--- a/charts/nri-bundle/README.md.gotmpl
+++ b/charts/nri-bundle/README.md.gotmpl
@@ -23,6 +23,7 @@ here is a list of components that this chart installs and where you can find mor
 | [newrelic-k8s-metrics-adapter](https://github.com/newrelic/newrelic-k8s-metrics-adapter/tree/main/charts/newrelic-k8s-metrics-adapter) |  | (Beta) Provides a source of data for Horizontal Pod Autoscalers (HPA) based on a NRQL query from New Relic. |
 | [newrelic-logging](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging) |  | Sends logs for Kubernetes components and workloads running on the cluster to New Relic. |
 | [nri-prometheus](https://github.com/newrelic/nri-prometheus/tree/main/charts/nri-prometheus) |  | Sends metrics from applications exposing Prometheus metrics to New Relic. |
+| [newrelic-prometheus-configurator](https://github.com/newrelic/newrelic-prometheus-configurator/tree/master/charts/newrelic-prometheus-agent) |  | Configures instances of Prometheus in Agent mode to send metrics to the New Relic Prometheus endpoint. |
 | [newrelic-pixie](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie) |  | Connects to the Pixie API and enables the New Relic plugin in Pixie. The plugin allows you to export data from Pixie to New Relic for long-term data retention. |
 | [Pixie](https://docs.pixielabs.ai/installing-pixie/install-schemes/helm/#3.-deploy) |  | Is an open source observability tool for Kubernetes applications that uses eBPF to automatically capture telemetry data without the need for manual instrumentation. |
 

--- a/charts/nri-bundle/values.yaml
+++ b/charts/nri-bundle/values.yaml
@@ -40,6 +40,10 @@ newrelic-infra-operator:
   # newrelic-infra-operator.enabled -- Install the [`newrelic-infra-operator` chart](https://github.com/newrelic/newrelic-infra-operator/tree/main/charts/newrelic-infra-operator) (Beta)
   enabled: false
 
+newrelic-prometheus-agent:
+  # newrelic-prometheus-agent.enabled -- Install the [`newrelic-prometheus-agent` chart](https://github.com/newrelic/newrelic-prometheus-configurator/tree/main/charts/newrelic-prometheus-agent) (Public preview)
+  enabled: false
+
 newrelic-k8s-metrics-adapter:
   # newrelic-k8s-metrics-adapter.enabled -- Install the [`newrelic-k8s-metrics-adapter.` chart](https://github.com/newrelic/newrelic-k8s-metrics-adapter/tree/main/charts/newrelic-k8s-metrics-adapter) (Beta)
   enabled: false


### PR DESCRIPTION
#### Is this a new chart
Yes!

#### What this PR does / why we need it:
This enables the possibility to install New Relic's Prometheus Configurator using the `nri-bundle`.

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
