### PR TITLE
[common-library] Add insights key helpers

### DIFF
--- a/library/CHART-TEMPLATE/Chart.lock
+++ b/library/CHART-TEMPLATE/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: file://../common-library
-  version: 1.1.0
-digest: sha256:810c8b54c04a83d06208becb3ee0c3268fbff165624ef8d0da5d75d5a3ae5074
-generated: "2022-08-31T10:40:37.947861+02:00"
+  version: 1.2.0
+digest: sha256:ca0a371fb6ce46b821593db9949d1942f2fdf40b54df1eff377ac094bc3d78fa
+generated: "2024-06-19T10:51:12.685283+02:00"

--- a/library/CHART-TEMPLATE/Chart.yaml
+++ b/library/CHART-TEMPLATE/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,7 +25,7 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: common-library
-    version: 1.1.0
+    version: 1.2.0
     repository: file://../common-library  # We keep this as a file to test things immediately locally/in the pipeline
 
 keywords:
@@ -39,3 +39,5 @@ maintainers:
     url: https://github.com/csongnr
   - name: dbudziwojskiNR
     url: https://github.com/dbudziwojskiNR
+  - name: kang-makes
+    url: https://github.com/kang-makes

--- a/library/CHART-TEMPLATE/README.md
+++ b/library/CHART-TEMPLATE/README.md
@@ -2,7 +2,7 @@
 
 # CHART-TEMPLATE
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes showing how to use/implement the common-library
 
@@ -103,3 +103,4 @@ low data modes or any other quirk that it could have.
 * [juanjjaramillo](https://github.com/juanjjaramillo)
 * [csongnr](https://github.com/csongnr)
 * [dbudziwojskiNR](https://github.com/dbudziwojskiNR)
+* [kang-makes](https://github.com/kang-makes)

--- a/library/CHART-TEMPLATE/templates/example-cm-insightskey.yaml
+++ b/library/CHART-TEMPLATE/templates/example-cm-insightskey.yaml
@@ -1,0 +1,9 @@
+# This is a dummy CM to test what insightskey helpers of the common library return
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "newrelic.common.naming.fullname" . }}-examples-insightskey
+  namespace: {{ .Release.Namespace }}
+data:
+  insightskey-secret-name: {{ include "newrelic.common.insightsKey.secretName" . }}
+  insightskey-secret-key-name: {{ include "newrelic.common.insightsKey.secretKeyName" . }}

--- a/library/CHART-TEMPLATE/templates/example-insights-secret.yaml
+++ b/library/CHART-TEMPLATE/templates/example-insights-secret.yaml
@@ -1,0 +1,2 @@
+{{- /* Common library will take care of creating the insightsKey' secret or not. */ -}}
+{{- include "newrelic.common.insightsKey.secret" . -}}

--- a/library/CHART-TEMPLATE/templates/example-license-secret.yaml
+++ b/library/CHART-TEMPLATE/templates/example-license-secret.yaml
@@ -1,0 +1,2 @@
+{{- /* Common library will take care of creating the license key' secret or not. */ -}}
+{{- include "newrelic.common.license.secret" . -}}

--- a/library/CHART-TEMPLATE/templates/example-secret.yaml
+++ b/library/CHART-TEMPLATE/templates/example-secret.yaml
@@ -1,2 +1,0 @@
-{{- /* Common library will take care of creating the licen key' secret or not. */ -}}
-{{- include "newrelic.common.license.secret" . -}}

--- a/library/CHART-TEMPLATE/templates/integration-deployment.yaml
+++ b/library/CHART-TEMPLATE/templates/integration-deployment.yaml
@@ -56,11 +56,24 @@ spec:
               containerPort: 80
               protocol: TCP
           env:
+            - name: CLUSTER_NAME
+              value: {{ include "newrelic.common.cluster" . }}
+            - name: MY_APP_NON_OPTIONAL_ENV_VAR
+          {{- with include "newrelic.common.proxy" . }}
+            - name: MY_APP_PROXY_URL
+              value: {{ . | quote }}
+          {{- end }}
+
             - name: NRIA_LICENSE_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "newrelic.common.license.secretName" . }}
                   key: {{ include "newrelic.common.license.secretKeyName" . }}
