### PR TITLE
Add KMS upgrade path workaround

### DIFF
--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -16,7 +16,7 @@ sources:
   - https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie
   - https://github.com/newrelic/newrelic-infra-operator/tree/master/charts/newrelic-infra-operator
 
-version: 5.0.0
+version: 5.0.1
 
 dependencies:
   - name: newrelic-infrastructure

--- a/charts/nri-bundle/values.yaml
+++ b/charts/nri-bundle/values.yaml
@@ -14,6 +14,9 @@ kube-state-metrics:
   # kube-state-metrics.enabled -- Install the [`kube-state-metrics` chart](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics) from the stable helm charts repository.
   # This is mandatory if `infrastructure.enabled` is set to `true` and the user does not provide its own instance of KSM version >=1.8 and <=2.0
   enabled: false
+  # As the chart was migrated to https://prometheus-community.github.io/helm-charts, it comes with labels updated. So, when upgrading the chart if fails as it tries
+  # to update the deployment spec.selector which is an immutable field.
+  nameOverride: nr-kube-state-metrics
 
 nri-kube-events:
   # nri-kube-events.enabled -- Install the [`nri-kube-events` chart](https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events)

--- a/charts/nri-bundle/values.yaml
+++ b/charts/nri-bundle/values.yaml
@@ -16,6 +16,7 @@ kube-state-metrics:
   enabled: false
   # As the chart was migrated to https://prometheus-community.github.io/helm-charts, it comes with labels updated. So, when upgrading the chart if fails as it tries
   # to update the deployment spec.selector which is an immutable field.
+  # See: https://github.com/prometheus-community/helm-charts/issues/568 for details.
   nameOverride: nr-kube-state-metrics
 
 nri-kube-events:


### PR DESCRIPTION
This PR fixes an issue while upgrading the `nri-bundle` with KSM v2.

For more details, check this [issue](https://github.com/prometheus-community/helm-charts/issues/568).