### PR TITLE
[nri-bundle] Bump newrelic-logging version of nri-bundle to 1.20.0

### DIFF
--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -57,7 +57,7 @@ dependencies:
   - name: newrelic-logging
     repository: https://newrelic.github.io/helm-charts
     condition: logging.enabled,newrelic-logging.enabled
-    version: 1.19.0
+    version: 1.20.0
 
   - name: newrelic-pixie
     repository: https://newrelic.github.io/helm-charts


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
This bumps the newrelic-logging chart version on nri-bundle.

#### Which issue this PR fixes
This adds support for GKE autopilot on newrelic-logging

#### Special notes for your reviewer:
This adds this version of newrelic-logging https://github.com/newrelic/helm-charts/pull/1259
