### PR TITLE
set hostNetwork:false by default ( reopening from https://github.com/newrelic/helm-charts/pull/1100 )

### DIFF
--- a/charts/newrelic-logging/templates/daemonset.yaml
+++ b/charts/newrelic-logging/templates/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}
-      hostNetwork: true # This option is a requirement for the Infrastructure Agent to report the proper hostname in New Relic.
+      hostNetwork: {{ include "newrelic.common.hostNetwork.value" . }}
       {{- with include "newrelic.common.dnsConfig" . }}
       dnsConfig:
         {{- . | nindent 8 }}

--- a/charts/newrelic-logging/tests/hostNetwork_test.yaml
+++ b/charts/newrelic-logging/tests/hostNetwork_test.yaml
@@ -1,0 +1,97 @@
+suite: test hostNetwork
+templates:
+  - templates/daemonset.yaml
+tests:
+  - it: hostNetwork defaults (includes the values.yaml)
+    set:
+      licenseKey: test
+      cluster: test
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: false
+        template: templates/daemonset.yaml
+
+  - it: hostNetwork is false if nothing is set
+    set:
+      licenseKey: test
+      cluster: test
+      global.hostNetwork: null
+      hostNetwork: null
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: false
+        template: templates/daemonset.yaml
+
+  - it: hostNetwork is set by global.hostNetwork
+    set:
+      licenseKey: test
+      cluster: test
+      global.hostNetwork: true
+      hostNetwork: null
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+        template: templates/daemonset.yaml
+
+  - it: hostNetwork is set by global.hostNetwork
+    set:
+      licenseKey: test
+      cluster: test
+      global.hostNetwork: false
+      hostNetwork: null
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: false
+        template: templates/daemonset.yaml
+
+  - it: hostNetwork is overridable to true
+    set:
+      licenseKey: test
+      cluster: test
+      global.hostNetwork: null
+      hostNetwork: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+        template: templates/daemonset.yaml
+
+  - it: hostNetwork is overridable to false
+    set:
+      licenseKey: test
+      cluster: test
+      global.hostNetwork: null
+      hostNetwork: false
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: false
+        template: templates/daemonset.yaml
+
+  - it: hostNetwork is overridable to true
+    set:
+      licenseKey: test
+      cluster: test
+      global.hostNetwork: false
+      hostNetwork: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+        template: templates/daemonset.yaml
+
+  - it: hostNetwork is overridable to false
+    set:
+      licenseKey: test
+      cluster: test
+      global.hostNetwork: true
+      hostNetwork: false
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: false
+        template: templates/daemonset.yaml

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -236,6 +236,10 @@ nodeSelector: {}
 # Windows containers can only be executed on hosts running the exact same Windows version and build number.
 windowsNodeSelector: {}
 
+# -- (bool) Sets pod's hostNetwork. Can be configured also with `global.hostNetwork`
+# @default -- `false`
+hostNetwork: false
+
 # These are default tolerations to be able to run the New Relic Kubernetes integration.
 tolerations:
   - operator: "Exists"


### PR DESCRIPTION
Not sure how or why the other [PR]( https://github.com/newrelic/helm-charts/pull/1100) was closed 

The [newrelic-logging Helm chart](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging) is currently [using the hostNetwork:true setting](https://github.com/newrelic/helm-charts/blob/master/charts/newrelic-logging/templates/daemonset.yaml#L36) when creating the DaemonSet
The recommended value for this setting is false, unless strictly necessary.

To see the specific tasks where the Asana app for GitHub is being used, see below:
https://app.asana.com/0/0/1204883406985385