### PR TITLE
[synthetics-job-manager] Fix label indents for CronJobs

### DIFF
--- a/charts/synthetics-job-manager/charts/node-api-runtime/templates/job.yaml
+++ b/charts/synthetics-job-manager/charts/node-api-runtime/templates/job.yaml
@@ -21,7 +21,7 @@ spec:
           labels:
             {{- include "node-api-runtime.selectorLabels" . | nindent 12 }}
               {{- with .Values.labels -}}
-              {{ toYaml . | nindent 10 }}
+              {{ toYaml . | nindent 12 }}
               {{- end }}
           {{- include "node-api-runtime.podAnnotations" . | nindent 10 }}
         spec:

--- a/charts/synthetics-job-manager/charts/node-browser-runtime/templates/job.yaml
+++ b/charts/synthetics-job-manager/charts/node-browser-runtime/templates/job.yaml
@@ -21,7 +21,7 @@ spec:
           labels:
             {{- include "node-browser-runtime.selectorLabels" . | nindent 12 }}
               {{- with .Values.labels -}}
-              {{ toYaml . | nindent 10 }}
+              {{ toYaml . | nindent 12 }}
               {{- end }}
           {{- include "node-browser-runtime.podAnnotations" . | nindent 10 }}
         spec:


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
Fixed an indentation error in the subcharts for the New Relic Synthetics Job Manager 

#### Which issue this PR fixes
  - fixes #986

#### Special notes for your reviewer:
I figured since this is fixing a breaking bug/not changing functionality no Chart Version bump is needed but happy to consider other opinions. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X ] Title of the PR starts with chart name (e.g. `[mychartname]`)
