### PR TITLE
WIP [newrelic-logging] Add persistent volumes for fb db

### DIFF
--- a/charts/newrelic-logging/templates/daemonset.yaml
+++ b/charts/newrelic-logging/templates/daemonset.yaml
@@ -92,8 +92,17 @@ spec:
               {{- else }}
               value: "docker,cri"
               {{- end }}
+            {{- if .Values.persistentVolume.enabled }}
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: FB_DB
+              value: "/db/$(NODE_NAME)-fb.db"
+            {{- else }}
             - name: FB_DB
               value: {{ .Values.fluentBit.db | quote }}
+            {{- end }}
             - name: PATH
               value: {{ .Values.fluentBit.path | quote }}
             - name: K8S_BUFFER_SIZE
@@ -118,8 +127,13 @@ spec:
           volumeMounts:
             - name: fluent-bit-config
               mountPath: /fluent-bit/etc
-            - name: var
-              mountPath: /var
+            - name: var-log
+              mountPath: /var/log
+            {{- if .Values.persistentVolume.enabled }}
+              readOnly: true
+            - name: fb-db-pvc
+              mountPath: /db
+            {{- end}}
           {{- if .Values.exposedPorts }}
           ports: {{ toYaml .Values.exposedPorts | nindent 12 }}
           {{- end }}
@@ -134,9 +148,14 @@ spec:
         - name: fluent-bit-config
           configMap:
             name: {{ template "newrelic-logging.fluentBitConfig" . }}
-        - name: var
+        - name: var-log
           hostPath:
-            path: /var
+            path: /var/log
+        {{- if .Values.persistentVolume.enabled }}
+        - name: fb-db-pvc
+          persistentVolumeClaim:
+            claimName: {{ template "newrelic-logging.fullname" . }}-pvc
+        {{- end}}
       {{- if .Values.extraVolumes }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}

--- a/charts/newrelic-logging/templates/persistentvolume.yaml
+++ b/charts/newrelic-logging/templates/persistentvolume.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.persistentVolume.enabled }}
+{{- if not .Values.persistentVolume.dynamicProvisioning }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "newrelic-logging.labels" . | indent 4 }}
+  name: {{ template "newrelic-logging.fullname" . }}-pv
+  annotations:
+  {{- if .Values.persistentVolume.annotations }}
+{{ toYaml .Values.persistentVolume.annotations | indent 4 }}
+  {{- end }}
+spec: 
+  accessModes:
+    - ReadWriteMany
+  capacity:
+    storage: {{ .Values.persistentVolume.size }}
+  storageClassName: {{ .Values.persistentVolume.storageClassName }}
+  persistentVolumeReclaimPolicy: Retain
+---
+{{- end }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "newrelic-logging.labels" . | indent 4 }}
+  name: {{ template "newrelic-logging.fullname" . }}-pvc
+  annotations:
+  {{- if .Values.persistentVolume.annotations }}
+{{ toYaml .Values.persistentVolume.annotations | indent 4 }}
+  {{- end }}
+spec:
+  storageClassName: {{ .Values.persistentVolume.storageClassName }}
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.persistentVolume.size }}
+{{- end }}

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -284,3 +284,12 @@ windows:
 
 # -- Sets pod dnsConfig. Can also be configured with `global.dnsConfig`
 dnsConfig: {}
+
+# -- Use persistent volumes to store the fluent-bit db, this will override `fluentBit.db` path and use `/db/${NODE_NAME}-fb.db` file instead
+persistentVolume:
+  enabled: false
+  size: 10Gi
+  # -- The storage class should allow ReadWriteMany mode
+  storageClassName: "standard-rwx"
+  # -- If dynamicProvisioning is enabled the chart will create only the PersistentVolumeClaim
+  dynamicProvisioning: true


### PR DESCRIPTION
This is a WIP

#### Is this a new chart
No

#### What this PR does / why we need it:
This will enable to use the logging chart in environments where hostPath is not possible as it doesn't need to have read/write permission over /var/log.

#### Which issue this PR fixes
- 

#### Special notes for your reviewer:
- 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
