### PR TITLE
[newrelic-logging] Upgrade helm chart to v1.16.0 and app version to v1.17.3

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.15.0
-appVersion: 1.16.0
+version: 1.16.0
+appVersion: 1.17.3
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:


### PR DESCRIPTION
#### What this PR does / why we need it:

Upgrade the logging helm chart to use the last version of Fluent Bit output plugin

* Upgraded logging helm chart to v1.16.0.
* Upgraded app version to v1.17.3

#### Checklist
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name
