### PR TITLE
nri-statsd: Support customSecretName Statsd Chart

### DIFF
--- a/charts/nri-statsd/templates/_helpers.tpl
+++ b/charts/nri-statsd/templates/_helpers.tpl
@@ -78,14 +78,18 @@ Define the statsd metric tags
 Return the insightsKey
 */}}
 {{- define "nri-statsd.insightsKey" -}}
-{{- if .Values.global}}
-  {{- if .Values.global.insightsKey }}
-      {{- .Values.global.insightsKey -}}
-  {{- else -}}
-      {{- .Values.insightsKey | default "" -}}
-  {{- end -}}
+{{- if or (include "newrelic.common.license._customSecretName" .) (include "newrelic.common.license._customSecretKey" .) -}}
+    {{- if .Values.global}}
+        {{- if .Values.global.insightsKey }}
+            {{- .Values.global.insightsKey -}}
+        {{- else -}}
+            {{- .Values.insightsKey | default "" -}}
+        {{- end -}}
+    {{- else -}}
+        {{- .Values.insightsKey | default "" -}}
+    {{- end -}}
 {{- else -}}
-    {{- .Values.insightsKey | default "" -}}
+    {{- "" -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/nri-statsd/values.yaml
+++ b/charts/nri-statsd/values.yaml
@@ -10,6 +10,7 @@
 #
 # global:
 #   insightsKey: ""
+#   customSecretName: ""
 #   cluster: ""
 
 accountId: ""


### PR DESCRIPTION
# What and Why

Right now, the `nri-statsd` chart requires the API key to be hardcoded in the `values.yaml` or injected during the `helm install`, but it would be better if a `customSecretName` could be utilized to reference the secret location like the other `nri-bundle` elements utilize.

### Acceptance Criteria

Before:

```yaml
global:
   insightsKey: ""
```

After:

```yaml
global:
  customSecretName: nri-statsd-key
```

## Checks

- [X] Read contributing guidelines
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [X] Support [this issue](https://github.com/newrelic/helm-charts/issues/1324)**