### PR TITLE
[newrelic-logging] Add metric source

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.21.1
+version: 1.21.2
 appVersion: 1.19.2
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -214,6 +214,7 @@ fluentBit:
           add_label            cluster_name ${CLUSTER_NAME}
           add_label            hostname ${HOSTNAME}
           add_label            node_name ${NODE_NAME}
+          add_label            source kubernetes
 
 image:
   repository: newrelic/newrelic-fluentbit-output


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Adds source dimension to metrics to indicate that they come from a Kubernetes cluster. This will allow us, later on, to distinguish metrics coming from other kind of deployments (infra-agent, etc.)

#### Which issue this PR fixes
None

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
