### PR TITLE
[common-library][newrelic-logging] feature: Adding support for GKE Autopilot

### DIFF
--- a/charts/newrelic-logging/templates/_helpers.tpl
+++ b/charts/newrelic-logging/templates/_helpers.tpl
@@ -185,3 +185,36 @@ If additionalEnvVariables is set, renames to extraEnv. Returns extraEnv.
   {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Returns var volume path
+*/}}
+{{- define "newrelic-logging.varLogPath" -}}
+{{- if (include "newrelic.common.gkeAutopilot" .) -}}
+/var/log
+{{- else -}}
+/var
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns hostNetwork value
+*/}}
+{{- define "newrelic-logging.hostNetwork" -}}
+{{- if (include "newrelic.common.gkeAutopilot" .) -}}
+false
+{{- else -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns FluentBit DB Location
+*/}}
+{{- define "newrelic-logging.fluentDb" -}}
+{{- if (include "newrelic.common.gkeAutopilot" .) -}}
+"/var/flb_kube.db"
+{{- else -}}
+{{ default .Values.fluentBit.db "/var/log/flb_kube.db" }}
+{{- end -}}
+{{- end -}}

--- a/charts/newrelic-logging/templates/daemonset.yaml
+++ b/charts/newrelic-logging/templates/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}
-      hostNetwork: true # This option is a requirement for the Infrastructure Agent to report the proper hostname in New Relic.
+      hostNetwork: {{ include "newrelic-logging.hostNetwork" . }} # This option is a requirement for the Infrastructure Agent to report the proper hostname in New Relic.
       {{- with include "newrelic.common.dnsConfig" . }}
       dnsConfig:
         {{- . | nindent 8 }}
@@ -94,7 +94,8 @@ spec:
               value: "docker,cri"
               {{- end }}
             - name: FB_DB
-              value: {{ .Values.fluentBit.db | quote }}
+              value: {{ include "newrelic-logging.fluentDb" . }}
+              value1: {{ .Values.fluentBit.db | quote }}
             - name: PATH
               value: {{ .Values.fluentBit.path | quote }}
             - name: K8S_BUFFER_SIZE
@@ -120,7 +121,7 @@ spec:
             - name: fluent-bit-config
               mountPath: /fluent-bit/etc
             - name: var
-              mountPath: /var
+              mountPath: {{ include "newrelic-logging.varLogPath" . }}
           {{- if .Values.exposedPorts }}
           ports: {{ toYaml .Values.exposedPorts | nindent 12 }}
           {{- end }}

--- a/charts/nri-bundle/README.md
+++ b/charts/nri-bundle/README.md
@@ -160,6 +160,7 @@ Note, the value table below is automatically generated from `values.yaml` by `he
 | global.customSecretName | string | `""` | Name of the Secret object where the license key is stored |
 | global.dnsConfig | object | `{}` | Sets pod's dnsConfig |
 | global.fargate | bool | false | Must be set to `true` when deploying in an EKS Fargate environment |
+| global.gkeAutopilot | bool | false |  Must be set to `true` when deploying in an GKE Autopilot environment |
 | global.hostNetwork | bool | false | Sets pod's hostNetwork |
 | global.images.pullSecrets | list | `[]` | Set secrets to be able to fetch images |
 | global.images.registry | string | `""` | Changes the registry where to get the images. Useful when there is an internal image cache/proxy |

--- a/charts/nri-bundle/values.yaml
+++ b/charts/nri-bundle/values.yaml
@@ -116,6 +116,10 @@ global:
   # @default -- false
   fargate:
 
+  # -- (bool) Must be set to `true` when deploying in an GKE Autopilot environment
+  # @default -- false
+  gkeAutopilot:
+
   # -- Configures the integration to send all HTTP/HTTPS request through the proxy in that URL. The URL should have a standard format like `https://user:password@hostname:port`
   proxy: ""
 

--- a/library/common-library/templates/_gke-autopilot.tpl
+++ b/library/common-library/templates/_gke-autopilot.tpl
@@ -1,6 +1,26 @@
-{{/*
-Returns gkeAutopilot
-*/}}
+{{- /*
+This helper allows to override the global `.global.gkeAutopilot` with the value of `.gkeAutopilot`.
+Returns "true" if `gkeAutopilot` is enabled, otherwise "" (empty string)
+# Source: ./_hostNetwork.tpl
+*/ -}}
 {{- define "newrelic.common.gkeAutopilot" -}}
