### PR TITLE
[nri-bundle] Bump newrelic-logging 1.14.1

### DIFF
--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -16,7 +16,7 @@ sources:
   - https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie
   - https://github.com/newrelic/newrelic-infra-operator/tree/master/charts/newrelic-infra-operator
 
-version: 5.0.12
+version: 5.0.13
 
 dependencies:
   - name: newrelic-infrastructure
@@ -61,7 +61,7 @@ dependencies:
   - name: newrelic-logging
     repository: https://newrelic.github.io/helm-charts
     condition: logging.enabled,newrelic-logging.enabled
-    version: 1.13.1
+    version: 1.14.1
 
   - name: newrelic-pixie
     repository: https://newrelic.github.io/helm-charts


### PR DESCRIPTION


#### Is this a new chart

No 

#### What this PR does / why we need it:

Gets the latest changes of newrelic-logging into nri-bundle

#### Which issue this PR fixes

This will bring in:
- version 1.16.0 of newrelic-fluentbit-output: #1079
- init container configuration: #1085

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
