### PR TITLE
feat(nri-bundle): bump newrelic-logging version to 1.20.0

### DIFF
--- a/charts/nri-bundle/Chart.lock
+++ b/charts/nri-bundle/Chart.lock
@@ -22,7 +22,7 @@ dependencies:
   version: 3.8.0
 - name: newrelic-logging
   repository: https://newrelic.github.io/helm-charts
-  version: 1.19.0
+  version: 1.20.0
 - name: newrelic-pixie
   repository: https://newrelic.github.io/helm-charts
   version: 2.1.2
@@ -32,5 +32,5 @@ dependencies:
 - name: newrelic-infra-operator
   repository: https://newrelic.github.io/newrelic-infra-operator
   version: 2.9.0
-digest: sha256:081eaa5b1f70e0854f4db22172c37692bc88d9ae86c459b2b4bb428f8d3a4b49
-generated: "2024-02-05T12:43:01.920028581Z"
+digest: sha256:567eec2f33e949a44f18902897abc85b9a7ed1093d5cb89eb9de439a8961a08f
+generated: "2024-02-07T12:24:45.602579+01:00"

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -57,7 +57,7 @@ dependencies:
   - name: newrelic-logging
     repository: https://newrelic.github.io/helm-charts
     condition: logging.enabled,newrelic-logging.enabled
-    version: 1.19.0
+    version: 1.20.0
 
   - name: newrelic-pixie
     repository: https://newrelic.github.io/helm-charts


### PR DESCRIPTION
**Is this a new chart**
No

**What this PR does / why we need it:**
This bumps the newrelic-logging chart version on nri-bundle.

**Which issue this PR fixes**
This adds support for GKE autopilot on newrelic-logging

**Special notes for your reviewer:**
This adds this version of newrelic-logging https://github.com/newrelic/helm-charts/pull/1259