### PR TITLE
Chart Name newrelic-logging: Adding indentation to pod labels

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.22.1
+version: 1.22.2
 appVersion: 2.0.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/templates/daemonset.yaml
+++ b/charts/newrelic-logging/templates/daemonset.yaml
@@ -28,9 +28,9 @@ spec:
         release: {{.Release.Name }}
         kubernetes.io/os: linux
         app.kubernetes.io/name: {{ template "newrelic-logging.name" . }}
-        {{- if .Values.podLabels}}
-        {{ toYaml .Values.podLabels }}
-        {{- end }}
+{{- if .Values.podLabels}}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
     spec:
       serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}
       {{- with include "newrelic.common.dnsConfig" . }}

--- a/charts/newrelic-logging/tests/fluentbit_pod_label_test.yaml
+++ b/charts/newrelic-logging/tests/fluentbit_pod_label_test.yaml
@@ -1,0 +1,43 @@
+suite: test fluent-bit pods labels
+templates:
+  - templates/daemonset.yaml
+  - templates/configmap.yaml
+  - templates/persistentvolume.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+tests:
+- it: pod labels are correct
+  templates:
+    - templates/daemonset.yaml
+  set:
+    podLabels:
+      key1: value1
+      key2: value2
+  asserts:
+    - equal:
+        - spec.template.metadata.labels.key1
+        - value1
+    - equal:
+        - spec.template.metadata.labels.key2
+        - value2
+- it: pod labels are not set
+  templates:
+    - templates/daemonset.yaml
+  asserts:
+    - notExists:
+        - spec.template.metadata.labels.key1
+    - notExists:
+        - spec.template.metadata.labels.key2
+- it: pod labels are correctly indented
+  set:
+    podLabels:
+      customLabel1: customValue1
+      customLabel2: customValue2
+  asserts:
+    - matchSnippet:
+        path: spec.template.metadata.labels
+        snippet: |
+          customLabel1: customValue1
+          customLabel2: customValue2
+        indent: 8


### PR DESCRIPTION
[newrelic-logging] Adding more than one podLabel results in invalid yaml errors

<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
Validated the changes with dry run of the helm chart newrelic-logging installation locally and validated generated metadata of the fluentbit daemon set. Also validated indentation.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
