### PR TITLE
[newrelic-pixie] Update newrelic-pixie chart to support ARM and include updates in nri-bundle

### DIFF
--- a/charts/newrelic-pixie/Chart.yaml
+++ b/charts/newrelic-pixie/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart for the New Relic Pixie integration.
 name: newrelic-pixie
-version: 2.1.2
-appVersion: 2.1.4
+version: 2.1.3
+appVersion: 2.2.0
 home: https://hub.docker.com/u/newrelic
 sources:
   - https://github.com/newrelic/

--- a/charts/newrelic-pixie/values.yaml
+++ b/charts/newrelic-pixie/values.yaml
@@ -24,8 +24,8 @@
 # customSecretApiKeyKey:
 
 image:
-  repository: ddelnano/newrelic-pixie-integration
-  tag: "multiarch-0.2"
+  repository: newrelic/newrelic-pixie-integration
+  tag: ""
   pullPolicy: IfNotPresent
   pullSecrets: []
   # - name: regsecret

--- a/charts/nri-bundle/Chart.lock
+++ b/charts/nri-bundle/Chart.lock
@@ -25,7 +25,7 @@ dependencies:
   version: 1.18.1
 - name: newrelic-pixie
   repository: https://newrelic.github.io/helm-charts
-  version: 2.1.2
+  version: 2.1.3
 - name: pixie-operator-chart
   repository: https://pixie-operator-charts.storage.googleapis.com
   version: 0.1.4

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -62,7 +62,7 @@ dependencies:
   - name: newrelic-pixie
     repository: https://newrelic.github.io/helm-charts
     condition: newrelic-pixie.enabled
-    version: 2.1.2
+    version: 2.1.3
 
   # Keep the version of pixie-operator-chart in sync with the CRD versions for
   # olm_crd.yaml and px.dev_viziers.yaml in


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

Update newrelic-pixie chart to support ARM and include updates in nri-bundle

#### Is this a new chart

No

#### What this PR does / why we need it:
Updates the newrelic-pixie-integration container image to a multi arch image including one of its dependencies (curl container)

#### Which issue this PR fixes

  - fixes #1152 

#### Special notes for your reviewer:

##### Testing done
- [x] Deployed the newrelic-pixie chart standalone to an ARM cluster and verified that it is successful and no longer experiences the exec error from #1152 

```
Events:
  Type    Reason     Age   From               Message
  ----    ------     ----  ----               -------
  Normal  Scheduled  4m5s  default-scheduler  Successfully assigned newrelic/newrelic-pixie-c9bcx to aks-armpool-21043053-vmss000019
  Normal  Pulled     4m4s  kubelet            Container image "gcr.io/pixie-oss/pixie-dev-public/curl:multiarch-7.87.0@sha256:f7f265d5c64eb4463a43a99b6bf773f9e61a50aaa7cefaf564f43e42549a01dd" already present on machine
  Normal  Created    4m4s  kubelet            Created container cluster-registration-wait
  Normal  Started    4m4s  kubelet            Started container cluster-registration-wait
  Normal  Pulling    4m4s  kubelet            Pulling image "newrelic/newrelic-pixie-integration:2.2.0"
  Normal  Pulled     4m2s  kubelet            Successfully pulled image "newrelic/newrelic-pixie-integration:2.2.0" in 1.661279967s (1.661287247s including waiting)
  Normal  Created    4m2s  kubelet            Created container newrelic-pixie
  Normal  Started    4m2s  kubelet            Started container newrelic-pixie

# Job events
Events:
  Type    Reason            Age    From            Message
  ----    ------            ----   ----            -------
  Normal  SuccessfulCreate  4m50s  job-controller  Created pod: newrelic-pixie-c9bcx
  Normal  Completed         4m19s  job-controller  Job completed
```

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md -- Not applicable
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
