### PR TITLE
fix: Skip releasing chart if it already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,7 @@ jobs:
           # so use alternative token to allow post-release workflow to run
           # Source: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
           CR_TOKEN: "${{ secrets.K8S_AGENTS_BOT_TOKEN }}"
+          CR_SKIP_EXISTING: true
 
   notify-failure:
     if: ${{ always() && failure() && (github.event_name == 'schedule') }}


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
Last week, [this workflow run](https://github.com/newrelic/helm-charts/actions/runs/7710787642/job/21014874442) created tag `nri-bundle-5.0.61` after tag `super-agent-0.0.2-beta`, so we know for sure temporal dependencies between the two tags.

However, this week [this workflow run failed](https://github.com/newrelic/helm-charts/actions/runs/7799298965/job/21269820082) because it read tag `super-agent-0.0.2-beta` as if it were the latest.

While it is not clear the source of the issue (bad cache, chart releaser action bug?), we can use the flag `--skip-existing` to tell the chart releaser not to fail when a release already exists, adding more reliability to our workflow.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
