### PR TITLE
[newrelic-logging] Use the correct variable for retry limit in windows

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.11.9
+version: 1.11.10
 appVersion: 1.14.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/templates/daemonset-windows.yaml
+++ b/charts/newrelic-logging/templates/daemonset-windows.yaml
@@ -92,7 +92,7 @@ spec:
             - name: LOW_DATA_MODE
               value: {{ include "newrelic-logging.lowDataMode" $ | default "false" | quote }}
             - name: RETRY_LIMIT
-              value: {{ .Values.fluentBit.retryLimit | quote }}
+              value: {{ $.Values.fluentBit.retryLimit | quote }}
             {{- include "newrelic-logging.extraEnv" $ | nindent 12 }}
           command:
             - C:\fluent-bit\bin\fluent-bit.exe


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Fixes the windows fluent-bit daemonset variable.

#### Which issue this PR fixes

#### Special notes for your reviewer:
Windows daemonset should include the $ in front of the variable unlike linux one because we're iterating over windows versions.

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
