### PR TITLE
[nri-bundle] Fix agent toogle and READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,15 @@ Just as a glance of the process of installation and configuration the process in
 global:
   licenseKey: YOUR_LICENSE_KEY
   cluster: YOUR_CLUSTER_NAME
-kubeEvents:
+nri-kube-events:
   enabled: true
-webhook:
+nri-metadata-injection:
   enabled: true
-prometheus:
+nri-prometheus:
   enabled: true
-logging:
+newrelic-logging:
   enabled: true
-ksm:
+kube-state-metrics:
   enabled: true
 ```
 

--- a/charts/nri-bundle/Chart.lock
+++ b/charts/nri-bundle/Chart.lock
@@ -32,5 +32,5 @@ dependencies:
 - name: newrelic-infra-operator
   repository: https://newrelic.github.io/newrelic-infra-operator
   version: 1.0.10
-digest: sha256:b827d2a89c3e407cf33a1419a6c127fde1117af39d5cceafa1e470fd6a047525
-generated: "2022-10-14T14:36:27.640683+02:00"
+digest: sha256:0ac31e3f88985cbb10ac8d8094ab265adbe658ff08b9c7d7fe6bff8c9c89317d
+generated: "2022-10-21T10:00:15.891437+02:00"

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -16,7 +16,7 @@ sources:
   - https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie
   - https://github.com/newrelic/newrelic-infra-operator/tree/master/charts/newrelic-infra-operator
 
-version: 4.9.0
+version: 4.9.1
 
 dependencies:
   - name: newrelic-infrastructure
@@ -31,7 +31,7 @@ dependencies:
 
   - name: newrelic-prometheus-agent
     repository: https://newrelic.github.io/newrelic-prometheus-configurator
-    condition: newrelic-prometheus-configurator.enabled
+    condition: newrelic-prometheus-agent.enabled
     version: 0.0.6
 
   - name: nri-metadata-injection

--- a/charts/nri-bundle/README.md
+++ b/charts/nri-bundle/README.md
@@ -182,7 +182,7 @@ honors global options as described below.
 | newrelic-k8s-metrics-adapter.enabled | bool | `false` | Install the [`newrelic-k8s-metrics-adapter.` chart](https://github.com/newrelic/newrelic-k8s-metrics-adapter/tree/main/charts/newrelic-k8s-metrics-adapter) (Beta) |
 | newrelic-logging.enabled | bool | `false` | Install the [`newrelic-logging` chart](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging) |
 | newrelic-pixie.enabled | bool | `false` | Install the [`newrelic-pixie`](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie) |
-| newrelic-prometheus-agent.enabled | bool | `false` | Install the [`newrelic-prometheus-agent` chart](https://github.com/newrelic/newrelic-prometheus-configurator/tree/main/charts/newrelic-prometheus-agent) (Public preview) |
+| newrelic-prometheus-agent.enabled | bool | `false` | Install the [`newrelic-prometheus-agent` chart](https://github.com/newrelic/newrelic-prometheus-configurator/tree/main/charts/newrelic-prometheus-agent) |
 | nri-kube-events.enabled | bool | `false` | Install the [`nri-kube-events` chart](https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events) |
 | nri-metadata-injection.enabled | bool | `true` | Install the [`nri-metadata-injection` chart](https://github.com/newrelic/k8s-metadata-injection/tree/main/charts/nri-metadata-injection) |
 | nri-prometheus.enabled | bool | `false` | Install the [`nri-prometheus` chart](https://github.com/newrelic/nri-prometheus/tree/main/charts/nri-prometheus) |

--- a/charts/nri-bundle/values.yaml
+++ b/charts/nri-bundle/values.yaml
@@ -41,7 +41,7 @@ newrelic-infra-operator:
   enabled: false
 
 newrelic-prometheus-agent:
-  # newrelic-prometheus-agent.enabled -- Install the [`newrelic-prometheus-agent` chart](https://github.com/newrelic/newrelic-prometheus-configurator/tree/main/charts/newrelic-prometheus-agent) (Public preview)
+  # newrelic-prometheus-agent.enabled -- Install the [`newrelic-prometheus-agent` chart](https://github.com/newrelic/newrelic-prometheus-configurator/tree/main/charts/newrelic-prometheus-agent)
   enabled: false
 
 newrelic-k8s-metrics-adapter:


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
Fixes the toogle of the new Prometheus agent to honor the false that is in the `values.yaml`


#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