+            - name: NR_INSIGHTS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "newrelic.common.insightsKey.secretName" . }}
+                  key: {{ include "newrelic.common.insightsKey.secretKeyName" . }}
           livenessProbe:
             httpGet:
               path: /
@@ -71,14 +84,6 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          env:
-            - name: CLUSTER_NAME
-              value: {{ include "newrelic.common.cluster" . }}
-            - name: MY_APP_NON_OPTIONAL_ENV_VAR
-          {{- with include "newrelic.common.proxy" . }}
-            - name: MY_APP_PROXY_URL
-              value: {{ . | quote }}
-          {{- end }}
       {{- with include "newrelic.common.nodeSelector" . }}
       nodeSelector:
         {{- . | nindent 8 }}

--- a/library/CHART-TEMPLATE/templates/sidecar-deployment.yaml
+++ b/library/CHART-TEMPLATE/templates/sidecar-deployment.yaml
@@ -44,38 +44,6 @@ spec:
       serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}
 
       containers:
-        {{- /* The integration that sends its metrics to the agent in its sidecar */}}
-        - name: {{ .Chart.Name }}
-          {{- with include "newrelic.common.securityContext.container" . }}
-          securityContext:
-            {{- . | nindent 12 }}
-          {{- end }}
-          image: {{ include "newrelic.common.images.image" ( dict "imageRoot" .Values.image "context" .) }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          ports:
-            - name: http
-              containerPort: 80
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: http
-          readinessProbe:
-            httpGet:
-              path: /
-              port: http
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
-          env:
-            - name: CLUSTER_NAME
-              value: {{ include "newrelic.common.cluster" . }}
-            - name: MY_APP_NON_OPTIONAL_ENV_VAR
-          {{- with include "newrelic.common.proxy" . }}
-            - name: MY_APP_PROXY_URL
-              value: {{ . | quote }}
-          {{- end }}
-
-
         {{- /* The agent that sends the data from the integration to the backend */}}
         - name: agent
           image: {{ include "newrelic.common.images.image" ( dict "imageRoot" .Values.image "context" .) }}
@@ -89,11 +57,24 @@ spec:
               containerPort: 8003
               protocol: TCP
           env:
+            - name: CLUSTER_NAME
+              value: {{ include "newrelic.common.cluster" . }}
+            - name: MY_APP_NON_OPTIONAL_ENV_VAR
+          {{- with include "newrelic.common.proxy" . }}
+            - name: MY_APP_PROXY_URL
+              value: {{ . | quote }}
+          {{- end }}
+
             - name: NRIA_LICENSE_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "newrelic.common.license.secretName" . }}
                   key: {{ include "newrelic.common.license.secretKeyName" . }}
+            - name: NR_INSIGHTS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "newrelic.common.insightsKey.secretName" . }}
+                  key: {{ include "newrelic.common.insightsKey.secretKeyName" . }}
 
             {{- /* At least needed for NRIA_DISPLAY_NAME during special cases below */}}
             - name: "NRI_KUBERNETES_NODE_NAME"
@@ -127,6 +108,30 @@ spec:
                   fieldPath: "spec.nodeName"
               {{- end }}
             {{- end }}
