### PR TITLE
fix(cm): add config maps and make superAgent compatible

### DIFF
--- a/charts/super-agent-deployment/Chart.yaml
+++ b/charts/super-agent-deployment/Chart.yaml
@@ -3,7 +3,7 @@ name: super-agent-deployment
 description: A Helm chart to install New Relic Super agent on Kubernetes
 
 type: application
-version: 0.0.1-beta
+version: 0.0.2-beta
 appVersion: nightly  # TODO: Change this with a proper version of the image.
 
 dependencies:

--- a/charts/super-agent-deployment/templates/_helpers.tpl
+++ b/charts/super-agent-deployment/templates/_helpers.tpl
@@ -54,12 +54,9 @@ readOnlyRootFilesystem: true
 {{- $defaults := fromYaml ( include "newrelic-super-agent.securityContext.containerDefaults" . ) -}}
 {{- $commonLibrary := include "newrelic.common.securityContext.container" . | fromYaml -}}
 
-{{- $finalSecurityContext := dict -}}
 {{- if $commonLibrary -}}
-    {{- $finalSecurityContext = mustMergeOverwrite $commonLibrary  -}}
+    {{- toYaml $commonLibrary -}}
 {{- else -}}
-    {{- $finalSecurityContext = $defaults  -}}
+    {{- toYaml $defaults -}}
 {{- end -}}
-
-{{- toYaml $finalSecurityContext -}}
 {{- end -}}

--- a/charts/super-agent-deployment/templates/_helpers.tpl
+++ b/charts/super-agent-deployment/templates/_helpers.tpl
@@ -40,3 +40,26 @@ If you need a list of TODOs, just `grep TODO` on the `values.yaml` and look for 
   {{- .Values.config.content | toYaml -}}
 {{- end -}}
 {{- end -}}
+
+{{- /* These are the defaults that are used for all the containers in this chart */ -}}
+{{- define "newrelic-super-agent.securityContext.containerDefaults" -}}
+runAsUser: 1000
+runAsGroup: 2000
+allowPrivilegeEscalation: false
+readOnlyRootFilesystem: true
+{{- end -}}
+
+{{- /* Allow to change pod defaults dynamically */ -}}
+{{- define "newrelic-super-agent.securityContext.container" -}}
+{{- $defaults := fromYaml ( include "newrelic-super-agent.securityContext.containerDefaults" . ) -}}
+{{- $commonLibrary := include "newrelic.common.securityContext.container" . | fromYaml -}}
+
+{{- $finalSecurityContext := dict -}}
+{{- if $commonLibrary -}}
+    {{- $finalSecurityContext = mustMergeOverwrite $commonLibrary  -}}
+{{- else -}}
+    {{- $finalSecurityContext = $defaults  -}}
+{{- end -}}
+
+{{- toYaml $finalSecurityContext -}}
+{{- end -}}

--- a/charts/super-agent-deployment/templates/deployment-superagent.yaml
+++ b/charts/super-agent-deployment/templates/deployment-superagent.yaml
@@ -66,7 +66,9 @@ spec:
             - name: super-agent-config
               mountPath: /etc/newrelic-super-agent
               readOnly: true
-
+            - mountPath: /var/lib/newrelic-super-agent
+              name: var-lib-newrelic-super-agent
+              readOnly: false
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -80,7 +82,8 @@ spec:
             items:
               - key: {{ include "newrelic-super-agent.config.key" . }}
                 path: config.yaml
-
+        - name: var-lib-newrelic-super-agent
+          emptyDir: {}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/super-agent-deployment/templates/deployment-superagent.yaml
+++ b/charts/super-agent-deployment/templates/deployment-superagent.yaml
@@ -45,9 +45,9 @@ spec:
 
       containers:
         - name: {{ .Chart.Name }}
-          {{- with include "newrelic.common.securityContext.container" . }}
+          {{- with include "newrelic-super-agent.securityContext.container" . | fromYaml }}
           securityContext:
