### PR TITLE
[NOT FOR MERGING]: prototype: Send logs to team account based on namespace

### DIFF
--- a/charts/newrelic-logging/templates/configcreator.yaml
+++ b/charts/newrelic-logging/templates/configcreator.yaml
@@ -1,0 +1,67 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: newrelic-logging-config-creator
+  # TODO: do we need namespace and labels like in configmap.yml?annotations:
+  annotations:
+    # This makes it so that this job is run first before any other resources
+    # are created during chart installation/upgrade
+    "helm.sh/hook": post-install,post-upgrade
+spec:
+  template:
+    spec:
+      containers:
+        - name: config-creator
+          image: node # TODO: what image should we use
+          command:
+          - node
+          - -e
+          - |
+            const fs = require('fs');
+
+            // Read configuration information
+            const mappingFileName = '/etc/namespace-to-api-key-mapping/fluent-bit-namespace-to-api-key-mapping.json';
+            const mappingFileContents = fs.readFileSync(mappingFileName);
+            const keysByNamespace = JSON.parse(mappingFileContents);
+
+            // Write out the Fluent Bit config file
+            const outputBlock = (namespace, key) => {
+              return `[OUTPUT]
+                  Name          newrelic
+                  Match_regex   .*_${namespace}_.*
+                  apiKey        ${key}
+                  endpoint      \${ENDPOINT}`;
+            };
+            const namespaces = Object.keys(keysByNamespace);
+            const regexTerms = namespaces
+              .map(namespace => `_${namespace}_`)
+              .join('|');
+            const fallbackRegex = `^(?:(?!${regexTerms}).)*$`
+            const fallbackBlock = `[OUTPUT]
+                  Name          newrelic
+                  Match_regex   ${fallbackRegex}
+                  apiKey        \${LICENSE_KEY}
+                  endpoint      \${ENDPOINT}`;
+            const teamOutputBlocks = Object.entries(keysByNamespace)
+              .map(([namespace, key]) => outputBlock(namespace, key));
+            const outputBlocks = [
+              ...teamOutputBlocks,
+              fallbackBlock,
+            ];
+            const configFileContents = outputBlocks.join('\n\n');
+            const configFileName = '/etc/fluent-bit-teams-config/newrelic-teams-output.conf';
+            fs.writeFileSync(configFileName, configFileContents);
+          volumeMounts:
+            - name: fluent-bit-namespace-to-api-key-mapping-volume
+              mountPath: /etc/namespace-to-api-key-mapping
+            - name: fluent-bit-teams-config-volume
+              mountPath: /etc/fluent-bit-teams-config
+      volumes:
+        - name: fluent-bit-namespace-to-api-key-mapping-volume
+          configMap:
+            name: fluent-bit-namespace-to-api-key-mapping
+        - name: fluent-bit-teams-config-volume
+          hostPath:
+            path: /etc/teams-config
+      # TODO: docs had this, but do we need it? https://docs.openshift.com/dedicated/3/dev_guide/configmaps.html
+      restartPolicy: Never

--- a/charts/newrelic-logging/templates/configmap.yaml
+++ b/charts/newrelic-logging/templates/configmap.yaml
@@ -6,29 +6,42 @@ metadata:
   name: {{ template "newrelic-logging.fluentBitConfig" . }}
 data:
   fluent-bit.conf: |
-    {{- if .Values.fluentBit.config.service }}
-      {{- .Values.fluentBit.config.service | nindent 4 }}
-    {{- end }}
-    {{- if .Values.fluentBit.config.inputs }}
-      {{- .Values.fluentBit.config.inputs | nindent 4 }}
-    {{- end }}
-    {{- if .Values.fluentBit.config.extraInputs }}
-      {{- .Values.fluentBit.config.extraInputs | nindent 4}}
-    {{- end }}
-    {{- if and (include "newrelic-logging.lowDataMode" .) (.Values.fluentBit.config.lowDataModeFilters) }}
-      {{- .Values.fluentBit.config.lowDataModeFilters | nindent 4 }}
-    {{- else }}
-      {{- .Values.fluentBit.config.filters | nindent 4 }}
-    {{- end }}
-    {{- if .Values.fluentBit.config.extraFilters }}
-      {{- .Values.fluentBit.config.extraFilters | nindent 4}}
-    {{- end }}
-    {{- if .Values.fluentBit.config.outputs }}
-      {{- .Values.fluentBit.config.outputs | nindent 4 }}
-    {{- end }}
-    {{- if .Values.fluentBit.config.extraOutputs }}
-      {{- .Values.fluentBit.config.extraOutputs | nindent 4}}
-    {{- end }}
+    [SERVICE]
+        Flush         1
+        Log_Level     ${LOG_LEVEL}
+        Daemon        off
+        Parsers_File  parsers.conf
+        HTTP_Server   On
+        HTTP_Listen   0.0.0.0
+        HTTP_Port     2020
+
+    [INPUT]
+        Name              tail
+        Tag               kube.*
+        Path              ${PATH}
+        multiline.parser  ${LOG_PARSER}
+        DB                ${FB_DB}
+        Mem_Buf_Limit     7MB
+        Skip_Long_Lines   On
+        Refresh_Interval  10
+
+    [FILTER]
+        Name                kubernetes
+        Match               kube.*
+        # We need the full DNS suffix as Windows only supports resolving names with this suffix
+        # See: https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#dns-limitations
+        Kube_URL            https://kubernetes.default.svc.cluster.local:443
+        Buffer_Size         ${K8S_BUFFER_SIZE}
+        K8S-Logging.Exclude ${K8S_LOGGING_EXCLUDE}
+
+    [FILTER]
+        Name           record_modifier
+        Match          *
+        Record         cluster_name ${CLUSTER_NAME}
+
+    # Include the output blocks that we build during Helm chart installation/upgrade
+    @INCLUDE /etc/teams-config/newrelic-teams-output.conf
+
   parsers.conf: |
   {{- if .Values.fluentBit.config.parsers }}
     {{- .Values.fluentBit.config.parsers | nindent 4}}

