### PR TITLE
[synthetics-minion] Update synthetics-minion helm chart v3.1.6

### DIFF
--- a/charts/synthetics-minion/Chart.yaml
+++ b/charts/synthetics-minion/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: synthetics-minion
 description: New Relic Synthetics Containerized Private Minion (CPM)
 type: application
-version: 1.0.61
-appVersion: 3.1.5
+version: 1.0.62
+appVersion: 3.1.6
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith


### PR DESCRIPTION
#### Is this a new chart
- No

#### What this PR does / why we need it:
- Updates the synthetics-minion helm chart to use the latest containerized private minion release version v3.1.6

#### Which issue this PR fixes
- Removes warning messages related to the Blackbird module

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
