### PR TITLE
[newrelic-logging]: Remove unneeded hostNetwork setting

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.18.1
+version: 1.18.2
 appVersion: 1.17.3
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/templates/daemonset-windows.yaml
+++ b/charts/newrelic-logging/templates/daemonset-windows.yaml
@@ -37,7 +37,6 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "newrelic.common.serviceAccount.name" $ }}
-      hostNetwork: false
       {{- with include "newrelic.common.dnsConfig" $ }}
       dnsConfig:
         {{- . | nindent 8 }}

--- a/charts/newrelic-logging/templates/daemonset.yaml
+++ b/charts/newrelic-logging/templates/daemonset.yaml
@@ -33,7 +33,6 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}
-      hostNetwork: true # This option is a requirement for the Infrastructure Agent to report the proper hostname in New Relic.
       {{- with include "newrelic.common.dnsConfig" . }}
       dnsConfig:
         {{- . | nindent 8 }}

--- a/charts/newrelic-logging/templates/podsecuritypolicy.yaml
+++ b/charts/newrelic-logging/templates/podsecuritypolicy.yaml
@@ -18,7 +18,6 @@ spec:
   - '*'
   hostPID: true
   hostIPC: true
-  hostNetwork: true
   hostPorts:
   - min: 1
     max: 65536


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

We think that `hostNetwork: true` got copied-and-pasted from another chart when the `newrelic-logging` was originally created a few years ago. We want the `newrelic-logging` pod to have as little access as possible, to increase security -- it should just need as much access as it needs to do its job and no more. As far as we can tell, it doesn't need to connect to the host network.

Also, PodSecurityPolicy is now deprecated and
[removed from the latest versions](https://kubernetes.io/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/) of Kubernetes, but we're keeping it because we have customers are older versions of Kubernetes. There is no direct replacement for a PSP, see [here](https://kubernetes.io/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/#what-does-this-mean-for-you) for Kubernetes's advice. 

#### Which issue this PR fixes

- Fixes #335 
  - Note: We do not think that we need to mount `/etc/hostname`

#### Special notes for your reviewer:

I've verified that the logs forwarded by the chart have the same attributes (specifically, the same `host` value) before and after this change. So this `hostNetwork` change _should_ be a no-op -- no functionality will change (besides us not asking for the pod to have access to the host network)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
