### PR TITLE
[newrelic-pixie] Use standard pattern for lowDataMode to suport local overrride

### DIFF
--- a/charts/newrelic-pixie/Chart.yaml
+++ b/charts/newrelic-pixie/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the New Relic Pixie integration.
 name: newrelic-pixie
-version: 2.0.2
+version: 2.0.3
 appVersion: 2.0.2
 home: https://hub.docker.com/u/newrelic
 sources:

--- a/charts/newrelic-pixie/templates/_helpers.tpl
+++ b/charts/newrelic-pixie/templates/_helpers.tpl
@@ -82,16 +82,34 @@ release: {{.Release.Name }}
 {{- end -}}
 {{- end -}}
 
-{{/*
-Returns lowDataMode
-*/}}
+{{- /*
+adapted from https://github.com/newrelic/helm-charts/blob/af747af93fb5b912374196adc59b552965b6e133/library/common-library/templates/_low-data-mode.tpl
+TODO: actually use common-library chart dep
+*/ -}}
+{{- /*
+Abstraction of the lowDataMode toggle.
+This helper allows to override the global `.global.lowDataMode` with the value of `.lowDataMode`.
+Returns "true" if `lowDataMode` is enabled, otherwise "" (empty string)
+*/ -}}
 {{- define "newrelic-pixie.lowDataMode" -}}
-{{- if .Values.global }}
-  {{- if .Values.global.lowDataMode }}
-    {{- .Values.global.lowDataMode -}}
-  {{- end -}}
-{{- else if .Values.lowDataMode }}
-  {{- .Values.lowDataMode -}}
+{{- /* `get` will return "" (empty string) if value is not found, and the value otherwise, so we can type-assert with kindIs */ -}}
+{{- if (get .Values "lowDataMode" | kindIs "bool") -}}
+    {{- if .Values.lowDataMode -}}
+        {{- /*
+            We want only to return when this is true, returning `false` here will template "false" (string) when doing
+            an `(include "newrelic.common.lowDataMode" .)`, which is not an "empty string" so it is `true` if it is used
+            as an evaluation somewhere else.
+        */ -}}
+        {{- .Values.lowDataMode -}}
+    {{- end -}}
+{{- else -}}
+{{- /* This allows us to use `$global` as an empty dict directly in case `Values.global` does not exists */ -}}
+{{- $global := index .Values "global" | default dict -}}
+{{- if get $global "lowDataMode" | kindIs "bool" -}}
+    {{- if $global.lowDataMode -}}
+        {{- $global.lowDataMode -}}
+    {{- end -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/newrelic-pixie/values.yaml
+++ b/charts/newrelic-pixie/values.yaml
@@ -54,5 +54,6 @@ excludePodsRegex:
 
 # When low data mode is enabled the integration performs heavier sampling on the Pixie span data
 # and sets the collect interval to 15 seconds instead of 10 seconds.
-# Can be set as a global: global.lowDataMode
-lowDataMode: false
+# Can be set as a global: global.lowDataMode or locally as newrelic-pixie.lowDataMode
+# @default -- false
+lowDataMode:


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No

#### What this PR does / why we need it:

This PR makes `newrelic-pixie` chart's handling of `lowDataMode` same as other charts to allow setting it by either `global.lowDataMode` or `newrelic-pixie.lowDataMode`.

Specifically, it adopts [_low-data-mode.tpl](https://github.com/newrelic/helm-charts/blob/af747af93fb5b912374196adc59b552965b6e133/library/common-library/templates/_low-data-mode.tpl) from the `common-library` chart.

Longer term, we should look into moving this chart to use the `common-library` chart instead of re-defining helpers.

#### Which issue this PR fixes

None

#### Special notes for your reviewer:

Hi please review this thank you.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
