### PR TITLE
[newrelic-logging] Revert to previous routing

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.21.0
+version: 1.21.1
 appVersion: 1.19.2
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -148,7 +148,7 @@ fluentBit:
 
       [FILTER]
           Name           nest
-          Match          kube.*
+          Match          *
           Alias          kubernetes-attribute-lifter
           Operation      lift
           Nested_under   kubernetes
@@ -168,7 +168,7 @@ fluentBit:
     outputs: |
       [OUTPUT]
           Name           newrelic
-          Match          kube.*
+          Match          *
           Alias          newrelic-logs-forwarder
           licenseKey     ${LICENSE_KEY}
           endpoint       ${ENDPOINT}


### PR DESCRIPTION

#### Is this a new chart
No

#### What this PR does / why we need it:
It reverts to using the previous matching for logs, so that all logs are sent by the NR plugin. Otherwise, if somebody defined an additional input via `fluentBit.config.extraInputs`, they would get ignored.

#### Which issue this PR fixes
None

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
