### PR TITLE
[newrelic-logging] fix: Fix key value pair error for the cluster name containing space

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.21.2
+version: 1.21.3
 appVersion: 1.19.2
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -125,7 +125,7 @@ fluentBit:
           Name           record_modifier
           Alias          node-attributes-enricher
           Match          *
-          Record         cluster_name ${CLUSTER_NAME}
+          Record         "cluster_name" "${CLUSTER_NAME}"
 
 #    extraFilters: |
 #      [FILTER]
@@ -157,7 +157,7 @@ fluentBit:
           Name           record_modifier
           Match          *
           Alias          node-attributes-enricher-filter
-          Record         cluster_name ${CLUSTER_NAME}
+          Record         "cluster_name" "${CLUSTER_NAME}"
           Allowlist_key  container_name
           Allowlist_key  namespace_name
           Allowlist_key  pod_name
@@ -211,7 +211,7 @@ fluentBit:
           Tls.verify           Off
           # User-defined labels
           add_label            app fluent-bit
-          add_label            cluster_name ${CLUSTER_NAME}
+          add_label            "cluster_name" "${CLUSTER_NAME}"
           add_label            hostname ${HOSTNAME}
           add_label            node_name ${NODE_NAME}
           add_label            source kubernetes

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -125,7 +125,7 @@ fluentBit:
           Name           record_modifier
           Alias          node-attributes-enricher
           Match          *
-          Record         "cluster_name" "${CLUSTER_NAME}"
+          Record         cluster_name "${CLUSTER_NAME}"
 
 #    extraFilters: |
 #      [FILTER]
@@ -157,7 +157,7 @@ fluentBit:
           Name           record_modifier
           Match          *
           Alias          node-attributes-enricher-filter
-          Record         "cluster_name" "${CLUSTER_NAME}"
+          Record         cluster_name "${CLUSTER_NAME}"
           Allowlist_key  container_name
           Allowlist_key  namespace_name
           Allowlist_key  pod_name
@@ -211,7 +211,7 @@ fluentBit:
           Tls.verify           Off
           # User-defined labels
           add_label            app fluent-bit
-          add_label            "cluster_name" "${CLUSTER_NAME}"
+          add_label            cluster_name "${CLUSTER_NAME}"
           add_label            hostname ${HOSTNAME}
           add_label            node_name ${NODE_NAME}
           add_label            source kubernetes


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No
#### What this PR does / why we need it:
Adds double quotes to the attribute cluster_name key value pairs in the values.yaml file. This will allow the cluster name containing spaces.

#### Which issue this PR fixes
  - This will fix the error **invalid record parameters, expects ‘KEY VALUE’**

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
