### PR TITLE
Fix reference to outdated Kubernetes repo

### DIFF
--- a/library/CHART-TEMPLATE/templates/job.yaml
+++ b/library/CHART-TEMPLATE/templates/job.yaml
@@ -2,7 +2,7 @@
 # are responsible of creating certificates and inject them to api services and mutating webhooks
 
 # To do not have colliding name, jobs are usually prefixed and the images we use to patch the webhooks
-# are not in our registry but in k8s.gcr.io.
+# are not in our registry but in registry.k8s.io.
 
 # This is why we test truncateToDNSWithSuffix and images.image with "defaultRegistry" here.
 apiVersion: batch/v1


### PR DESCRIPTION

<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No

#### What this PR does / why we need it:

We are working on updating the Kubernetes registry references:

k8s.gcr.io image registry will be redirected to registry.k8s.io on Monday March 20th.
All images available in k8s.gcr.io are available at registry.k8s.io.

See https://kubernetes.io/blog/2023/03/10/image-registry-redirect/

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
