### PR TITLE
[nri-bundle] Bump nri-kube-events from 2.3.3 to 2.3.4

### DIFF
--- a/charts/nri-bundle/Chart.lock
+++ b/charts/nri-bundle/Chart.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 4.23.0
 - name: nri-kube-events
   repository: https://newrelic.github.io/nri-kube-events
-  version: 2.3.3
+  version: 2.3.4
 - name: newrelic-logging
   repository: https://newrelic.github.io/helm-charts
   version: 1.13.1
@@ -32,5 +32,5 @@ dependencies:
 - name: newrelic-infra-operator
   repository: https://newrelic.github.io/newrelic-infra-operator
   version: 2.1.2
-digest: sha256:0cfdd5fdaa9ef7cd54abe7533f54cad759b30e2d6b4d7875efb5d22aa49b913b
-generated: "2023-04-06T21:45:28.43041752Z"
+digest: sha256:45bf374ce1426fd12e234bbf7da5f570865db08874f1e48c54647c3791be6140
+generated: "2023-04-12T18:26:20.447334-07:00"

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -16,7 +16,7 @@ sources:
   - https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie
   - https://github.com/newrelic/newrelic-infra-operator/tree/master/charts/newrelic-infra-operator
 
-version: 5.0.9
+version: 5.0.10
 
 dependencies:
   - name: newrelic-infrastructure
@@ -56,7 +56,7 @@ dependencies:
   - name: nri-kube-events
     repository: https://newrelic.github.io/nri-kube-events
     condition: kubeEvents.enabled,nri-kube-events.enabled
-    version: 2.3.3
+    version: 2.3.4
 
   - name: newrelic-logging
     repository: https://newrelic.github.io/helm-charts


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No

#### What this PR does / why we need it:

This PR pulls in the latest `nri-kube-events` chart release: 
https://github.com/newrelic/nri-kube-events/releases/tag/nri-kube-events-2.3.4

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
