### PR TITLE
[newrelic-logging] Bump newrelic-fluentbit-output image to 1.19.2

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.20.2
-appVersion: 1.19.0
+version: 1.20.3
+appVersion: 1.19.2
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:

--- a/charts/newrelic-logging/tests/images_test.yaml
+++ b/charts/newrelic-logging/tests/images_test.yaml
@@ -17,16 +17,16 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: newrelic/newrelic-fluentbit-output:1.19.0
+          value: newrelic/newrelic-fluentbit-output:1.19.2
         template: templates/daemonset.yaml
       - equal:
           path: spec.template.spec.containers[0].image
-          value: newrelic/newrelic-fluentbit-output:1.19.0-windows-ltsc-2019
+          value: newrelic/newrelic-fluentbit-output:1.19.2-windows-ltsc-2019
         template: templates/daemonset-windows.yaml
         documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].image
-          value: newrelic/newrelic-fluentbit-output:1.19.0-windows-ltsc-2022
+          value: newrelic/newrelic-fluentbit-output:1.19.2-windows-ltsc-2022
         template: templates/daemonset-windows.yaml
         documentIndex: 1
   - it: global registry is used if set


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
It bumps the image for newrelic-logging integration, it uses the plugin version 1.19.2 that user fluent-bit 2.2.2 for docker images. https://github.com/newrelic/newrelic-fluent-bit-output/pull/150

It fixes following vulnerabilities added by libpq5

**HIGH**
[CVE-2023-39417](https://avd.aquasec.com/nvd/cve-2023-39417): postgresql: extension script @substitutions@ within quoting allow SQL injection
[CVE-2023-5869](https://avd.aquasec.com/nvd/cve-2023-5869): postgresql: Buffer overrun from integer overflow in array modification

**MEDIUM**
[CVE-2023-5868](https://avd.aquasec.com/nvd/cve-2023-5868): postgresql: Memory disclosure in aggregate function calls
[CVE-2023-5870](https://avd.aquasec.com/nvd/cve-2023-5870): postgresql: Role pg_signal_backend can signal certain superuser processes.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
N/A

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
