### PR TITLE
[synthetics job manager] bring sjm and node-api-runtime up to date

### DIFF
--- a/charts/synthetics-job-manager/Chart.yaml
+++ b/charts/synthetics-job-manager/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: synthetics-job-manager
 description: New Relic Synthetics Containerized Job Manager
 type: application
-version: 2.0.3
-appVersion: release-363
+version: 2.0.4
+appVersion: release-367
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: kaschaefer-nr
@@ -27,7 +27,7 @@ dependencies:
     version: 1.0.20
     condition: ping-runtime.enabled
   - name: node-api-runtime
-    version: 1.0.31
+    version: 1.0.32
     condition: node-api-runtime.enabled
   - name: node-browser-runtime
     version: 1.0.39

--- a/charts/synthetics-job-manager/charts/node-api-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/node-api-runtime/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: node-api-runtime
 description: New Relic Synthetics Api Runtime
 type: application
-version: 1.0.31
-appVersion: 1.2.63
+version: 1.0.32
+appVersion: 1.2.72
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Brings SJM image and runtime images up to date with what is available in DockerHub

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