+
+        {{- /* The integration that sends its metrics to the agent in its sidecar */}}
+        - name: {{ .Chart.Name }}
+          {{- with include "newrelic.common.securityContext.container" . }}
+          securityContext:
+            {{- . | nindent 12 }}
+          {{- end }}
+          image: {{ include "newrelic.common.images.image" ( dict "imageRoot" .Values.image "context" .) }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+
 
           # env and envFrom are missing here
           volumeMounts:

--- a/library/CHART-TEMPLATE/tests/cl-agent_config_test.yaml
+++ b/library/CHART-TEMPLATE/tests/cl-agent_config_test.yaml
@@ -18,7 +18,7 @@ tests:
       - hasDocuments:
           count: 1
       - equal:
-          path: data.newrelic-infra\.yml
+          path: data["newrelic-infra.yml"]
           value: |
             # This is the configuration file for the infrastructure agent. See:
             # https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/
@@ -30,7 +30,7 @@ tests:
         verboseLog: true
     asserts:
       - equal:
-          path: data.newrelic-infra\.yml
+          path: data["newrelic-infra.yml"]
           value: |
             # This is the configuration file for the infrastructure agent. See:
             # https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/
@@ -42,7 +42,7 @@ tests:
       verboseLog: true
     asserts:
       - equal:
-          path: data.newrelic-infra\.yml
+          path: data["newrelic-infra.yml"]
           value: |
             # This is the configuration file for the infrastructure agent. See:
             # https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/
@@ -55,7 +55,7 @@ tests:
         verbose: 1
     asserts:
       - equal:
-          path: data.newrelic-infra\.yml
+          path: data["newrelic-infra.yml"]
           value: |
             # This is the configuration file for the infrastructure agent. See:
             # https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/
@@ -68,7 +68,7 @@ tests:
         nrStaging: true
     asserts:
       - equal:
-          path: data.newrelic-infra\.yml
+          path: data["newrelic-infra.yml"]
           value: |
             # This is the configuration file for the infrastructure agent. See:
             # https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/
@@ -79,7 +79,7 @@ tests:
       nrStaging: true
     asserts:
       - equal:
-          path: data.newrelic-infra\.yml
+          path: data["newrelic-infra.yml"]
           value: |
             # This is the configuration file for the infrastructure agent. See:
             # https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/
@@ -91,7 +91,7 @@ tests:
         staging: true
     asserts:
       - equal:
-          path: data.newrelic-infra\.yml
+          path: data["newrelic-infra.yml"]
           value: |
             # This is the configuration file for the infrastructure agent. See:
             # https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/
@@ -103,7 +103,7 @@ tests:
       proxy: test@test:a-proxy.com
     asserts:
       - equal:
-          path: data.newrelic-infra\.yml
+          path: data["newrelic-infra.yml"]
           value: |
             # This is the configuration file for the infrastructure agent. See:
             # https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/
@@ -114,7 +114,7 @@ tests:
       proxy: test@test:a-proxy.com
     asserts:
       - equal:
-          path: data.newrelic-infra\.yml
+          path: data["newrelic-infra.yml"]
           value: |
             # This is the configuration file for the infrastructure agent. See:
             # https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/
@@ -126,7 +126,7 @@ tests:
         proxy: test@test:a-proxy.com
     asserts:
       - equal:
-          path: data.newrelic-infra\.yml
+          path: data["newrelic-infra.yml"]
           value: |
             # This is the configuration file for the infrastructure agent. See:
             # https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/
@@ -139,7 +139,7 @@ tests:
       global.fedramp.enabled: true
     asserts:
       - equal:
-          path: data.newrelic-infra\.yml
+          path: data["newrelic-infra.yml"]
           value: |
             # This is the configuration file for the infrastructure agent. See:
             # https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/
@@ -150,7 +150,7 @@ tests:
       fedramp.enabled: true
     asserts:
       - equal:
-          path: data.newrelic-infra\.yml
+          path: data["newrelic-infra.yml"]
           value: |
             # This is the configuration file for the infrastructure agent. See:
             # https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/
@@ -161,7 +161,7 @@ tests:
       agent.fedramp: true
     asserts:
       - equal:
-          path: data.newrelic-infra\.yml
+          path: data["newrelic-infra.yml"]
           value: |
             # This is the configuration file for the infrastructure agent. See:
             # https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/
@@ -175,7 +175,7 @@ tests:
         test: test
     asserts:
       - equal:
-          path: data.newrelic-infra\.yml
+          path: data["newrelic-infra.yml"]
           value: |
             # This is the configuration file for the infrastructure agent. See:
             # https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/
@@ -191,7 +191,7 @@ tests:
           test: test
     asserts:
       - equal:
-          path: data.newrelic-infra\.yml
+          path: data["newrelic-infra.yml"]
           value: |
             # This is the configuration file for the infrastructure agent. See:
             # https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/
@@ -224,7 +224,7 @@ tests:
           agent: agent
     asserts:
       - equal:
-          path: data.newrelic-infra\.yml
+          path: data["newrelic-infra.yml"]
           value: |  # as they are merged and templated with `toYaml` they are alphabetically ordered.
             # This is the configuration file for the infrastructure agent. See:
             # https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/

--- a/library/CHART-TEMPLATE/tests/cl-images_pull_secrets_test.yaml
+++ b/library/CHART-TEMPLATE/tests/cl-images_pull_secrets_test.yaml
@@ -8,9 +8,8 @@ release:
 tests:
   - it: does not set imagePullSecrets if not specified
     asserts:
-      - equal:
+      - notExists:
           path: spec.template.spec.imagePullSecrets
-          value: null
 
   - it: does set imagePullSecrets if specified in values
     set:

--- a/library/CHART-TEMPLATE/tests/cl-images_security_context_container_test.yaml
+++ b/library/CHART-TEMPLATE/tests/cl-images_security_context_container_test.yaml
@@ -9,9 +9,8 @@ tests:
   - it: does not set securityContext if not specified
     set:
     asserts:
-      - equal:
+      - notExists:
           path: spec.template.spec.containers[0].securityContext
-          value: null
 
   - it: does set securityContext if specified in values
     set:

--- a/library/CHART-TEMPLATE/tests/cl-images_security_context_pod_test.yaml
+++ b/library/CHART-TEMPLATE/tests/cl-images_security_context_pod_test.yaml
@@ -9,9 +9,8 @@ tests:
   - it: does not set podSecurityContext if not specified
     set:
     asserts:
-      - equal:
+      - notExists:
           path: spec.template.spec.securityContext
-          value: null
 
   - it: does set podSecurityContext if specified in values
     set:

--- a/library/CHART-TEMPLATE/tests/cl-insights_helpers_test.yaml
+++ b/library/CHART-TEMPLATE/tests/cl-insights_helpers_test.yaml
@@ -1,0 +1,66 @@
+suite: test insightsKey helpers
+templates:
+  - templates/example-cm-insightskey.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+tests:
+  - it: creates secret names for local insightskey
+    set:
+      insightskey: local
+    asserts:
+      - equal:
+          path: data.insightskey-secret-name
+          value: my-release-CHART-TEMPLATE-insightskey
+      - equal:
+          path: data.insightskey-secret-key-name
+          value: insightsKey
+  - it: creates secret names for global insightskey
+    set:
+      global:
+        insightsKey: local
+    asserts:
+      - equal:
+          path: data.insightskey-secret-name
+          value: my-release-CHART-TEMPLATE-insightskey
+      - equal:
+          path: data.insightskey-secret-key-name
+          value: insightsKey
+
+  - it: returns local custom secret names
+    set:
+      customInsightsKeySecretName: local
+      customInsightsKeySecretKey: localkey
+    asserts:
+      - equal:
+          path: data.insightskey-secret-name
+          value: local
+      - equal:
+          path: data.insightskey-secret-key-name
+          value: localkey
+  - it: returns global custom secret names
+    set:
+      global:
+        customInsightsKeySecretName: global
+        customInsightsKeySecretKey: globalkey
+    asserts:
+      - equal:
+          path: data.insightskey-secret-name
+          value: global
+      - equal:
+          path: data.insightskey-secret-key-name
+          value: globalkey
+  - it: local secret names override global secret names
+    set:
+      customInsightsKeySecretName: local
+      customInsightsKeySecretKey: localkey
+      global:
+        customInsightsKeySecretName: global
+        customInsightsKeySecretKey: globalkey
+    asserts:
+      - equal:
+          path: data.insightskey-secret-name
+          value: local
+      - equal:
+          path: data.insightskey-secret-key-name
+          value: localkey

--- a/library/CHART-TEMPLATE/tests/cl-insights_secret_test.yaml
+++ b/library/CHART-TEMPLATE/tests/cl-insights_secret_test.yaml
@@ -1,56 +1,56 @@
-suite: test licenseKey secret
+suite: test insightsKey secret
 templates:
-  - templates/example-license-secret.yaml
+  - templates/example-insights-secret.yaml
 release:
   name: my-release
   namespace: my-namespace
 tests:
-  - it: errors if licenseKey is empty
+  - it: errors if insightsKey is empty
     set:
       global: null
-      licenseKey: null
+      insightsKey: null
     asserts:
       - failedTemplate:
-          errorMessage: You must specify a licenseKey or a customSecretName containing it
+          errorMessage: You must specify a insightsKey or a customInsightsSecretName containing it
   - it: creates secret with local license key
     set:
       global: null
-      licenseKey: local
+      insightsKey: local
     asserts:
       - equal:
-          path: data.licenseKey
+          path: data.insightsKey
           value: bG9jYWw=  # echo -n local | base64
   - it: creates secret with global license key
     set:
-      licenseKey: null
+      insightsKey: null
       global:
-        licenseKey: global
+        insightsKey: global
     asserts:
       - equal:
-          path: data.licenseKey
+          path: data.insightsKey
           value: Z2xvYmFs  # echo -n global | base64
   - it: local overrides global
     set:
-      licenseKey: local
+      insightsKey: local
       global:
-        licenseKey: global
+        insightsKey: global
     asserts:
       - equal:
-          path: data.licenseKey
+          path: data.insightsKey
           value: bG9jYWw=  # echo -n local | base64
 
   - it: does not create a secret if one is provided locally
     set:
-      licenseKey: I exist but will be ignored
-      customSecretName: foo
+      insightsKey: I exist but will be ignored
+      customInsightsKeySecretName: foo
     asserts:
       - hasDocuments:
           count: 0
   - it: does not create a secret if one is provided globally
     set:
-      licenseKey: I exist but will be ignored
+      insightsKey: I exist but will be ignored
       global:
-        customSecretName: foo
+        customInsightsKeySecretName: foo
     asserts:
       - hasDocuments:
           count: 0

--- a/library/CHART-TEMPLATE/tests/cl-priority_class_name_test.yaml
+++ b/library/CHART-TEMPLATE/tests/cl-priority_class_name_test.yaml
@@ -8,9 +8,8 @@ release:
 tests:
   - it: does not set priorityClassName is not specified
     asserts:
-      - equal:
+      - notExists:
           path: spec.template.spec.priorityClassName
-          value: null
   - it: set priorityClassName if specified in values
     set:
       priorityClassName: testPriority

--- a/library/CHART-TEMPLATE/values.yaml
+++ b/library/CHART-TEMPLATE/values.yaml
@@ -41,6 +41,7 @@ global:
   verboseLog:
 
 licenseKey: foobar  # These ease testing as we don't have to set these values in each test
+insightsKey: foobaz  # These ease testing as we don't have to set these values in each test
 cluster: barfoo  # These ease testing as we don't have to set these values in each test
 customSecretName: ""
 customSecretLicenseKey: ""

--- a/library/common-library/Chart.yaml
+++ b/library/common-library/Chart.yaml
@@ -3,7 +3,7 @@ name: common-library
 description: Provides helpers to provide consistency on all the charts
 
 type: library
-version: 1.1.1
+version: 1.2.0
 
 keywords:
   - newrelic
@@ -16,3 +16,5 @@ maintainers:
     url: https://github.com/csongnr
   - name: dbudziwojskiNR
     url: https://github.com/dbudziwojskiNR
+  - name: kang-makes
+    url: https://github.com/kang-makes

--- a/library/common-library/DEVELOPERS.md
+++ b/library/common-library/DEVELOPERS.md
@@ -462,6 +462,49 @@ You just must have a template with these two lines:
 
 
 
+## _insights.tpl
+### `newrelic.common.insightsKey.secretName` and ### `newrelic.common.insightsKey.secretKeyName`
+Returns the secret and key inside the secret where to read the insights key.
+
+The common library will take care of using a user-provided custom secret or creating a secret that contains the insights key.
+
+To create the secret use `newrelic.common.insightsKey.secret`.
+
+Usage:
+```mustache
+apiVersion: v1
+kind: Pod
+metadata:
+  name: statsd
+spec:
+  containers:
+  - name: statsd
+    env:
+    - name: "INSIGHTS_KEY"
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "newrelic.common.insightsKey.secretName" . }}
+          key: {{ include "newrelic.common.insightsKey.secretKeyName" . }}
+```
+
+
+
+## _insights_secret.tpl
+### `newrelic.common.insightsKey.secret`
+This function templates the secret that is used by agents and integrations with the insights key provided by the user. It will
+template nothing (empty string) if the user provides a custom pair of secret name and key.
+
+This template also fails in case the user has not provided any insights key or custom secret so no safety checks have to be done
+by chart writers.
+
+You just must have a template with these two lines:
+```mustache
+{{- /* Common library will take care of creating the secret or not. */ -}}
+{{- include "newrelic.common.insightsKey.secret" . -}}
+```
+
+
+
 ## _low-data-mode.tpl
 ### `newrelic.common.lowDataMode`
 Like almost everything in this library, it reads global and local variables:

--- a/library/common-library/templates/_insights.tpl
+++ b/library/common-library/templates/_insights.tpl
@@ -1,0 +1,56 @@
+{{/*
+Return the name of the secret holding the Insights Key.
+*/}}
+{{- define "newrelic.common.insightsKey.secretName" -}}
+{{- $default := include "newrelic.common.naming.truncateToDNSWithSuffix" ( dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "insightskey" ) -}}
+{{- include "newrelic.common.insightsKey._customSecretName" . | default $default -}}
+{{- end -}}
+
+{{/*
+Return the name key for the Insights Key inside the secret.
+*/}}
+{{- define "newrelic.common.insightsKey.secretKeyName" -}}
+{{- include "newrelic.common.insightsKey._customSecretKey" . | default "insightsKey" -}}
+{{- end -}}
+
+{{/*
+Return local insightsKey if set, global otherwise.
+This helper is for internal use.
+*/}}
+{{- define "newrelic.common.insightsKey._licenseKey" -}}
+{{- if .Values.insightsKey -}}
+  {{- .Values.insightsKey -}}
+{{- else if .Values.global -}}
+  {{- if .Values.global.insightsKey -}}
+    {{- .Values.global.insightsKey -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the name of the secret holding the Insights Key.
+This helper is for internal use.
+*/}}
+{{- define "newrelic.common.insightsKey._customSecretName" -}}
+{{- if .Values.customInsightsKeySecretName -}}
+  {{- .Values.customInsightsKeySecretName -}}
+{{- else if .Values.global -}}
+  {{- if .Values.global.customInsightsKeySecretName -}}
+    {{- .Values.global.customInsightsKeySecretName -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the name key for the Insights Key inside the secret.
+This helper is for internal use.
+*/}}
+{{- define "newrelic.common.insightsKey._customSecretKey" -}}
+{{- if .Values.customInsightsKeySecretKey -}}
+  {{- .Values.customInsightsKeySecretKey -}}
+{{- else if .Values.global -}}
+  {{- if .Values.global.customInsightsKeySecretKey }}
+    {{- .Values.global.customInsightsKeySecretKey -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/library/common-library/templates/_insights_secret.yaml.tpl
+++ b/library/common-library/templates/_insights_secret.yaml.tpl
@@ -1,0 +1,21 @@
+{{/*
+Renders the insights key secret if user has not specified a custom secret.
+*/}}
+{{- define "newrelic.common.insightsKey.secret" }}
+{{- if not (include "newrelic.common.insightsKey._customSecretName" .) }}
+{{- /* Fail if licenseKey is empty and required: */ -}}
+{{- if not (include "newrelic.common.insightsKey._licenseKey" .) }}
+    {{- fail "You must specify a insightsKey or a customInsightsSecretName containing it" }}
+{{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "newrelic.common.insightsKey.secretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "newrelic.common.labels" . | nindent 4 }}
+data:
+  {{ include "newrelic.common.insightsKey.secretKeyName" . }}: {{ include "newrelic.common.insightsKey._licenseKey" . | b64enc }}
+{{- end }}
+{{- end }}

--- a/library/common-library/templates/_license.tpl
+++ b/library/common-library/templates/_license.tpl
@@ -2,14 +2,15 @@
 Return the name of the secret holding the License Key.
 */}}
 {{- define "newrelic.common.license.secretName" -}}
-{{ include "newrelic.common.license._customSecretName" . | default (printf "%s-license" (include "newrelic.common.naming.fullname" . )) }}
+{{- $default := include "newrelic.common.naming.truncateToDNSWithSuffix" ( dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "license" ) -}}
+{{- include "newrelic.common.license._customSecretName" . | default $default -}}
 {{- end -}}
 
 {{/*
 Return the name key for the License Key inside the secret.
 */}}
 {{- define "newrelic.common.license.secretKeyName" -}}
-{{ include "newrelic.common.license._customSecretKey" . | default "licenseKey" }}
+{{- include "newrelic.common.license._customSecretKey" . | default "licenseKey" -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
Issue #1324 ask for support to have the insights key out of the `values.yaml`. This is an opportunity to have the same UX for that key that we have for the rest of secrets/licenses.

#### Which issue this PR fixes
This PR does not fix any issue yet but it is the first step to fix #1324.

Once this PR is merged, we have the tooling to add `common-library` to `nri-statsd`.

#### Special notes for your reviewer:
Some test were not passing because of updates of `helm unittest` so I have to fix them. 

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
