### PR TITLE
Add missing flux2 helm repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,7 @@ jobs:
           helm repo add pixie-operator-chart https://pixie-operator-charts.storage.googleapis.com
           helm repo add newrelic-infra-operator https://newrelic.github.io/newrelic-infra-operator
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo add flux2 https://fluxcd-community.github.io/helm-charts
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
See this [release](https://github.com/newrelic/helm-charts/actions/runs/6655400256/job/18085596673) failing.