### PR TITLE
delete extra codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,0 @@
-# This is a comment.
-# Each line is a file pattern followed by one or more owners.
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence.
-
-* @newrelic/k8s011y


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Deletes the new CODEOWNERS file located at .github/CODEOWNERS which appears to be conflicting with existing CODEOWNERS file at root, causing the k8s011y group to be required as an approver for charts owned by synthetics. If this was intentional & we DO want k8s011y to additionally review charts owned by other teams then please disregard!

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
N/A

#### Special notes for your reviewer:
I think there's only supposed to be one CODEOWNERS file per branch - could be wrong though. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
