### PR TITLE
[newrelic-logging] Fix bug exposedPorts and extraVolumeMounts

### DIFF
--- a/charts/newrelic-logging/templates/daemonset.yaml
+++ b/charts/newrelic-logging/templates/daemonset.yaml
@@ -121,11 +121,11 @@ spec:
               mountPath: /fluent-bit/etc
             - name: var
               mountPath: /var
-          {{- if .Values.exposedPorts }}
-          ports: {{ toYaml .Values.exposedPorts | nindent 12 }}
-          {{- end }}
           {{- if .Values.extraVolumeMounts }}
               {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- end }}
+          {{- if .Values.exposedPorts }}
+          ports: {{ toYaml .Values.exposedPorts | nindent 12 }}
           {{- end }}
           {{- if .Values.resources }}
           resources:


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

#### What this PR does / why we need it:

#### Which issue this PR fixes
* At this moment there is no way to use exposedPorts and extraVolumeMounts

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
