### PR TITLE
[newrelic-logging] fix: Using extraVolumeMounts and exposedPorts generates invalid YAML

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.20.0
+version: 1.20.1
 appVersion: 1.19.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/templates/daemonset.yaml
+++ b/charts/newrelic-logging/templates/daemonset.yaml
@@ -149,11 +149,11 @@ spec:
             - name: fb-db-pvc
               mountPath: /db
             {{- end }}
-          {{- if .Values.exposedPorts }}
-          ports: {{ toYaml .Values.exposedPorts | nindent 12 }}
-          {{- end }}
           {{- if .Values.extraVolumeMounts }}
               {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- end }}
+          {{- if .Values.exposedPorts }}
+          ports: {{ toYaml .Values.exposedPorts | nindent 12 }}
           {{- end }}
           {{- if .Values.resources }}
           resources:


### PR DESCRIPTION
#### What this PR does / why we need it:

When setting `extraVolumeMounts` and `exposedPorts`

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