-{{- coalesce .Values.global.gkeAutopilot .Values.gkeAutopilot }}
+{{- /* `get` will return "" (empty string) if value is not found, and the value otherwise, so we can type-assert with kindIs */ -}}
+{{- if (get .Values "gkeAutopilot" | kindIs "bool") -}}
+    {{- if .Values.gkeAutopilot -}}
+        {{- /*
+            We want only to return when this is true, returning `false` here will template "false" (string) when doing
+            an `(include "newrelic.common.gkeAutopilot" .)`, which is not an "empty string" so it is `true` if it is used
+            as an evaluation somewhere else.
+        */ -}}
+        {{- .Values.gkeAutopilot -}}
+    {{- end -}}
+{{- else -}}
+{{- /* This allows us to use `$global` as an empty dict directly in case `Values.global` does not exists */ -}}
+{{- $global := index .Values "global" | default dict -}}
+{{- if get $global "gkeAutopilot" | kindIs "bool" -}}
+    {{- if $global.gkeAutopilot -}}
+        {{- $global.gkeAutopilot -}}
+    {{- end -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}

--- a/library/common-library/templates/_gke-autopilot.tpl
+++ b/library/common-library/templates/_gke-autopilot.tpl
@@ -2,7 +2,5 @@
 Returns gkeAutopilot
 */}}
 {{- define "newrelic.common.gkeAutopilot" -}}
-{{- if (or .Values.global.gkeAutopilot .Values.gkeAutopilot) -}}
-{{- default .Values.global.gkeAutopilot .Values.gkeAutopilot -}}
-{{- end -}}
+{{- coalesce .Values.global.gkeAutopilot .Values.gkeAutopilot }}
 {{- end -}}

--- a/library/common-library/templates/_gke-autopilot.tpl
+++ b/library/common-library/templates/_gke-autopilot.tpl
@@ -1,0 +1,8 @@
+{{/*
+Returns gkeAutopilot
+*/}}
+{{- define "newrelic.common.gkeAutopilot" -}}
+{{- if (or .Values.global.gkeAutopilot .Values.gkeAutopilot) -}}
+{{- default .Values.global.gkeAutopilot .Values.gkeAutopilot -}}
+{{- end -}}
+{{- end -}}

--- a/library/common-library/templates/_privileged.tpl
+++ b/library/common-library/templates/_privileged.tpl
@@ -5,7 +5,9 @@ This is a helper that returns whether the chart should assume the user is fine d
 {{- /* This allows us to use `$global` as an empty dict directly in case `Values.global` does not exists. */ -}}
 {{- $global := index .Values "global" | default dict -}}
 {{- /* `get` will return "" (empty string) if value is not found, and the value otherwise, so we can type-assert with kindIs */ -}}
-{{- if get .Values "privileged" | kindIs "bool" -}}
+{{- if include "newrelic.common.gkeAutopilot" . -}}
+    false
+{{- else if get .Values "privileged" | kindIs "bool" -}}
     {{- if .Values.privileged -}}
         {{- .Values.privileged -}}
     {{- end -}}


### PR DESCRIPTION
This pull request enhances the New Relic Helm chart by introducing a feature flag for Google Kubernetes Engine Autopilot, making it more compatible and functional in Autopilot environments. 

<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
Currently, there is only support for AWS Fargate.  This PR adds support for GKE Autopilot.

#### Which issue this PR fixes
* Disabling Hostnetwork: The PR disables the hostnetwork, ensuring that network configurations align with GKE Autopilot's requirements.

* Fluentbit DB Location Override: It addresses an issue where Fluentbit attempts to write to a read-only location. This change allows for proper Fluentbit operation within the chart.

* Common Library Addition: The PR introduces a common library to detect whether GKE Autopilot is enabled, either through the gkeAutopilot or global.gkeAutopilot setting. This addition streamlines the codebase and makes it more maintainable.

* Updated Mounted Path of logging: Additionally, this PR updates the mounted path to /var/log instead of just /var. This adjustment is necessary because GKE Autopilot does not support mounting the /var directory directly from the host. By specifying the /var/log path, the PR ensures that the New Relic Helm chart functions seamlessly in GKE Autopilot environments, enhancing its compatibility and usability.

#### Special notes for your reviewer:
This is my first chart change, so I'm eager to get this pull request out and see if we can get a build created. Your feedback and guidance are greatly appreciated.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
