### PR TITLE
[super-agent] feat: add license key as env from secret (NR-293501)

### DIFF
--- a/charts/super-agent/Chart.lock
+++ b/charts/super-agent/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 2.13.0
 - name: super-agent-deployment
   repository: ""
-  version: 0.0.19-beta
+  version: 0.0.20-beta
 - name: common-library
   repository: https://helm-charts.newrelic.com
   version: 1.2.0
-digest: sha256:7a702b512c98c314986bb4e22be71bbc52183b4d4b05758658a942e184fdc935
-generated: "2024-07-02T17:23:44.108104+02:00"
+digest: sha256:d25475b5e93bd110455a26233c94ba42fa75556799ad10414a31e0043e446311
+generated: "2024-07-24T12:28:38.117429+02:00"

--- a/charts/super-agent/Chart.yaml
+++ b/charts/super-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: super-agent
 description: Bootstraps New Relic' Super Agent
 
 type: application
-version: 0.0.13-beta
+version: 0.0.14-beta
 
 dependencies:
   - name: flux2
@@ -11,7 +11,7 @@ dependencies:
     version: 2.13.0
     condition: flux2.enabled
   - name: super-agent-deployment
-    version: 0.0.19-beta
+    version: 0.0.20-beta
     condition: super-agent-deployment.enabled
     # The following dependency is needed as sub-dependency of super-agent-deployment
   - name: common-library
@@ -29,7 +29,5 @@ maintainers:
     url: https://github.com/gsanchezgavier
   - name: kang-makes
     url: https://github.com/kang-makes
-  - name: marcsanmi
-    url: https://github.com/marcsanmi
   - name: paologallinaharbur
     url: https://github.com/paologallinaharbur

--- a/charts/super-agent/charts/super-agent-deployment/Chart.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Super agent on Kubernetes
 
 type: application
 
-version: 0.0.19-beta
+version: 0.0.20-beta
 
 keywords:
   - newrelic
@@ -17,7 +17,5 @@ maintainers:
     url: https://github.com/gsanchezgavier
   - name: kang-makes
     url: https://github.com/kang-makes
-  - name: marcsanmi
-    url: https://github.com/marcsanmi
   - name: paologallinaharbur
     url: https://github.com/paologallinaharbur

--- a/charts/super-agent/charts/super-agent-deployment/templates/_helpers.tpl
+++ b/charts/super-agent/charts/super-agent-deployment/templates/_helpers.tpl
@@ -14,13 +14,6 @@ cluster name, licenses, and custom attributes
 This snippet should execute always to block all unsupported features from the common-lirary that are not yet supported
 by this chart.
 
-TODO: Remove this file when the Super Agent supports licensekey as an envVar.
-*/ -}}
-{{ $licenseKey := include "newrelic.common.license._licenseKey" . }}
-{{- if or (include "newrelic.common.license._customSecretName" .) (include "newrelic.common.license._customSecretKey" .) -}}
-    {{- fail "Common library supports setting an external custom secret for the license but the super agent still does not support the license by an env var. You must specify a .licenseKey or .global.licenseKey" -}}
-{{- end -}}
-
 {{- /*
 TODO: There are a lot of TODOs to be made in this chart yet and some of them are going to impact the YAML that holds 
 the config.

--- a/charts/super-agent/charts/super-agent-deployment/templates/deployment-superagent.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/templates/deployment-superagent.yaml
@@ -54,8 +54,20 @@ spec:
           image: {{ include "newrelic.common.images.image" ( dict "imageRoot" .Values.image "context" .) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
 
-          {{- with .Values.extraEnv }}
           env:
+            - name: NR_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "newrelic.common.license.secretName" . }}
+                  key: {{ include "newrelic.common.license.secretKeyName" . }}
+          {{- if .Values.config.superAgent.content.opamp }}
+            - name: NR_SA_OPAMP__HEADERS__API-KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "newrelic.common.license.secretName" . }}
+                  key: {{ include "newrelic.common.license.secretKeyName" . }}
+          {{- end }}
+          {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.extraEnvFrom }}

--- a/charts/super-agent/charts/super-agent-deployment/templates/secret.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/templates/secret.yaml
@@ -1,0 +1,2 @@
+{{- /* Common library will take care of creating the secret or not. */}}
+{{- include "newrelic.common.license.secret" . }}

--- a/charts/super-agent/charts/super-agent-deployment/tests/configmap_fleet_configs_test.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/tests/configmap_fleet_configs_test.yaml
@@ -5,7 +5,11 @@ release:
   name: my-release
   namespace: my-namespace
 tests:
-  - it: does not template nothing by default
+  - it: default value can be overridden
+    set:
+      config:
+        subAgents:
+          open-telemetry: null
     asserts:
       - hasDocuments:
           count: 0
@@ -13,6 +17,7 @@ tests:
     set:
       config:
         subAgents:
+          open-telemetry: null
           test-0:
             content:
               a: test

