### PR TITLE
[super-agent-deployment] include uninstall job

### DIFF
--- a/charts/super-agent-deployment/Chart.yaml
+++ b/charts/super-agent-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Super agent on Kubernetes
 
 type: application
 
-version: 0.0.8-beta
+version: 0.0.9-beta
 appVersion: 0.7.0
 
 dependencies:

--- a/charts/super-agent-deployment/README.md
+++ b/charts/super-agent-deployment/README.md
@@ -2,7 +2,7 @@
 
 # super-agent-deployment
 
-![Version: 0.0.8-beta](https://img.shields.io/badge/Version-0.0.8--beta-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: nightly](https://img.shields.io/badge/AppVersion-nightly-informational?style=flat-square)
+![Version: 0.0.8-beta](https://img.shields.io/badge/Version-0.0.8--beta-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
 
 A Helm chart to install New Relic Super agent on Kubernetes
 
@@ -35,6 +35,7 @@ At the point of the creation of the chart, it has no particularities and this se
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Sets pod/node affinities. Can be configured also with `global.affinity` |
+| cleanupManagedResources | bool | `true` | Enable the cleanup of super-agent managed resources when the chart is uninstalled. If disabled, agents and / or agent configurations could remain in the cluster after the chart is uninstalled. |
 | cluster | string | `""` | TODO: Name of the Kubernetes cluster monitored. Can be configured also with `global.cluster`. |
 | config.subAgents | object | See `values.yaml` for examples | Values that the fleet is going to have in the deployment. |
 | config.superAgent | object | See `values.yaml` | Configuration for the Super Agent. |

--- a/charts/super-agent-deployment/README.md
+++ b/charts/super-agent-deployment/README.md
@@ -2,7 +2,7 @@
 
 # super-agent-deployment
 
-![Version: 0.0.8-beta](https://img.shields.io/badge/Version-0.0.8--beta-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
+![Version: 0.0.9-beta](https://img.shields.io/badge/Version-0.0.9--beta-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
 
 A Helm chart to install New Relic Super agent on Kubernetes
 

--- a/charts/super-agent-deployment/README.md
+++ b/charts/super-agent-deployment/README.md
@@ -35,7 +35,7 @@ At the point of the creation of the chart, it has no particularities and this se
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Sets pod/node affinities. Can be configured also with `global.affinity` |
-| cleanupManagedResources | bool | `true` | Enable the cleanup of super-agent managed resources when the chart is uninstalled. If disabled, agents and / or agent configurations could remain in the cluster after the chart is uninstalled. |
+| cleanupManagedResources | bool | `true` | Enable the cleanup of super-agent managed resources when the chart is uninstalled. If disabled, agents and / or agent configurations managed by the super-agent will not be deleted when the chart is uninstalled. |
 | cluster | string | `""` | TODO: Name of the Kubernetes cluster monitored. Can be configured also with `global.cluster`. |
 | config.subAgents | object | See `values.yaml` for examples | Values that the fleet is going to have in the deployment. |
 | config.superAgent | object | See `values.yaml` | Configuration for the Super Agent. |

--- a/charts/super-agent-deployment/templates/uninstall-job.yaml
+++ b/charts/super-agent-deployment/templates/uninstall-job.yaml
@@ -33,12 +33,11 @@ spec:
             - |
               set -o pipefail
               {{- /* Delete the standard resources (configmaps) managed by the super-agent */ -}}
-              {{ $managedResourcesNamespace := .Release.Namespace }}
-              kubectl delete configmaps -n {{ $managedResourcesNamespace }} -l {{ $saResourcesLabelSelector }}
+              kubectl delete configmaps -n {{ .Release.Namespace }} -l {{ $saResourcesLabelSelector }}
               {{- /* Delete the CRs managed by the super-agent if the corresponding CRDs exist */ -}}
               {{ range $i, $cr := $saCRList }}
               if kubectl api-resources -o name |grep {{ $cr }}; then
-                kubectl delete {{ $cr }} -n {{ $managedResourcesNamespace }} -l {{ $saResourcesLabelSelector }}
+                kubectl delete {{ $cr }} -n {{ $.Release.Namespace }} -l {{ $saResourcesLabelSelector }}
               fi
               {{ end -}}
 

--- a/charts/super-agent-deployment/templates/uninstall-job.yaml
+++ b/charts/super-agent-deployment/templates/uninstall-job.yaml
@@ -3,7 +3,8 @@
 {{- /*
 The resources managed by the super-agent and the label selector are hardcoded on the super-agent.
 */ -}}
-{{- $saResourcesList := (list "configmaps" "helmreleases" "helmrepositories") -}}
+{{- $saResourceList := (list "configmaps") -}}
+{{- $saCRList := (list "helmreleases.helm.toolkit.fluxcd.io" "helmrepositories.source.toolkit.fluxcd.io") -}}
 {{- $saResourcesLabelSelector := "app.kubernetes.io/managed-by=newrelic-super-agent" -}}
 {{- /*
 To understand why this job installs manifests instead of using Helm, read the comment at `job-manifests.yaml`.
@@ -30,7 +31,17 @@ spec:
             - bash
           args:
             - -c
-            - {{ range $i, $resourceName := $saResourcesList }}
-              {{- if $i }} &&{{ end }} kubectl delete {{ $resourceName }} -l {{ $saResourcesLabelSelector }}
-              {{- end -}}
+            - |
+              set -o pipefail
+              {{- /* Delete the standard resources managed by the super-agent */ -}}
+              {{ range $i, $resourceName := $saResourceList }}
+              kubectl delete {{ $resourceName }} -l {{ $saResourcesLabelSelector }}
+              {{ end -}}
+              {{- /* Delete the CRs managed by the super-agent if the corresponding CRDs exist */ -}}
+              {{ range $i, $cr := $saCRList }}
+              if kubectl api-resources -o name |grep {{ $cr }}; then
+                kubectl delete {{ (splitList "." $cr) |first }} -l {{ $saResourcesLabelSelector }}
+              fi
+              {{ end -}}
+
 {{- end -}}

--- a/charts/super-agent-deployment/templates/uninstall-job.yaml
+++ b/charts/super-agent-deployment/templates/uninstall-job.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.cleanupManagedResources -}}
+{{- $uninstallJobName := include "newrelic.common.naming.truncateToDNSWithSuffix" ( dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "uninstall-job" ) -}}
+{{- /*
+The resources managed by the super-agent and the label selector are hardcoded on the super-agent.
+*/ -}}
+{{- $saResourcesList := (list "configmaps" "helmreleases" "helmrepositories") -}}
+{{- $saResourcesLabelSelector := "app.kubernetes.io/managed-by=newrelic-super-agent" -}}
+{{- /*
+To understand why this job installs manifests instead of using Helm, read the comment at `job-manifests.yaml`.
+*/ -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "10010"
+  name: {{ $uninstallJobName }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  ttlSecondsAfterFinished: 120
+  template:
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}
+      containers:
+        - name: delete-crs
+          image: bitnami/kubectl
+          command:
+            - bash
+          args:
+            - -c
+            - {{ range $i, $resourceName := $saResourcesList }}
+              {{- if $i }} &&{{ end }} kubectl delete {{ $resourceName }} -l {{ $saResourcesLabelSelector }}
+              {{- end -}}
+{{- end -}}

--- a/charts/super-agent-deployment/templates/uninstall-job.yaml
+++ b/charts/super-agent-deployment/templates/uninstall-job.yaml
@@ -3,7 +3,6 @@
 {{- /*
 The resources managed by the super-agent and the label selector are hardcoded on the super-agent.
 */ -}}
-{{- $saResourceList := (list "configmaps") -}}
 {{- $saCRList := (list "helmreleases.helm.toolkit.fluxcd.io" "helmrepositories.source.toolkit.fluxcd.io") -}}
 {{- $saResourcesLabelSelector := "app.kubernetes.io/managed-by=newrelic-super-agent" -}}
 {{- /*
@@ -25,7 +24,7 @@ spec:
       restartPolicy: Never
       serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}
       containers:
-        - name: delete-crs
+        - name: delete-managed-resources
           image: bitnami/kubectl
           command:
             - bash
@@ -33,14 +32,13 @@ spec:
             - -c
             - |
               set -o pipefail
-              {{- /* Delete the standard resources managed by the super-agent */ -}}
-              {{ range $i, $resourceName := $saResourceList }}
-              kubectl delete {{ $resourceName }} -l {{ $saResourcesLabelSelector }}
-              {{ end -}}
+              {{- /* Delete the standard resources (configmaps) managed by the super-agent */ -}}
+              {{ $managedResourcesNamespace := .Release.Namespace }}
+              kubectl delete configmaps -n {{ $managedResourcesNamespace }} -l {{ $saResourcesLabelSelector }}
               {{- /* Delete the CRs managed by the super-agent if the corresponding CRDs exist */ -}}
               {{ range $i, $cr := $saCRList }}
               if kubectl api-resources -o name |grep {{ $cr }}; then
-                kubectl delete {{ (splitList "." $cr) |first }} -l {{ $saResourcesLabelSelector }}
+                kubectl delete {{ $cr }} -n {{ $managedResourcesNamespace }} -l {{ $saResourcesLabelSelector }}
               fi
               {{ end -}}
 

--- a/charts/super-agent-deployment/values.yaml
+++ b/charts/super-agent-deployment/values.yaml
@@ -96,6 +96,10 @@ fedramp:
 # @default -- `false`
 verboseLog:
 
+# -- Enable the cleanup of super-agent managed resources when the chart is uninstalled.
+# If disabled, agents and / or agent configurations could remain in the cluster after the chart is uninstalled.
+cleanupManagedResources: true
+
 config:
   # -- Configuration for the Super Agent.
   # @default -- See `values.yaml`

--- a/charts/super-agent-deployment/values.yaml
+++ b/charts/super-agent-deployment/values.yaml
@@ -97,7 +97,7 @@ fedramp:
 verboseLog:
 
 # -- Enable the cleanup of super-agent managed resources when the chart is uninstalled.
-# If disabled, agents and / or agent configurations could remain in the cluster after the chart is uninstalled.
+# If disabled, agents and / or agent configurations managed by the super-agent will not be deleted when the chart is uninstalled.
 cleanupManagedResources: true
 
 config:


### PR DESCRIPTION
#### Is this a new chart?
No

#### What this PR does / why we need it:

This PR includes a helm pre-delete hook to delete that are managed by the super-agent, since some of the resources may not be garbage collected.

#### Special notes for your reviewer:

There are still _race conditions_ when this chart is deployed by flux and flux is uninstalled in the same step (the CRs can be deleted after flux is uninstalled and the underlying kubernetes resources stop being managed). This will be addressed in a follow-up PR by updating the uninstall-job in the `super-agent` chart (#1279).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
