### PR TITLE
[newrelic-logging]  Upgrade helm chart to v1.19.0 and app version to v1.19.0

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.18.2
-appVersion: 1.17.3
+version: 1.19.0
+appVersion: 1.19.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:

--- a/charts/newrelic-logging/tests/images_test.yaml
+++ b/charts/newrelic-logging/tests/images_test.yaml
@@ -17,16 +17,16 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: newrelic/newrelic-fluentbit-output:1.17.3
+          value: newrelic/newrelic-fluentbit-output:1.19.0
         template: templates/daemonset.yaml
       - equal:
           path: spec.template.spec.containers[0].image
-          value: newrelic/newrelic-fluentbit-output:1.17.3-windows-ltsc-2019
+          value: newrelic/newrelic-fluentbit-output:1.19.0-windows-ltsc-2019
         template: templates/daemonset-windows.yaml
         documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].image
-          value: newrelic/newrelic-fluentbit-output:1.17.3-windows-ltsc-2022
+          value: newrelic/newrelic-fluentbit-output:1.19.0-windows-ltsc-2022
         template: templates/daemonset-windows.yaml
         documentIndex: 1
   - it: global registry is used if set


### PR DESCRIPTION
#### What this PR does / why we need it:

Upgrade the logging helm chart to use the last version of Fluent Bit output plugin

* Upgraded logging helm chart to v1.19.0.
* Upgraded app version to v1.19.0

#### Checklist
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name
