### PR TITLE
[chore] Add a ci pipeline to test renovate's configuration on PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base",
+    "config:recommended",
     // Disable the creation of this issue that renovate updates with the pending issue we follow with Zenhub:
     // https://github.com/newrelic/helm-charts/issues/484
     ":disableDependencyDashboard"
@@ -14,7 +14,7 @@
   "packageRules": [
     {
       // Group all nri-bundle dependencies together in a single PR.
-      "matchPaths": [
+      "matchFileNames": [
         "charts/nri-bundle/**"
       ],
       "groupName": "Bundle dependencies",
@@ -30,7 +30,7 @@
     },
     {
       // Disable updates in nri-bundle-legacy chart.
-      "matchPaths": [
+      "matchFileNames": [
         "charts/nri-bundle-legacy/**"
       ],
       "enabled": false
@@ -40,7 +40,7 @@
       "matchPackageNames": [
         "newrelic-infrastructure"
       ],
-      "matchPaths": [
+      "matchFileNames": [
         "charts/nri-bundle-legacy/**"
       ],
       "matchUpdateTypes": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -48,7 +48,9 @@
         "patch"
       ],
       "enabled": true
-    },
+    }
+  ],
+  "regexManagers": [
     {
       // Update Super Agent chart
       "fileMatch": [ "^charts/super-agent-deployment/Chart.yaml$" ],

--- a/.github/workflows/test-renovate-configuration.yaml
+++ b/.github/workflows/test-renovate-configuration.yaml
@@ -1,0 +1,17 @@
+name: Test Renovate configuration
+
+on: pull_request
+
+jobs:
+  renovate-config-validator:
+    name: Renovate config validator
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Renovate config validator
+        run: npm install --global renovate
+
+      - name: Test that the config is valid
+        run: renovate-config-validator


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
I merged an invalid configuration for renovatebot on the PR #1155

This PR should add a test to not allow to merging an invalid configuration and fix the configuration.

#### Which issue this PR fixes
  - fixes #1180

#### Special notes for your reviewer:
The first commit (or set of commits) tries to create a pipeline that fails because the configuration is broken at the time of opening this PR.

After having a failing pipeline, I'll add a commit that fixes the config.

I advise the reviewer to go commit by commit. I'll try to squash them to make the review easier :)

#### Checklist
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
