### PR TITLE
[synthetics-job-manager] re-adds inadvertently deleted proxy settings for sjm

### DIFF
--- a/charts/synthetics-job-manager/Chart.yaml
+++ b/charts/synthetics-job-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: synthetics-job-manager
 description: New Relic Synthetics Containerized Job Manager
 type: application
-version: 2.0.9
+version: 2.0.10
 appVersion: release-380
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:

--- a/charts/synthetics-job-manager/templates/deployment.yaml
+++ b/charts/synthetics-job-manager/templates/deployment.yaml
@@ -46,6 +46,9 @@ spec:
               value: {{ .Values.synthetics.hordeApiEndpoint | quote }}
             {{- end }}
             {{- include "synthetics-job-manager.vsePassphrase" . | nindent 12 -}}
+
+            {{- include "synthetics-job-manager.apiProxyHost" . | nindent 12 -}}
+            {{- include "synthetics-job-manager.apiProxyPort" . | nindent 12 -}}
             {{- if .Values.synthetics.hordeApiProxySelfSignedCert }}
             - name: HORDE_API_PROXY_ACCEPT_SELF_SIGNED_CERT
               value: {{ .Values.synthetics.hordeApiProxySelfSignedCert | quote }}


### PR DESCRIPTION

#### Is this a new chart
No

#### What this PR does / why we need it:
I inadvertently deleted the proxy settings while working on something else. This PR adds these back so users can run their K8s SJMs behind a proxy.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
