### PR TITLE
[super-agent-deployment] Redeploy super-agent on configmap changes (NR-182327)

### DIFF
--- a/charts/super-agent-deployment/Chart.yaml
+++ b/charts/super-agent-deployment/Chart.yaml
@@ -3,7 +3,7 @@ name: super-agent-deployment
 description: A Helm chart to install New Relic Super agent on Kubernetes
 
 type: application
-version: 0.0.3-beta
+version: 0.0.4-beta
 appVersion: nightly  # TODO: Change this with a proper version of the image.
 
 dependencies:

--- a/charts/super-agent-deployment/templates/deployment-superagent.yaml
+++ b/charts/super-agent-deployment/templates/deployment-superagent.yaml
@@ -11,10 +11,11 @@ spec:
       {{- include "newrelic.common.labels.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/agent-config: {{ include (print $.Template.BasePath "/configmap-superagent-config.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "newrelic.common.labels.podLabels" . | nindent 8 }}
     spec:

--- a/charts/super-agent-deployment/tests/securityContext_test.yaml
+++ b/charts/super-agent-deployment/tests/securityContext_test.yaml
@@ -1,8 +1,11 @@
 suite: test securityContext
 templates:
   - templates/deployment-superagent.yaml
+  - templates/configmap-superagent-config.yaml
 tests:
   - it: securityContext.runAsUser is populated with defaults
+    set:
+      cluster: test
     asserts:
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsUser


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

This allows the super-agent to redeploy when configuration changes. 

#### Special notes for your reviewer:

#### Checklist
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
