### PR TITLE
[super-agent] Making sure all resources are deleted

### DIFF
--- a/.github/workflows/lint_test_charts.yaml
+++ b/.github/workflows/lint_test_charts.yaml
@@ -86,8 +86,6 @@ jobs:
           github token: ${{ secrets.GITHUB_TOKEN }}
           driver: docker
           start args: "--container-runtime=containerd"
-      - name: Create test ns
-        run: kubectl create ns ct
 
       - name: Create certificate manager
         run: |
@@ -98,9 +96,9 @@ jobs:
             --set crds.enabled=true
 
       - name: Test install charts
-        run: ct install --namespace ct --config .github/ct-install.yaml
+        run: ct install --config .github/ct-install.yaml
       - name: Test upgrade charts
-        run: ct install --namespace ct --config .github/ct-install.yaml --upgrade
+        run: ct install --config .github/ct-install.yaml --upgrade
 
   bundle-integrity:
     name: Test nri-bundle dependencies has the same version of the common-library

--- a/charts/super-agent/Chart.lock
+++ b/charts/super-agent/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 2.13.0
 - name: super-agent-deployment
   repository: ""
-  version: 0.0.18-beta
+  version: 0.0.19-beta
 - name: common-library
   repository: https://helm-charts.newrelic.com
   version: 1.2.0
-digest: sha256:3f902772b4a9b1ba68f6839f200a360324770c4bec10f5708f406bcbc429b477
-generated: "2024-06-28T11:25:09.117036+02:00"
+digest: sha256:7a702b512c98c314986bb4e22be71bbc52183b4d4b05758658a942e184fdc935
+generated: "2024-07-02T17:23:44.108104+02:00"

--- a/charts/super-agent/Chart.yaml
+++ b/charts/super-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: super-agent
 description: Bootstraps New Relic' Super Agent
 
 type: application
-version: 0.0.12-beta
+version: 0.0.13-beta
 
 dependencies:
   - name: flux2
@@ -11,7 +11,7 @@ dependencies:
     version: 2.13.0
     condition: flux2.enabled
   - name: super-agent-deployment
-    version: 0.0.18-beta
+    version: 0.0.19-beta
     condition: super-agent-deployment.enabled
     # The following dependency is needed as sub-dependency of super-agent-deployment
   - name: common-library

--- a/charts/super-agent/charts/super-agent-deployment/Chart.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/Chart.yaml
@@ -4,8 +4,7 @@ description: A Helm chart to install New Relic Super agent on Kubernetes
 
 type: application
 
-version: 0.0.18-beta
-appVersion: 0.17.0
+version: 0.0.19-beta
 
 keywords:
   - newrelic

--- a/charts/super-agent/charts/super-agent-deployment/templates/rbac.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/templates/rbac.yaml
@@ -27,7 +27,7 @@ kind: ClusterRole
 metadata:
   labels:
     {{- include "newrelic.common.labels" . | nindent 4 }}
-  name: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "cm") }}
+  name: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "resources") }}
   namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups: [ "" ]
@@ -54,6 +54,13 @@ rules:
       - get
       - list
       - watch
+  - apiGroups: [ "apps" ]
+    resources:
+      - deployments/scale
+    verbs:
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -76,12 +83,12 @@ kind: RoleBinding
 metadata:
   labels:
     {{- include "newrelic.common.labels" . | nindent 4 }}
-  name: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "cm") }}
+  name: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "resources") }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "cm") }}
+  name: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "resources") }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "newrelic.common.serviceAccount.name" . }}

--- a/charts/super-agent/charts/super-agent-deployment/templates/uninstall-job.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/templates/uninstall-job.yaml
@@ -33,6 +33,9 @@ spec:
             - |
               set -o pipefail
 
+              # We want to avoid having the SA recreating some of the resources we are deleting running this job
+              kubectl scale deployment --replicas=0 {{ include "newrelic.common.naming.fullname" . }}  -n {{ $.Release.Namespace }} --timeout=60s
+
               # Delete the standard resources (configmaps) managed by the super-agent
               kubectl delete configmaps -n {{ .Release.Namespace }} -l {{ $saResourcesLabelSelector }}
 


### PR DESCRIPTION
#### Is this a new chart
This PR:
 -  forces `CT` to use a separate naspace so that we are sure `kubectl delete ns ...` will wait that resources are garbage collected (`ct` is not doing so when running helm delete)
 - modifies the uninstall job to make sure the super agent is NOT running before deleting resources. This is needed to avoid the SA recreating it right after  

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
