### PR TITLE
[super-agent-deployment] include cluster_name and namespace in the config-map

### DIFF
--- a/charts/super-agent-deployment/Chart.yaml
+++ b/charts/super-agent-deployment/Chart.yaml
@@ -3,7 +3,7 @@ name: super-agent-deployment
 description: A Helm chart to install New Relic Super agent on Kubernetes
 
 type: application
-version: 0.0.2-beta
+version: 0.0.3-beta
 appVersion: nightly  # TODO: Change this with a proper version of the image.
 
 dependencies:

--- a/charts/super-agent-deployment/Chart.yaml
+++ b/charts/super-agent-deployment/Chart.yaml
@@ -3,7 +3,7 @@ name: super-agent-deployment
 description: A Helm chart to install New Relic Super agent on Kubernetes
 
 type: application
-version: 0.0.1-beta
+version: 0.0.2-beta
 appVersion: nightly  # TODO: Change this with a proper version of the image.
 
 dependencies:

--- a/charts/super-agent-deployment/ci/test-values.yaml
+++ b/charts/super-agent-deployment/ci/test-values.yaml
@@ -1,3 +1,4 @@
+cluster: sa-cluster
 config:
   content:
     agents: {}

--- a/charts/super-agent-deployment/templates/_helpers.tpl
+++ b/charts/super-agent-deployment/templates/_helpers.tpl
@@ -36,7 +36,8 @@ the config.
 
 If you need a list of TODOs, just `grep TODO` on the `values.yaml` and look for things that are yet to be implemented.
 */ -}}
-{{- if .Values.config.content -}}
-  {{- .Values.config.content | toYaml -}}
-{{- end -}}
+{{- $config :=  .Values.config.content | default dict -}}
+{{- $config = mustMergeOverwrite (dict "k8s" (dict "cluster_name" (include "newrelic.common.cluster" .))) $config -}}
+{{- $config = mustMergeOverwrite (dict "k8s" (dict "namespace" .Release.Namespace)) $config -}}
+{{- $config | toYaml -}}
 {{- end -}}

--- a/charts/super-agent-deployment/tests/configmap_config_test.yaml
+++ b/charts/super-agent-deployment/tests/configmap_config_test.yaml
@@ -12,15 +12,20 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-  - it: super agent's config could be empty
+  - it: super agent's config always include cluster_name and namespace
     set:
+      cluster: my-cluster
       config: {}
     asserts:
       - equal:
           path: data["config.yaml"]
-          value: ""
+          value: |
+            k8s:
+              cluster_name: my-cluster
+              namespace: my-namespace
   - it: super agent's config templates
     set:
+      cluster: my-cluster
       config:
         content:
           test: value
@@ -29,5 +34,27 @@ tests:
       - equal:
           path: data["config.yaml"]
           value: |
+            k8s:
+              cluster_name: my-cluster
+              namespace: my-namespace
+            test: value
+            test2: value2
+  - it: cluster_name and namespace from config have precedence
+    set:
+      cluster: my-cluster
+      config:
+        content:
+          test: value
+          test2: value2
+          k8s:
+            cluster_name: config-cluster
+            namespace: config-namespace
+    asserts:
+      - equal:
+          path: data["config.yaml"]
+          value: |
+            k8s:
+              cluster_name: config-cluster
+              namespace: config-namespace
             test: value
             test2: value2


### PR DESCRIPTION

#### What this PR does / why we need it:

Following up the support of k8s values in the super-agent [newrelic-super-agent#283](https://github.com/newrelic/newrelic-super-agent/pull/283), this PR includes the cluster_name
and the namespace in the super-agent config map. 

#### Special notes for your reviewer:

❗ The pipeline will fail since we are using the `nightly` version of the super-agent and it already expects these new values. Consequently, the previous version of the chart doesn't work anymore.