--- a/charts/super-agent/charts/super-agent-deployment/tests/deployment_superagent_env_test.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/tests/deployment_superagent_env_test.yaml
@@ -1,0 +1,93 @@
+suite: test super agent deployment's securityContext
+templates:
+  - templates/deployment-superagent.yaml
+  - templates/configmap-superagent-config.yaml
+  - templates/configmap-subagent-configs.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+tests:
+  - it: license key gets added as env var from secret
+    set:
+      cluster: test
+      licenseKey: fake-license
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: NR_LICENSE_KEY
+        template: templates/deployment-superagent.yaml
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
+          value: my-release-super-agent-deployment-license
+        template: templates/deployment-superagent.yaml
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.key
+          value: licenseKey
+        template: templates/deployment-superagent.yaml
+        
+  - it: license key gets added as env var from custom secret
+    set:
+      cluster: test
+      customSecretName: "custom-secret"
+      customSecretLicenseKey: "custom-key"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: NR_LICENSE_KEY
+        template: templates/deployment-superagent.yaml
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
+          value: custom-secret
+        template: templates/deployment-superagent.yaml
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.key
+          value: custom-key
+        template: templates/deployment-superagent.yaml
+ 
+  - it: api-key config gets added as env var from secret
+    set:
+      cluster: test
+      licenseKey: fake-license
+      config:
+        superAgent:
+          content: 
+            opamp:
+              endpoint: test
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: NR_SA_OPAMP__HEADERS__API-KEY
+        template: templates/deployment-superagent.yaml
+      - equal:
+          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.name
+          value: my-release-super-agent-deployment-license
+        template: templates/deployment-superagent.yaml
+      - equal:
+          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.key
+          value: licenseKey
+        template: templates/deployment-superagent.yaml
+
+  - it: api-key config gets added as env var from custom secret
+    set:
+      cluster: test
+      customSecretName: "custom-secret"
+      customSecretLicenseKey: "custom-key"
+      config:
+        superAgent:
+          content: 
+            opamp:
+              endpoint: test
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: NR_SA_OPAMP__HEADERS__API-KEY
+        template: templates/deployment-superagent.yaml
+      - equal:
+          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.name
+          value: custom-secret
+        template: templates/deployment-superagent.yaml
+      - equal:
+          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.key
+          value: custom-key
+        template: templates/deployment-superagent.yaml
+        

--- a/charts/super-agent/charts/super-agent-deployment/tests/licenseKey_test.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/tests/licenseKey_test.yaml
@@ -1,28 +1,48 @@
-suite: licenseKey temporary tests
-# These tests are to test that a missing licenseKey actually aborts templating the chart.
-# This should be something that the common-library should do, but the common library does
-# it while templating the secret with the license to be used as a envVar.
-# As the super agent does not support it as a envvar (yet), we added it directly on the
-# configuration file. The consequence is that the chart is able to template without
-# license.
-# TODO: Remove this file when the Super Agent supports licensekey as an envVar.
+suite: licenseKey tests
 templates:
-  - templates/configmap-superagent-config.yaml
+  - templates/secret.yaml
 release:
   name: my-release
   namespace: my-namespace
 tests:
-  - it: Using custom secret abort the template
+  - it: licenseKey is required
     set:
-      global:
-        customSecretName: non-empty
+      cluster: test
+      licenseKey: null
     asserts:
       - failedTemplate:
-          errorMessage: Common library supports setting an external custom secret for the license but the super agent still does not support the license by an env var. You must specify a .licenseKey or .global.licenseKey
-  - it: Using custom secret abort the template
+          errorMessage: You must specify a licenseKey or a customSecretName containing it
+# generated secret
+  - it: licenseKey generates the secret
     set:
-      global:
-        customSecretLicenseKey: non-empty
+      cluster: test
+      licenseKey: test
     asserts:
-      - failedTemplate:
-          errorMessage: Common library supports setting an external custom secret for the license but the super agent still does not support the license by an env var. You must specify a .licenseKey or .global.licenseKey
+      - hasDocuments:
+          count: 1
+  - it: global licenseKey generates the secret
+    set:
+      cluster: test
+      global: 
+        licenseKey: test
+    asserts:
+      - hasDocuments:
+          count: 1
+# custom secret
+  - it: licenseKey secret is not generated when custom is used
+    set:
+      cluster: test
+      customSecretName: "custom-secret"
+      customSecretLicenseKey: "custom-key"
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: licenseKey secret is not generated when global custom is used
+    set:
+      cluster: test
+      global:
+        customSecretName: "custom-secret"
+        customSecretLicenseKey: "custom-key"
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/super-agent/ci/test-values.yaml
+++ b/charts/super-agent/ci/test-values.yaml
@@ -7,4 +7,3 @@ super-agent-deployment:
         content:
           chart_values:
             cluster: "sa-cluster"
-            licenseKey: "test"

--- a/charts/super-agent/tests/placeholder
+++ b/charts/super-agent/tests/placeholder
@@ -1,0 +1,1 @@
+This file is a placeholder so the CI run the unittest command for the sub charts contained here.

--- a/charts/super-agent/values.yaml
+++ b/charts/super-agent/values.yaml
@@ -24,7 +24,7 @@ super-agent-deployment:
   image:
     registry:
     repository: newrelic/newrelic-super-agent
-    tag: 0.17.0
+    tag: 0.20.0
     imagePullPolicy: IfNotPresent
     # -- The secrets that are needed to pull images from a custom registry.
     pullSecrets: []
@@ -163,9 +163,9 @@ super-agent-deployment:
         content:
           # chart_version: "0.4.0"
           chart_values:
+            licenseKey: ${nr-env:NR_LICENSE_KEY}
             # TODO the following values are set twice in the config, we have to add some logic to improve UX either in the chart or in the agentType
             # cluster: ""
-            # licenseKey: ""
             # customSecretName: ""
             # customSecretLicenseKey: ""
 


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

#### What this PR does / why we need it:

- Adds license key as env variable  from the secret for the SA deployment. This will allow to use env vars placeholders in configs rather than plain secrets for sub-agents.



#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
