### PR TITLE
[synthetics-job-manager] node browser and api runtimes deploy

### DIFF
--- a/charts/synthetics-job-manager/Chart.yaml
+++ b/charts/synthetics-job-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: synthetics-job-manager
 description: New Relic Synthetics Containerized Job Manager
 type: application
-version: 1.0.44
+version: 1.0.45
 appVersion: release-291
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:

--- a/charts/synthetics-job-manager/Chart.yaml
+++ b/charts/synthetics-job-manager/Chart.yaml
@@ -27,8 +27,8 @@ dependencies:
     version: 1.0.12
     condition: ping-runtime.enabled
   - name: node-api-runtime
-    version: 1.0.22
+    version: 1.0.23
     condition: node-api-runtime.enabled
   - name: node-browser-runtime
-    version: 1.0.27
+    version: 1.0.28
     condition: node-browser-runtime.enabled

--- a/charts/synthetics-job-manager/charts/node-api-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/node-api-runtime/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: node-api-runtime
 description: New Relic Synthetics Api Runtime
 type: application
-version: 1.0.22
-appVersion: 1.1.50
+version: 1.0.23
+appVersion: 1.1.52
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith

--- a/charts/synthetics-job-manager/charts/node-browser-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/node-browser-runtime/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: node-browser-runtime
 description: New Relic Synthetics Browser Runtime
 type: application
-version: 1.0.27
-appVersion: 2.0.29
+version: 1.0.28
+appVersion: 2.0.32
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
* Updates the helm chart for node browser runtime, api runtime, and synthetics job manager to use latest runtime releases

#### Which issue this PR fixes
* 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
