### PR TITLE
[newrelic-logging]: Add back image tag suffix for Windows for newrelic-logging

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.18.0
+version: 1.18.1
 appVersion: 1.17.3
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/templates/daemonset-windows.yaml
+++ b/charts/newrelic-logging/templates/daemonset-windows.yaml
@@ -54,7 +54,9 @@ spec:
       {{- end }}
       containers:
         - name: {{ template "newrelic-logging.name" $ }}
-          image: {{ include "newrelic.common.images.image" ( dict "imageRoot" $.Values.image "context" $) }}
+          # We have to use 'replace' to remove the double-quotes that "newrelic.common.images.image" has, so that
+          # we can append the Windows image tag suffix (and then re-quote that value)
+          image: "{{ include "newrelic.common.images.image" ( dict "imageRoot" $.Values.image "context" $) | replace "\"" ""}}-{{ .imageTagSuffix }}"
           imagePullPolicy: "{{ $.Values.image.pullPolicy }}"
           securityContext: {}
           env:

--- a/charts/newrelic-logging/tests/images_test.yaml
+++ b/charts/newrelic-logging/tests/images_test.yaml
@@ -7,6 +7,28 @@ release:
   name: my-release
   namespace: my-namespace
 tests:
+  - it: image names are correct
+    templates:
+      - templates/daemonset.yaml
+      - templates/daemonset-windows.yaml
+    set:
+      licenseKey: nr_license_key
+      enableWindows: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: newrelic/newrelic-fluentbit-output:1.17.3
+        template: templates/daemonset.yaml
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: newrelic/newrelic-fluentbit-output:1.17.3-windows-ltsc-2019
+        template: templates/daemonset-windows.yaml
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: newrelic/newrelic-fluentbit-output:1.17.3-windows-ltsc-2022
+        template: templates/daemonset-windows.yaml
+        documentIndex: 1
   - it: global registry is used if set
     templates:
       - templates/daemonset.yaml


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No

#### What this PR does / why we need it:

In [this PR](https://github.com/newrelic/helm-charts/pull/1126/files#diff-c0bb284370f360ccbc2828f1011058c92df6170d86b07fb4a911d4a93a356375R57) we accidentally broke the `newrelic-logging` chart for Windows -- our Fluent Bit Windows image has a suffix containing the OS name.
 
#### Which issue this PR fixes

NR-146879

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
