### PR TITLE
[newrelic-logging] Leverage built-in `multiline.parser`s

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.17.1
+version: 1.18.0
 appVersion: 1.17.3
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -137,6 +137,14 @@ fluentBit:
 #          Name null
 #          Match *
 
+#    parsers: |
+#      [PARSER]
+#          Name         my_custom_parser
+#          Format       json
+#          Time_Key     time
+#          Time_Format  %Y-%m-%dT%H:%M:%S.%L
+#          Time_Keep    On
+
 image:
   repository: newrelic/newrelic-fluentbit-output
 #  registry: my_registry

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -137,21 +137,6 @@ fluentBit:
 #          Name null
 #          Match *
 
-    parsers: |
-      [PARSER]
-          Name         docker
-          Format       json
-          Time_Key     time
-          Time_Format  %Y-%m-%dT%H:%M:%S.%L
-          Time_Keep    On
-
-      [PARSER]
-          Name cri
-          Format regex
-          Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
-          Time_Key    time
-          Time_Format %Y-%m-%dT%H:%M:%S.%L%z
-
 image:
   repository: newrelic/newrelic-fluentbit-output
 #  registry: my_registry

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -62,7 +62,7 @@ fluentBit:
           Name              tail
           Tag               kube.*
           Path              ${PATH}
-          Parser            ${LOG_PARSER}
+          multiline.parser  ${LOG_PARSER}
           DB                ${FB_DB}
           Mem_Buf_Limit     7MB
           Skip_Long_Lines   On


### PR DESCRIPTION
Defining multiple parsers is only supported for multiline parsers. Furthermore, we can now leverage the [built-in multiline parsers for `cri,docker`](https://docs.fluentbit.io/manual/pipeline/inputs/tail#multiline-and-containers-v1.8).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
