### PR TITLE
[newrelic-logging] Add sha256sum ConfigMap annotation to fluent-bit DaemonSet

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.12.2
+version: 1.12.3
 appVersion: 1.14.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/templates/daemonset-windows.yaml
+++ b/charts/newrelic-logging/templates/daemonset-windows.yaml
@@ -22,8 +22,9 @@ spec:
       kubernetes.io/os: windows
   template:
     metadata:
-    {{- if $.Values.podAnnotations }}
       annotations:
+        checksum/fluent-bit-config: {{ include (print $.Template.BasePath "/configmap.yaml") $ | sha256sum }}
+    {{- if $.Values.podAnnotations }}
 {{ toYaml $.Values.podAnnotations | indent 8}}
     {{- end }}
       labels:

--- a/charts/newrelic-logging/templates/daemonset.yaml
+++ b/charts/newrelic-logging/templates/daemonset.yaml
@@ -18,8 +18,9 @@ spec:
       release: {{.Release.Name }}
   template:
     metadata:
-    {{- if .Values.podAnnotations }}
       annotations:
+        checksum/fluent-bit-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8}}
     {{- end }}
       labels:


### PR DESCRIPTION
It allows the pods to be recreated if a change happens on the fluent-bit ConfigMap.
We've followed same approach that other charts like https://github.com/newrelic/nri-kubernetes/blob/main/charts/newrelic-infrastructure/templates/controlplane/daemonset.yaml#L31-L32 

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
