### PR TITLE
[newrelic-logging] Bump logging chart version properly

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.11.10
+version: 1.12.0
 appVersion: 1.14.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Version of the `newrelic-logging` was not porperly bumped and is blocking the release CI.

#### Which issue this PR fixes

#### Checklist
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
