### PR TITLE
[super-agent-deployment] fix conflicting names for uninstall job

### DIFF
--- a/charts/super-agent-deployment/Chart.yaml
+++ b/charts/super-agent-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Super agent on Kubernetes
 
 type: application
 
-version: 0.0.10-beta
+version: 0.0.11-beta
 appVersion: 0.7.0
 
 dependencies:

--- a/charts/super-agent-deployment/README.md
+++ b/charts/super-agent-deployment/README.md
@@ -2,7 +2,7 @@
 
 # super-agent-deployment
 
-![Version: 0.0.10-beta](https://img.shields.io/badge/Version-0.0.10--beta-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
+![Version: 0.0.11-beta](https://img.shields.io/badge/Version-0.0.11--beta-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
 
 A Helm chart to install New Relic Super agent on Kubernetes
 

--- a/charts/super-agent-deployment/templates/uninstall-job.yaml
+++ b/charts/super-agent-deployment/templates/uninstall-job.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.cleanupManagedResources -}}
-{{- $uninstallJobName := include "newrelic.common.naming.truncateToDNSWithSuffix" ( dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "uninstall-job" ) -}}
+{{- $uninstallJobName := include "newrelic.common.naming.truncateToDNSWithSuffix" ( dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "deployment-uninstall-job" ) -}}
 {{- /*
 The resources managed by the super-agent and the label selector are hardcoded on the super-agent.
 */ -}}


### PR DESCRIPTION

#### Is this a new chart

no

#### What this PR does / why we need it:

The `super-agent-deployment` uninstall-job name was conflicting with the `super-agent` uninstall job name, therefore when `super-agent-deployment` is installed through `super-agent` via Flux, the uninstall was not behaving as expected.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
