### PR TITLE
[super-agent] remove super-agent crs on uninstall

### DIFF
--- a/charts/super-agent/Chart.yaml
+++ b/charts/super-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: super-agent
 description: Bootstraps New Relic' Super Agent
 
 type: application
-version: 0.0.3-beta
+version: 0.0.4-beta
 
 dependencies:
   - name: flux2

--- a/charts/super-agent/Chart.yaml
+++ b/charts/super-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: super-agent
 description: Bootstraps New Relic' Super Agent
 
 type: application
-version: 0.0.4-beta
+version: 0.0.5-beta
 
 dependencies:
   - name: flux2

--- a/charts/super-agent/README.md
+++ b/charts/super-agent/README.md
@@ -2,7 +2,7 @@
 
 # super-agent
 
-![Version: 0.0.1-beta](https://img.shields.io/badge/Version-0.0.1--beta-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.4-beta](https://img.shields.io/badge/Version-0.0.4--beta-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Bootstraps New Relic' Super Agent
 
@@ -47,14 +47,16 @@ As of the creation of the chart, it has no particularities and this section can 
 | flux2.rbac | object | Enabled (See `values.yaml`) | Create RBAC rules for FluxCD is able to deploy all kind of workloads on the cluster. |
 | flux2.sourceController | object | Enabled | Source controller provides a way to fetch artifacts to the rest of controllers. The source API (which reference [can be read here](https://fluxcd.io/flux/components/source/api/v1/)) is used by admins and various automated operators to offload the Git, OCO, and Helm repositories management. |
 | flux2.watchAllNamespaces | bool | `false` | As we are using Flux as a tool from the super agent to release new workloads, we do not want Flux to listen to all CRs created on the whole cluster. If the user does not want to use Flux and is only using it because of the super agent, this is the way to go so the cluster has deployed all operators needed by the super agent. But if the user want to use Flux for other purposes besides the super agent, this toggle can be used to allow Flux to work on the whole cluster. |
+| helm.cleanupManagedResources | bool | `true` | Enable the cleanup of super-agent managed resources when the chart is uninstalled. should be always be true unless you know what you are going. |
 | helm.create | bool | `true` | Enable the installation of the CRs so FluxCD deploy the Super Agent is deployed. This an advanced/debug flag. It should be always be true unless you know what you are going. |
 | helm.release | object | See `values.yaml` | Values related to the super agent's Helm chart release. |
 | helm.release.chart | string | `"super-agent-deployment"` | The Helm chart of the super-agent. This values is meant to be changed only on air-gapped environments or for development/testing purposes. |
 | helm.release.install | object | See `values.yaml` | Change the behavior of the operator while installing the chart for the first time. This should only be changed by advanced users that know what they are doing. Exposes the remediations that the operator is going to try before give up installing the chart in case it hits an error. |
+| helm.release.rollback | object | See `values.yaml` | Optional configuration of rollback strategy when upgrading. This should only be changed by advanced users that know what they are doing. |
 | helm.release.upgrade | object | See `values.yaml` | Change the behavior of the operator while upgrading the chart. This should only be changed by advanced users that know what they are doing. Exposes the remediations that the operator is going to try before give up installing the chart in case it hits an error. |
 | helm.release.values | string | `{}`. Examples on the `values.yaml` | Set values to the super agent helm release directly from this `values.yaml` file. Refer to https://fluxcd.io/flux/components/helm/helmreleases/#values-overrides |
 | helm.release.valuesFrom | string | empty | Set values from a `configMap` or a `secret`. You can see examples and better documentation inside the `values.yaml` file. Also refer to https://fluxcd.io/flux/components/helm/helmreleases/#values-overrides |
-| helm.release.version | string | `"0.0.4-beta"` | The Helm chart of the super-agent. This values is meant to be changed only on air-gapped environments or for development/testing purposes.  TODO: Point renovatebot here. |
+| helm.release.version | string | `"0.0.8-beta"` | The Helm chart of the super-agent. This values is meant to be changed only on air-gapped environments or for development/testing purposes.  TODO: Point renovatebot here. |
 | helm.repository | object | See `values.yaml` | Values related to the Helm repository where to download the super agent's chart. |
 | helm.repository.certSecretRef | string | `nil` (no secret reference) | secret of type `kubernetes.io/tls` with the standard keys `tls.crt`, `tls.key`, and `ca.crt` |
 | helm.repository.secretRef | string | `nil` (no secret reference) | A reference to a secret with the keys username and password to authenticate to the repository. |

--- a/charts/super-agent/README.md
+++ b/charts/super-agent/README.md
@@ -2,7 +2,7 @@
 
 # super-agent
 
-![Version: 0.0.4-beta](https://img.shields.io/badge/Version-0.0.4--beta-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.5-beta](https://img.shields.io/badge/Version-0.0.5--beta-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Bootstraps New Relic' Super Agent
 
@@ -47,7 +47,6 @@ As of the creation of the chart, it has no particularities and this section can 
 | flux2.rbac | object | Enabled (See `values.yaml`) | Create RBAC rules for FluxCD is able to deploy all kind of workloads on the cluster. |
 | flux2.sourceController | object | Enabled | Source controller provides a way to fetch artifacts to the rest of controllers. The source API (which reference [can be read here](https://fluxcd.io/flux/components/source/api/v1/)) is used by admins and various automated operators to offload the Git, OCO, and Helm repositories management. |
 | flux2.watchAllNamespaces | bool | `false` | As we are using Flux as a tool from the super agent to release new workloads, we do not want Flux to listen to all CRs created on the whole cluster. If the user does not want to use Flux and is only using it because of the super agent, this is the way to go so the cluster has deployed all operators needed by the super agent. But if the user want to use Flux for other purposes besides the super agent, this toggle can be used to allow Flux to work on the whole cluster. |
-| helm.cleanupManagedResources | bool | `true` | Enable the cleanup of super-agent managed resources when the chart is uninstalled. should be always be true unless you know what you are going. |
 | helm.create | bool | `true` | Enable the installation of the CRs so FluxCD deploy the Super Agent is deployed. This an advanced/debug flag. It should be always be true unless you know what you are going. |
 | helm.release | object | See `values.yaml` | Values related to the super agent's Helm chart release. |
 | helm.release.chart | string | `"super-agent-deployment"` | The Helm chart of the super-agent. This values is meant to be changed only on air-gapped environments or for development/testing purposes. |
@@ -56,7 +55,7 @@ As of the creation of the chart, it has no particularities and this section can 
 | helm.release.upgrade | object | See `values.yaml` | Change the behavior of the operator while upgrading the chart. This should only be changed by advanced users that know what they are doing. Exposes the remediations that the operator is going to try before give up installing the chart in case it hits an error. |
 | helm.release.values | string | `{}`. Examples on the `values.yaml` | Set values to the super agent helm release directly from this `values.yaml` file. Refer to https://fluxcd.io/flux/components/helm/helmreleases/#values-overrides |
 | helm.release.valuesFrom | string | empty | Set values from a `configMap` or a `secret`. You can see examples and better documentation inside the `values.yaml` file. Also refer to https://fluxcd.io/flux/components/helm/helmreleases/#values-overrides |
-| helm.release.version | string | `"0.0.8-beta"` | The Helm chart of the super-agent. This values is meant to be changed only on air-gapped environments or for development/testing purposes.  TODO: Point renovatebot here. |
+| helm.release.version | string | `"0.0.11-beta"` | The Helm chart of the super-agent. This values is meant to be changed only on air-gapped environments or for development/testing purposes.  TODO: Point renovatebot here. |
 | helm.repository | object | See `values.yaml` | Values related to the Helm repository where to download the super agent's chart. |
 | helm.repository.certSecretRef | string | `nil` (no secret reference) | secret of type `kubernetes.io/tls` with the standard keys `tls.crt`, `tls.key`, and `ca.crt` |
 | helm.repository.secretRef | string | `nil` (no secret reference) | A reference to a secret with the keys username and password to authenticate to the repository. |

--- a/charts/super-agent/templates/_helm-release.yaml
+++ b/charts/super-agent/templates/_helm-release.yaml
@@ -43,4 +43,7 @@ spec:
   rollback:
     {{- . | toYaml | nindent 4 }}
   {{- end }}
+  uninstall: # Explicitly set to false since executing hooks and waiting for uninstall termination is needed to remove super-agent managed reseources.
+    disableWait: false
+    disableHooks: false
 {{- end -}}

--- a/charts/super-agent/templates/_helm-release.yaml
+++ b/charts/super-agent/templates/_helm-release.yaml
@@ -43,7 +43,7 @@ spec:
   rollback:
     {{- . | toYaml | nindent 4 }}
   {{- end }}
-  uninstall: # Explicitly set to false since executing hooks and waiting for uninstall termination is needed to remove super-agent managed reseources.
+  uninstall: # This is setup explicitly since executing hooks and waiting for uninstall termination is needed to remove super-agent managed resources
     disableWait: false
     disableHooks: false
 {{- end -}}

--- a/charts/super-agent/templates/uninstall-job.yaml
+++ b/charts/super-agent/templates/uninstall-job.yaml
@@ -2,6 +2,11 @@
 {{- $installJobName := include "newrelic.common.naming.truncateToDNSWithSuffix" ( dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "uninstall-job" ) -}}
 {{- $configMapName := include "newrelic.common.naming.truncateToDNSWithSuffix" ( dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "job-manifests" ) -}}
 {{- /*
+The CRD managed by the super-agent and the label selector are hardcoded on the super-agent.
+*/ -}}
+{{- $saCRList := (list "helmreleases" "helmrepositories") -}}
+{{- $saResourcesLabelSelector := "app.kubernetes.io/managed-by=newrelic-super-agent" -}}
+{{- /*
 To understand why this job installs manifests instead of using Helm, read the comment at `job-manifests.yaml`.
 */ -}}
 apiVersion: batch/v1
@@ -23,10 +28,13 @@ spec:
         - name: delete-crs
           image: bitnami/kubectl
           command:
-            - kubectl
-            - delete
-            - -f
-            - /manifests/
+            - bash
+          args:
+            - -c
+            - kubectl delete -f /manifests/
+              {{- if .Values.helm.cleanupManagedResources -}}
+              {{- range $crName := $saCRList }} && kubectl delete {{ $crName }} -l {{ $saResourcesLabelSelector }}{{ end }}
+              {{- end }}
           volumeMounts:
             - name: manifests-configmap
               mountPath: /manifests

--- a/charts/super-agent/templates/uninstall-job.yaml
+++ b/charts/super-agent/templates/uninstall-job.yaml
@@ -28,13 +28,10 @@ spec:
         - name: delete-crs
           image: bitnami/kubectl
           command:
-            - bash
-          args:
-            - -c
-            - kubectl delete -f /manifests/
-              {{- if .Values.helm.cleanupManagedResources -}}
-              {{- range $crName := $saCRList }} && kubectl delete {{ $crName }} -l {{ $saResourcesLabelSelector }}{{ end }}
-              {{- end }}
+            - kubectl
+            - delete
+            - -f
+            - /manifests/
           volumeMounts:
             - name: manifests-configmap
               mountPath: /manifests

--- a/charts/super-agent/templates/uninstall-job.yaml
+++ b/charts/super-agent/templates/uninstall-job.yaml
@@ -2,11 +2,6 @@
 {{- $installJobName := include "newrelic.common.naming.truncateToDNSWithSuffix" ( dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "uninstall-job" ) -}}
 {{- $configMapName := include "newrelic.common.naming.truncateToDNSWithSuffix" ( dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "job-manifests" ) -}}
 {{- /*
-The CRD managed by the super-agent and the label selector are hardcoded on the super-agent.
-*/ -}}
-{{- $saCRList := (list "helmreleases" "helmrepositories") -}}
-{{- $saResourcesLabelSelector := "app.kubernetes.io/managed-by=newrelic-super-agent" -}}
-{{- /*
 To understand why this job installs manifests instead of using Helm, read the comment at `job-manifests.yaml`.
 */ -}}
 apiVersion: batch/v1

--- a/charts/super-agent/values.yaml
+++ b/charts/super-agent/values.yaml
@@ -3,6 +3,10 @@ helm:
   # should be always be true unless you know what you are going.
   create: true
 
+  # -- Enable the cleanup of super-agent managed resources when the chart is uninstalled.
+  # should be always be true unless you know what you are going.
+  cleanupManagedResources: true
+
   # -- Values related to the Helm repository where to download the super agent's chart.
   # @default -- See `values.yaml`
   repository:

--- a/charts/super-agent/values.yaml
+++ b/charts/super-agent/values.yaml
@@ -3,10 +3,6 @@ helm:
   # should be always be true unless you know what you are going.
   create: true
 
-  # -- Enable the cleanup of super-agent managed resources when the chart is uninstalled.
-  # should be always be true unless you know what you are going.
-  cleanupManagedResources: true
-
   # -- Values related to the Helm repository where to download the super agent's chart.
   # @default -- See `values.yaml`
   repository:

--- a/charts/super-agent/values.yaml
+++ b/charts/super-agent/values.yaml
@@ -35,7 +35,7 @@ helm:
     # development/testing purposes.
     #
     # TODO: Point renovatebot here.
-    version: "0.0.8-beta"
+    version: "0.0.11-beta"
 
     # -- Set values to the super agent helm release directly from this `values.yaml` file. Refer to https://fluxcd.io/flux/components/helm/helmreleases/#values-overrides
     # @default -- `{}`. Examples on the `values.yaml`


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
~Extends the `super-agent` chart helm delete hook to remove the CRs managed by the super-agent. This is needed because there is a _race condition_ when uninstalling the chart. The CRs might be deleted after Flux is uninstalled, consequently, the underlying resources are keep in the cluster. Since the pre-delete hook is executed before uninstalling the chart, this we we assure the CR deletion is handled by Flux.~

Since the resources managed by the super-agent are deleted during the `super-agent-deployment` uninstallation, in order to guarantee those are properly deleted here, we need to assure that the corresponding job is executed before Flux is uninstalled. The [default uninstall configuration](https://fluxcd.io/flux/components/helm/helmreleases/#uninstall-configuration) for Flux helmreleaes is already like that, but we set it up explicitly to be aware of the change and avoid issues if those defaults change.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
