### PR TITLE
[newrelic-logging] Bump newrelic-fluentbit-output image to 2.0.0

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.21.5
+version: 1.21.6
 appVersion: 2.0.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
 version: 1.21.5
-appVersion: 1.19.2
+appVersion: 2.0.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:

--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.21.6
+version: 1.22.0
 appVersion: 2.0.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/tests/images_test.yaml
+++ b/charts/newrelic-logging/tests/images_test.yaml
@@ -17,16 +17,16 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: newrelic/newrelic-fluentbit-output:1.19.2
+          value: newrelic/newrelic-fluentbit-output:2.0.0
         template: templates/daemonset.yaml
       - equal:
           path: spec.template.spec.containers[0].image
-          value: newrelic/newrelic-fluentbit-output:1.19.2-windows-ltsc-2019
+          value: newrelic/newrelic-fluentbit-output:2.0.0-windows-ltsc-2019
         template: templates/daemonset-windows.yaml
         documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].image
-          value: newrelic/newrelic-fluentbit-output:1.19.2-windows-ltsc-2022
+          value: newrelic/newrelic-fluentbit-output:2.0.0-windows-ltsc-2022
         template: templates/daemonset-windows.yaml
         documentIndex: 1
   - it: global registry is used if set


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

#### What this PR does / why we need it:

#### Which issue this PR fixes
It bumps the image for newrelic-logging integration, it uses the plugin version 2.0.0 that user fluent-bit 3.0.4 for docker images. https://github.com/newrelic/newrelic-fluent-bit-output/pull/154

it fixes critical vulnerability https://nvd.nist.gov/vuln/detail/CVE-2024-4323 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
