### PR TITLE
[synthetics-job-manager] update job manager (release-297) and node browser versions (2.0.35)

### DIFF
--- a/charts/synthetics-job-manager/Chart.yaml
+++ b/charts/synthetics-job-manager/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: synthetics-job-manager
 description: New Relic Synthetics Containerized Job Manager
 type: application
-version: 1.0.45
-appVersion: release-291
+version: 1.0.46
+appVersion: release-297
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith
@@ -30,5 +30,5 @@ dependencies:
     version: 1.0.23
     condition: node-api-runtime.enabled
   - name: node-browser-runtime
-    version: 1.0.28
+    version: 1.0.29
     condition: node-browser-runtime.enabled

--- a/charts/synthetics-job-manager/charts/node-browser-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/node-browser-runtime/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: node-browser-runtime
 description: New Relic Synthetics Browser Runtime
 type: application
-version: 1.0.28
-appVersion: 2.0.32
+version: 1.0.29
+appVersion: 2.0.35
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

Releases the latest versions of the Synthetics Job Manager and the Synthetics Node Browser Runtime

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