--- a/charts/newrelic-logging/templates/daemonset.yaml
+++ b/charts/newrelic-logging/templates/daemonset.yaml
@@ -139,6 +139,8 @@ spec:
           volumeMounts:
             - name: fluent-bit-config
               mountPath: /fluent-bit/etc
+            - name: fluent-bit-teams-config
+              mountPath: /etc/teams-config
             - name: logs
               # We mount /var by default because container logs could be on /var/log or /var/lib/docker/containers (symlinked to /var/log)
               mountPath: {{ .Values.fluentBit.linuxMountPath | default "/var" }}
@@ -163,6 +165,9 @@ spec:
         - name: fluent-bit-config
           configMap:
             name: {{ template "newrelic-logging.fluentBitConfig" . }}
+        - name: fluent-bit-teams-config
+          hostPath:
+            path: /etc/teams-config
         - name: logs
           hostPath:
             path: {{ .Values.fluentBit.linuxMountPath | default "/var" }}

--- a/charts/newrelic-logging/templates/fluent-bit-namespace-to-api-key-mapping.yml
+++ b/charts/newrelic-logging/templates/fluent-bit-namespace-to-api-key-mapping.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluent-bit-namespace-to-api-key-mapping
+  # TODO: do we need namespace and labels? I stole them from configmap.yml
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "newrelic-logging.labels" . | indent 4 }}
+data:
+  # TODO: this needs to be a Vault path instead of hard-coding keys
+  fluent-bit-namespace-to-api-key-mapping.json: |
+    {
+      "logging": "<REDACTED_KEY_FOR_PRODUCTION_756053>"
+    }


### PR DESCRIPTION
We're trying to sort out a way that CF can allow teams to put their logs in their own team's account instead of account 1.

This PR prototypes providing a way for teams to tell the chart which key (and therefore to which account) they want their logs sent with based on a pod's namespace.  Any pod that doesn't have an explicit mapping from its namespace to an account key will default to be sent with the account 1 key.

This idea is:
* Creates a ConfigMap that teams can put the Vault location for their api keys (this prototype just hardcodes keys locally, I was lazy :P) 
* Creates a chart "hook" that runs on install and upgrade that generates the Fluent Bit `[OUTPUT]` blocks by running a NodeJS app to do that
* Including those `[OUTPUT]` blocks in the "main" fluent-bit.conf

For CF, we'd do something a little different (but basically the same), since CF uses their own Helm chart. I think it would still be mostly the same. I didn't do the prototype there because, uh, I don't know. 😄 

I tested this by: 
- Editing the chart to replace `REDACTED_KEY_FOR_PRODUCTION_756053` with the actual key for production 756053
- Installing the chart with `helm uninstall newrelic-logging && helm install newrelic-logging ./charts/newrelic-logging --set licenseKey=<REDACTED_ACCOUNT_1_KEY> --set cluster=brian-kind && kubectl logs $(kubectl get pod | grep newrelic-logging | grep -v creator | awk '{print $1}')`
- Creating a pod in the `logging` namespace
- Verifying that the `logging` namespace pod's logs go to account 756053 (and _not_ account 1)
- Verifying that the other pods in non-`logging` namespaces go to account 1

### Account 1 logs
(note that it doesn't include logs from the `logging` namespaces)

<img width="1054" alt="Screenshot 2024-02-22 at 9 03 41 PM" src="https://github.com/newrelic/helm-charts/assets/7001514/ff2f260b-155b-41e9-be44-3690807a1aa3">


### Account 756053 logs
(note that it doesn't include logs from other namespaces besides `logging`)

<img width="1024" alt="Screenshot 2024-02-22 at 9 03 37 PM" src="https://github.com/newrelic/helm-charts/assets/7001514/20864a76-448c-45e4-9fea-257bc4012c0e">