### PR TITLE
[synthetics-job-manager] Add latest node browser runtime deploy to helm charts

### DIFF
--- a/charts/synthetics-job-manager/Chart.yaml
+++ b/charts/synthetics-job-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: synthetics-job-manager
 description: New Relic Synthetics Containerized Job Manager
 type: application
-version: 1.0.59
+version: 1.0.60
 appVersion: release-337
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
@@ -30,5 +30,5 @@ dependencies:
     version: 1.0.27
     condition: node-api-runtime.enabled
   - name: node-browser-runtime
-    version: 1.0.35
+    version: 1.0.36
     condition: node-browser-runtime.enabled

--- a/charts/synthetics-job-manager/charts/node-browser-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/node-browser-runtime/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: node-browser-runtime
 description: New Relic Synthetics Browser Runtime
 type: application
-version: 1.0.35
-appVersion: 2.2.10
+version: 1.0.36
+appVersion: 2.2.22
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith


### PR DESCRIPTION

#### Is this a new chart
no

#### What this PR does / why we need it:

- adds latest node browser runtime deploy to helm charts

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
