### PR TITLE
[super-agent] Disable flux on renovatebot

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -47,6 +47,14 @@
         "patch"
       ],
       "enabled": true
+    },
+    {
+      // Disable Flux for now.
+      "matchPackageNames": [
+        "flux",
+        "flux2",
+      ],
+      "enabled": false
     }
   ],
   "customManagers": [


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:

My mail is being flooded by flux upgrades because the PR of the upgrade is not being merged.

We do not want to merge it (yet) and we will upgrade flux if it is needed. If we remove the PR from renovate we remove also the possibility of merging it by mistake.

#### Checklist
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
