### PR TITLE
fix: Update Renovate config file

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,13 @@
   ],
   "bumpVersion": "patch",
   "packageRules": [
+    // This is a shared repository where it is not clear that generic rules apply
+    // Making rules per folders or properties runs the risk that future 
+    // projects get accidentally automerged because they are not covered in old presets
+    {
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest", "pinDigest"],
+      "automerge": false
+    },
     {
       // Group all nri-bundle dependencies together in a single PR.
       "matchFileNames": [


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
Given the fact that this repository is shared by various teams with different rules on when to merge dependencies, it is not feasible to allow automerge without the risk of unintended merges happening in the future. This PR completely disables automerge for Renovate, forcing Renovate to create PRs that need to be manually merged by developers.