### PR TITLE
[synthetics-job-manager] NR-99199 set heavyweight workers based on parallelism settings

### DIFF
--- a/charts/synthetics-job-manager/Chart.yaml
+++ b/charts/synthetics-job-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: synthetics-job-manager
 description: New Relic Synthetics Containerized Job Manager
 type: application
-version: 1.0.28
+version: 1.0.29
 appVersion: release-230
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:

--- a/charts/synthetics-job-manager/templates/_helpers.tpl
+++ b/charts/synthetics-job-manager/templates/_helpers.tpl
@@ -173,3 +173,12 @@ default
 {{- $checkTimeout := default 240 .Values.global.checkTimeout -}}
 {{- printf "%d" (add $checkTimeout 20) -}}
 {{- end -}}
+
+{{/*
+Calculates the sum of parallelism of the ephemeral runtimes to configure the SJM parking lot
+*/}}
+{{- define "synthetics-job-manager.runtimeParallelism" -}}
+{{- $browserParallelism := default 1 (index .Values "node-browser-runtime" "parallelism") -}}
+{{- $apiParallelism := default 1 (index .Values "node-api-runtime" "parallelism") -}}
+{{- printf "%d" (add $browserParallelism $apiParallelism) -}}
+{{- end -}}

--- a/charts/synthetics-job-manager/templates/deployment.yaml
+++ b/charts/synthetics-job-manager/templates/deployment.yaml
@@ -74,6 +74,9 @@ spec:
             - name: CHECK_TIMEOUT
               value: {{ .Values.global.checkTimeout | quote }}
             {{- end }}
+
+            - name: HEAVYWEIGHT_WORKERS
+              value: {{ include "synthetics-job-manager.runtimeParallelism" . | quote }}
   
           {{- /*
           TODO - The following are not yet implemented


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
It sums the parallelism settings for the node-browser and node-api runtime pods and configures an environment variable within the SJM pod/container so that SJM knows how many jobs to run concurrently. Right now the parallelism settings don't do much because more pods will come up but SJM won't give them jobs.

#### Which issue this PR fixes
NR-99199

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
