### PR TITLE
[synthetics-job-manager] Add ping runtime release to helm chart

### DIFF
--- a/charts/synthetics-job-manager/Chart.yaml
+++ b/charts/synthetics-job-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: synthetics-job-manager
 description: New Relic Synthetics Containerized Job Manager
 type: application
-version: 1.0.60
+version: 1.0.61
 appVersion: release-337
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
@@ -24,7 +24,7 @@ keywords:
   - newrelic
 dependencies:
   - name: ping-runtime
-    version: 1.0.16
+    version: 1.0.17
     condition: ping-runtime.enabled
   - name: node-api-runtime
     version: 1.0.27

--- a/charts/synthetics-job-manager/charts/ping-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/ping-runtime/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: ping-runtime
 description: New Relic Synthetics Ping Runtime
 type: application
-version: 1.0.16
-appVersion: 1.36.0
+version: 1.0.17
+appVersion: 1.38.0
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Adds latest ping runtime release

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
