### PR TITLE
[synthetics-job-manager] update job manager and runtime chart versions

### DIFF
--- a/charts/synthetics-job-manager/Chart.yaml
+++ b/charts/synthetics-job-manager/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: synthetics-job-manager
 description: New Relic Synthetics Containerized Job Manager
 type: application
-version: 1.0.32
-appVersion: release-234
+version: 1.0.33
+appVersion: release-246
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith
@@ -24,11 +24,11 @@ keywords:
   - newrelic
 dependencies:
   - name: ping-runtime
-    version: 1.0.9
+    version: 1.0.10
     condition: ping-runtime.enabled
   - name: node-api-runtime
-    version: 1.0.18
+    version: 1.0.19
     condition: node-api-runtime.enabled
   - name: node-browser-runtime
-    version: 1.0.20
+    version: 1.0.21
     condition: node-browser-runtime.enabled

--- a/charts/synthetics-job-manager/charts/node-api-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/node-api-runtime/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: node-api-runtime
 description: New Relic Synthetics Api Runtime
 type: application
-version: 1.0.18
-appVersion: 1.1.38
+version: 1.0.19
+appVersion: 1.1.40
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith

--- a/charts/synthetics-job-manager/charts/node-browser-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/node-browser-runtime/Chart.yaml
@@ -3,7 +3,7 @@ name: node-browser-runtime
 description: New Relic Synthetics Browser Runtime
 type: application
 version: 1.0.21
-appVersion: 1.1.120
+appVersion: 1.1.115
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith

--- a/charts/synthetics-job-manager/charts/node-browser-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/node-browser-runtime/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: node-browser-runtime
 description: New Relic Synthetics Browser Runtime
 type: application
-version: 1.0.20
-appVersion: 1.1.111
+version: 1.0.21
+appVersion: 1.1.120
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith

--- a/charts/synthetics-job-manager/charts/ping-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/ping-runtime/Chart.yaml
@@ -3,7 +3,7 @@ name: ping-runtime
 description: New Relic Synthetics Ping Runtime
 type: application
 version: 1.0.10
-appVersion: 1.18.3
+appVersion: 1.19.0
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith

--- a/charts/synthetics-job-manager/charts/ping-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/ping-runtime/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: ping-runtime
 description: New Relic Synthetics Ping Runtime
 type: application
-version: 1.0.9
-appVersion: 1.16.0
+version: 1.0.10
+appVersion: 1.18.3
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

Updates the helm charts to use the latest release versions of the Synthetics Job Manager and its associated runtimes:
Synthetics Job Manager: `release-246`
synthetics-ping-runtime: `1.19.0`
synthetics-node-browser-runtime: `1.1.115`
synthetics-node-api-runtime: `1.1.40`


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
