### PR TITLE
[synthetics-job-manager] set heavyweight workers based on parallelism settings NR-99199

### DIFF
--- a/charts/synthetics-job-manager/Chart.yaml
+++ b/charts/synthetics-job-manager/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: synthetics-job-manager
 description: New Relic Synthetics Containerized Job Manager
 type: application
-version: 1.0.28
-appVersion: release-230
+version: 1.0.29
+appVersion: release-232
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith

--- a/charts/synthetics-job-manager/templates/_helpers.tpl
+++ b/charts/synthetics-job-manager/templates/_helpers.tpl
@@ -173,3 +173,12 @@ default
 {{- $checkTimeout := default 240 .Values.global.checkTimeout -}}
 {{- printf "%d" (add $checkTimeout 20) -}}
 {{- end -}}
+
+{{/*
+Calculates the sum of parallelism of the ephemeral runtimes to configure the SJM parking lot
+*/}}
+{{- define "synthetics-job-manager.runtimeParallelism" -}}
+{{- $browserParallelism := default 1 (index .Values "node-browser-runtime" "parallelism") -}}
+{{- $apiParallelism := default 1 (index .Values "node-api-runtime" "parallelism") -}}
+{{- printf "%d" (add $browserParallelism $apiParallelism) -}}
+{{- end -}}

--- a/charts/synthetics-job-manager/templates/deployment.yaml
+++ b/charts/synthetics-job-manager/templates/deployment.yaml
@@ -74,6 +74,9 @@ spec:
             - name: CHECK_TIMEOUT
               value: {{ .Values.global.checkTimeout | quote }}
             {{- end }}
+
+            - name: HEAVYWEIGHT_WORKERS
+              value: {{ include "synthetics-job-manager.runtimeParallelism" . | quote }}
   
           {{- /*
           TODO - The following are not yet implemented


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
- Pulls in the latest version of Synthetics Job Manager
- Sets the HEAVYWEIGHT_WORKERS env variable to the sum of parallelism for the runtimes

#### Which issue this PR fixes
NR-99199

#### Special notes for your reviewer:
🐱 🌵 🍰 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
