### PR TITLE
[nri-bundle] Update bundle dependencies

### DIFF
--- a/charts/nri-bundle/Chart.lock
+++ b/charts/nri-bundle/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: newrelic-infrastructure
   repository: https://newrelic.github.io/nri-kubernetes
-  version: 3.12.0
+  version: 3.13.0
 - name: nri-prometheus
   repository: https://newrelic.github.io/nri-prometheus
   version: 2.1.15
@@ -10,7 +10,7 @@ dependencies:
   version: 1.0.1
 - name: nri-metadata-injection
   repository: https://newrelic.github.io/k8s-metadata-injection
-  version: 4.0.0
+  version: 4.1.0
 - name: newrelic-k8s-metrics-adapter
   repository: https://newrelic.github.io/newrelic-k8s-metrics-adapter
   version: 1.0.0
@@ -32,5 +32,5 @@ dependencies:
 - name: newrelic-infra-operator
   repository: https://newrelic.github.io/newrelic-infra-operator
   version: 2.0.0
-digest: sha256:bef301b9b23e6f66db3547f42155116068219c9a274bc6cbef03a732a17d0cdf
-generated: "2023-01-19T18:36:55.128459929Z"
+digest: sha256:0ee25f28e58513a0432bc3f3f5cf48e14c3363504688dbc99f98d4e36229af5b
+generated: "2023-03-06T08:43:24.258717-08:00"

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -22,7 +22,7 @@ dependencies:
   - name: newrelic-infrastructure
     repository: https://newrelic.github.io/nri-kubernetes
     condition: infrastructure.enabled,newrelic-infrastructure.enabled
-    version: 3.12.0
+    version: 3.13.0
 
   - name: nri-prometheus
     repository: https://newrelic.github.io/nri-prometheus
@@ -37,7 +37,7 @@ dependencies:
   - name: nri-metadata-injection
     repository: https://newrelic.github.io/k8s-metadata-injection
     condition: webhook.enabled,nri-metadata-injection.enabled
-    version: 4.0.0
+    version: 4.1.0
 
   - name: newrelic-k8s-metrics-adapter
     repository: https://newrelic.github.io/newrelic-k8s-metrics-adapter

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -16,7 +16,7 @@ sources:
   - https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie
   - https://github.com/newrelic/newrelic-infra-operator/tree/master/charts/newrelic-infra-operator
 
-version: 5.0.5
+version: 5.0.6
 
 dependencies:
   - name: newrelic-infrastructure


### PR DESCRIPTION
This PR contains the following changes:

- `newrelic-infrasctructure` (`nri-kubernetes`): `3.12.0` --> `3.13.0`
- `nri-metadata-injection`: `4.0.0` --> `4.1.0`