### PR TITLE
Revert "chore(deps): update helm release flux2 to v2.12.2 (#1222)"

### DIFF
--- a/charts/super-agent/Chart.lock
+++ b/charts/super-agent/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: flux2
   repository: https://fluxcd-community.github.io/helm-charts
-  version: 2.12.2
+  version: 2.12.1
 - name: common-library
   repository: https://helm-charts.newrelic.com
   version: 1.1.1
-digest: sha256:b8accc892d1405e664f9b1d47ad5246d9c9c1f266eb003608bc05423f56c4a26
-generated: "2024-01-23T07:58:02.772869526Z"
+digest: sha256:a891741628e34b65aaa135be033063cba8fb8b217198f00c0776ec063e0a5947
+generated: "2023-12-14T21:32:17.525166844Z"

--- a/charts/super-agent/Chart.yaml
+++ b/charts/super-agent/Chart.yaml
@@ -3,12 +3,12 @@ name: super-agent
 description: Bootstraps New Relic' Super Agent
 
 type: application
-version: 0.0.1
+version: 0.0.1-beta
 
 dependencies:
   - name: flux2
     repository: https://fluxcd-community.github.io/helm-charts
-    version: 2.12.2
+    version: 2.12.1
     condition: flux2.enabled
   - name: common-library
     version: 1.1.1


### PR DESCRIPTION
This reverts commit 594230530073f1ac622a727040230560a3d3f9a8.

<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

