### PR TITLE
[newrelic-pixie] Add ttl limit for container init Job in.

### DIFF
--- a/charts/newrelic-pixie/Chart.yaml
+++ b/charts/newrelic-pixie/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the New Relic Pixie integration.
 name: newrelic-pixie
-version: 2.1.2
+version: 2.1.3
 appVersion: 2.1.4
 home: https://hub.docker.com/u/newrelic
 sources:

--- a/charts/newrelic-pixie/templates/job.yaml
+++ b/charts/newrelic-pixie/templates/job.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "newrelic-pixie.labels" . | nindent 4 }}
 spec:
   backoffLimit: 4
+  ttlSecondsAfterFinished: 600
   template:
     metadata:
       labels:


### PR DESCRIPTION
We add a "TTL" or time-to-live for the container init Job in `newrelic-pixie`. This fixes a bug where users that wanted to upgrade the helm chart could not because the Job was immutable. After adding the TTL, the Job is removed from the cluster.

#### Checklist
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
