### PR TITLE
[super-agent-deployment] provide example for status server

### DIFF
--- a/charts/super-agent-deployment/Chart.yaml
+++ b/charts/super-agent-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Super agent on Kubernetes
 
 type: application
 
-version: 0.0.15-beta
+version: 0.0.16-beta
 appVersion: 0.14.0
 
 dependencies:

--- a/charts/super-agent-deployment/README.md
+++ b/charts/super-agent-deployment/README.md
@@ -2,7 +2,7 @@
 
 # super-agent-deployment
 
-![Version: 0.0.13-beta](https://img.shields.io/badge/Version-0.0.13--beta-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.1](https://img.shields.io/badge/AppVersion-0.13.1-informational?style=flat-square)
+![Version: 0.0.16-beta](https://img.shields.io/badge/Version-0.0.16--beta-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.1](https://img.shields.io/badge/AppVersion-0.13.1-informational?style=flat-square)
 
 A Helm chart to install New Relic Super agent on Kubernetes
 

--- a/charts/super-agent-deployment/values.yaml
+++ b/charts/super-agent-deployment/values.yaml
@@ -116,6 +116,12 @@ config:
       #    endpoint: https://opamp.service.newrelic.com/v1/opamp
       #    headers:
       #      api-key: LICENSE_KEY
+      #  -- This option enables a status server that can be useful for troubleshooting.
+      #  -- Port-forward it `$ kubectl port-forward pod/{pod-name} 51200:51200`
+      #  -- And query it as `$ curl localhost:51200/status`
+      #  server:
+      #    enabled: true
+      #    port: 51200
 
 
   # -- Values that the fleet is going to have in the deployment.


### PR DESCRIPTION
Just giving an example to enable and query the status server:
```json
{
  "super_agent": {
    "healthy": true
  },
  "opamp": {
    "enabled": true,
    "endpoint": "https://opamp.service.newrelic.com/v1/opamp",
    "reachable": true
  },
  "sub_agents": {
    "open-telemetry": {
      "agent_id": "open-telemetry",
      "agent_type": "newrelic/io.opentelemetry.collector:0.1.1",
      "healthy": true
    }
  }
}
```