### PR TITLE
[nri-bundle] manually update nri-bundle chart version

### DIFF
--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -16,7 +16,7 @@ sources:
   - https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie
   - https://github.com/newrelic/newrelic-infra-operator/tree/master/charts/newrelic-infra-operator
 
-version: 5.0.8
+version: 5.0.9
 
 dependencies:
   - name: newrelic-infrastructure

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -69,7 +69,7 @@ dependencies:
     version: 2.0.6
 
   # Keep the version of pixie-operator-chart in sync with the CRD versions for
-  # olm_crd.yaml and px.dev_viziers.yaml in 
+  # olm_crd.yaml and px.dev_viziers.yaml in
   # https://github.com/newrelic/open-install-library/blob/main/recipes/newrelic/infrastructure/kubernetes.yml
   - name: pixie-operator-chart
     alias: pixie-chart


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
A recent change to the nri-bundle Chart (https://github.com/newrelic/helm-charts/pull/1061) did not trigger dependency version updates from the renovate bot, so the nri-bundle version stayed at 5.0.8. The release workflow seems to have recognized this as a change and is trying to generate a new nri-bundle, but fails because the bundle for 5.0.8 already exists. Subsequent PR merges fail, presumably because the change is still detected. This change manually updates the nri-bundle chart version in order to let the release workflow package up the nri-bundle properly.

Slack discussion for internal NR for more context: https://newrelic.slack.com/archives/C2XN6HL2G/p1681249969204639


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