-            {{- . | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           image: {{ include "newrelic.common.images.image" ( dict "imageRoot" .Values.image "context" .) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/super-agent-deployment/templates/deployment-superagent.yaml
+++ b/charts/super-agent-deployment/templates/deployment-superagent.yaml
@@ -66,6 +66,7 @@ spec:
             - name: super-agent-config
               mountPath: /etc/newrelic-super-agent
               readOnly: true
+            # TODO: when releasing we should check if this is still needed and if we need to persist the data.
             - mountPath: /var/lib/newrelic-super-agent
               name: var-lib-newrelic-super-agent
               readOnly: false

--- a/charts/super-agent-deployment/templates/rbac.yaml
+++ b/charts/super-agent-deployment/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   labels:
     {{- include "newrelic.common.labels" . | nindent 4 }}
-  name: {{ include "newrelic.common.naming.fullname" . }}
+  name: {{ include "newrelic.common.naming.fullname" . }}-flux
   namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
@@ -21,6 +21,15 @@ rules:
       - deletecollection
       - patch
       - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "newrelic.common.labels" . | nindent 4 }}
+  name: {{ include "newrelic.common.naming.fullname" . }}-cm
+  namespace: {{ .Release.Namespace }}
+rules:
   - apiGroups: [ "" ]
     resources: ["configmaps"]
     verbs:
@@ -36,12 +45,28 @@ kind: RoleBinding
 metadata:
   labels:
     {{- include "newrelic.common.labels" . | nindent 4 }}
-  name: {{ include "newrelic.common.naming.fullname" . }}
+  name: {{ include "newrelic.common.naming.fullname" . }}-flux
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "newrelic.common.naming.fullname" . }}
+  name: {{ include "newrelic.common.naming.fullname" . }}-flux
+subjects:
+- kind: ServiceAccount
+  name: {{ include "newrelic.common.serviceAccount.name" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    {{- include "newrelic.common.labels" . | nindent 4 }}
+  name: {{ include "newrelic.common.naming.fullname" . }}-cm
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "newrelic.common.naming.fullname" . }}-cm
 subjects:
 - kind: ServiceAccount
   name: {{ include "newrelic.common.serviceAccount.name" . }}

--- a/charts/super-agent-deployment/templates/rbac.yaml
+++ b/charts/super-agent-deployment/templates/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   labels:
     {{- include "newrelic.common.labels" . | nindent 4 }}
-  name: {{ include "newrelic.common.naming.fullname" . }}-flux
+  name: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "flux") }}
   namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
@@ -27,7 +27,7 @@ kind: ClusterRole
 metadata:
   labels:
     {{- include "newrelic.common.labels" . | nindent 4 }}
-  name: {{ include "newrelic.common.naming.fullname" . }}-cm
+  name: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "cm") }}
   namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups: [ "" ]
@@ -45,12 +45,12 @@ kind: RoleBinding
 metadata:
   labels:
     {{- include "newrelic.common.labels" . | nindent 4 }}
-  name: {{ include "newrelic.common.naming.fullname" . }}-flux
+  name: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "flux") }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "newrelic.common.naming.fullname" . }}-flux
+  name: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "flux") }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "newrelic.common.serviceAccount.name" . }}
@@ -61,12 +61,12 @@ kind: RoleBinding
 metadata:
   labels:
     {{- include "newrelic.common.labels" . | nindent 4 }}
-  name: {{ include "newrelic.common.naming.fullname" . }}-cm
+  name: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "cm") }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "newrelic.common.naming.fullname" . }}-cm
+  name: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "cm") }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "newrelic.common.serviceAccount.name" . }}

--- a/charts/super-agent-deployment/templates/rbac.yaml
+++ b/charts/super-agent-deployment/templates/rbac.yaml
@@ -21,13 +21,23 @@ rules:
       - deletecollection
       - patch
       - update
+  - apiGroups: [ "" ]
+    resources: ["configmaps"]
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   labels:
     {{- include "newrelic.common.labels" . | nindent 4 }}
   name: {{ include "newrelic.common.naming.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/super-agent-deployment/tests/rbac_test.yaml
+++ b/charts/super-agent-deployment/tests/rbac_test.yaml
@@ -11,7 +11,7 @@ tests:
         create: true
     asserts:
       - hasDocuments:
-          count: 2
+          count: 4
   - it: RBAC does not template
     set:
       rbac:

--- a/charts/super-agent-deployment/tests/securityContext_test.yaml
+++ b/charts/super-agent-deployment/tests/securityContext_test.yaml
@@ -1,0 +1,45 @@
+suite: test securityContext
+templates:
+  - templates/deployment-superagent.yaml
+tests:
+  - it: securityContext.runAsUser is populated with defaults
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 1000
+        template: templates/deployment-superagent.yaml
+
+  - it: securityContext from the common library is templated
+    set:
+      licenseKey: test
+      cluster: test
+      global.containerSecurityContext:
+        runAsUser: 200
+        runAsGroup: 2000
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            runAsUser: 200
+            runAsGroup: 2000
+        template: templates/deployment-superagent.yaml
+
+  - it: global securityContext is ignored if local value is present
+    set:
+      licenseKey: test
+      cluster: test
+      global.containerSecurityContext:
+        runAsUser: 200
+        runAsGroup: 2000
+      containerSecurityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        runAsUser: 300
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 300
+        template: templates/deployment-superagent.yaml


### PR DESCRIPTION
Changes:
 - After the changes introduced by @rubenruizdegauna the container needs to be able to write to /var/lib. For now an empty dir is enough
 - The SA needs to be able to CRUD configmaps
 - Reduced the scope of the clusterRole to a single namespace