### PR TITLE
[synthetics-job-manager] update helm chart to reflect latest node api runtime deploy

### DIFF
--- a/charts/synthetics-job-manager/Chart.yaml
+++ b/charts/synthetics-job-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: synthetics-job-manager
 description: New Relic Synthetics Containerized Job Manager
 type: application
-version: 1.0.52
+version: 1.0.53
 appVersion: release-321
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
@@ -27,7 +27,7 @@ dependencies:
     version: 1.0.16
     condition: ping-runtime.enabled
   - name: node-api-runtime
-    version: 1.0.25
+    version: 1.0.26
     condition: node-api-runtime.enabled
   - name: node-browser-runtime
     version: 1.0.31

--- a/charts/synthetics-job-manager/charts/node-api-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/node-api-runtime/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: node-api-runtime
 description: New Relic Synthetics Api Runtime
 type: application
-version: 1.0.25
-appVersion: 1.2.8
+version: 1.0.26
+appVersion: 1.2.12
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith


### PR DESCRIPTION
#### Is this a new chart
Nope :) 
#### What this PR does / why we need it:
Updates node-api-runtime chart to pull latest version
#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
