### PR TITLE
[synthetics-job-manager]: Updating helm charts after deploy

### DIFF
--- a/charts/synthetics-job-manager/Chart.yaml
+++ b/charts/synthetics-job-manager/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: synthetics-job-manager
 description: New Relic Synthetics Containerized Job Manager
 type: application
-version: 1.0.25
-appVersion: release-225
+version: 1.0.26
+appVersion: release-227
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith
@@ -24,11 +24,11 @@ keywords:
   - newrelic
 dependencies:
   - name: ping-runtime
-    version: 1.0.7
+    version: 1.0.8
     condition: ping-runtime.enabled
   - name: node-api-runtime
-    version: 1.0.16
+    version: 1.0.17
     condition: node-api-runtime.enabled
   - name: node-browser-runtime
-    version: 1.0.15
+    version: 1.0.16
     condition: node-browser-runtime.enabled

--- a/charts/synthetics-job-manager/charts/node-api-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/node-api-runtime/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: node-api-runtime
 description: New Relic Synthetics Api Runtime
 type: application
-version: 1.0.16
-appVersion: 1.1.35
+version: 1.0.17
+appVersion: 1.1.38
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith

--- a/charts/synthetics-job-manager/charts/node-browser-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/node-browser-runtime/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: node-browser-runtime
 description: New Relic Synthetics Browser Runtime
 type: application
-version: 1.0.15
-appVersion: 1.1.99
+version: 1.0.16
+appVersion: 1.1.102
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith

--- a/charts/synthetics-job-manager/charts/ping-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/ping-runtime/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: ping-runtime
 description: New Relic Synthetics Ping Runtime
 type: application
-version: 1.0.7
-appVersion: 1.13.0
+version: 1.0.8
+appVersion: 1.14.0
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith


### PR DESCRIPTION
#### Is this a new chart? 

No.

#### What this PR does / why we need it:

Updating the chart and app versions in the synthetics-job-manager chart after a deploy. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
