### PR TITLE
[synthetics-job-manager] Updating node-api-runtime chart with v1.1.29

### DIFF
--- a/charts/synthetics-job-manager/Chart.yaml
+++ b/charts/synthetics-job-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: synthetics-job-manager
 description: New Relic Synthetics Containerized Job Manager
 type: application
-version: 1.0.18
+version: 1.0.19
 appVersion: release-206
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
@@ -27,7 +27,7 @@ dependencies:
     version: 1.0.3
     condition: ping-runtime.enabled
   - name: node-api-runtime
-    version: 1.0.12
+    version: 1.0.13
     condition: node-api-runtime.enabled
   - name: node-browser-runtime
     version: 1.0.12

--- a/charts/synthetics-job-manager/charts/node-api-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/node-api-runtime/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: node-api-runtime
 description: New Relic Synthetics Api Runtime
 type: application
-version: 1.0.12
-appVersion: 1.1.27
+version: 1.0.13
+appVersion: 1.1.29
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

Updates the release version of the node-api-runtime image

#### Which issue this PR fixes
  - Adds node-vault and otp auth modules


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
