### PR TITLE
[super-agent] Add system identity creation and registration to the chart

### DIFF
--- a/charts/super-agent/Chart.lock
+++ b/charts/super-agent/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 2.13.0
 - name: super-agent-deployment
   repository: ""
-  version: 0.0.22-beta
+  version: 0.0.23-beta
 - name: common-library
   repository: https://helm-charts.newrelic.com
   version: 1.2.0
-digest: sha256:b2770b12c9ff3f93eebbc745645f4026cf9b899b1fabc614b298a61dc4b4c9ed
-generated: "2024-08-01T10:11:46.199593+02:00"
+digest: sha256:2d08c8a6be0be9f173c1ddd88fc992e80515e7cc2cb6bb7f93922c4ec96be7c9
+generated: "2024-08-16T12:32:39.289966+02:00"

--- a/charts/super-agent/Chart.yaml
+++ b/charts/super-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: super-agent
 description: Bootstraps New Relic' Super Agent
 
 type: application
-version: 0.0.18-beta
+version: 0.0.19-beta
 
 dependencies:
   - name: flux2
@@ -11,7 +11,7 @@ dependencies:
     version: 2.13.0
     condition: flux2.enabled
   - name: super-agent-deployment
-    version: 0.0.22-beta
+    version: 0.0.23-beta
     condition: super-agent-deployment.enabled
     # The following dependency is needed as sub-dependency of super-agent-deployment
   - name: common-library

--- a/charts/super-agent/charts/super-agent-deployment/Chart.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Super agent on Kubernetes
 
 type: application
 
-version: 0.0.22-beta
+version: 0.0.23-beta
 
 keywords:
   - newrelic

--- a/charts/super-agent/charts/super-agent-deployment/templates/_helpers.tpl
+++ b/charts/super-agent/charts/super-agent-deployment/templates/_helpers.tpl
@@ -14,7 +14,7 @@ Return the agents part that should go in the super agent config. It is created f
 {{- if (.Values.config).subAgents -}}
 {{- $agents := dict -}}
 {{- range $subAgentName, $subAgentConfig := (.Values.config).subAgents -}}
-  {{- if not $subAgentConfig.type -}}
+  {{- if not ($subAgentConfig).type -}}
     {{- fail (printf "Agent %s does not have agent type" $subAgentName) -}}
   {{- end -}}
   {{- $_ := dict $subAgentName (dict "agent_type" $subAgentConfig.type "content" $subAgentConfig.content) | mustMerge $agents -}}
@@ -155,10 +155,11 @@ readOnlyRootFilesystem: true
 Return .Values.config.auth.organizationId and fails if it does not exists
 */ -}}
 {{- define "newrelic-super-agent.auth.organizationId" -}}
-{{- if not ((.Values.config).auth).organizationId -}}
-  {{- fail ".Values.config.auth.organizationId is required." -}}
+{{- if ((.Values.config).auth).organizationId -}}
+  {{- .Values.config.auth.organizationId -}}
+{{- else -}}
+  {{- fail ".config.auth.organizationId is required." -}}
 {{- end -}}
-{{- .Values.config.auth.organizationId -}}
 {{- end -}}
 
 
@@ -211,7 +212,7 @@ Helper to toggle the creation of the secret that has the system identity as valu
 
 
 {{- /*
-Check if .Values.config.auth.secret.private_key.secret_key exists and use it for the key in the secret contaning the private
+Check if .Values.config.auth.secret.private_key.secret_key exists and use it for the key in the secret containing the private
 key needed for the system identity. Fallbacks to `private_key`.
 */ -}}
 {{- define "newrelic-super-agent.auth.secret.privateKey.key" -}}

--- a/charts/super-agent/charts/super-agent-deployment/templates/_helpers.tpl
+++ b/charts/super-agent/charts/super-agent-deployment/templates/_helpers.tpl
@@ -2,19 +2,76 @@
 Return the name of the configMap holding the Super Agent's config. Defaults to release's fill name suffiexed with "-config"
 */ -}}
 {{- define "newrelic-super-agent.config.name" -}}
-{{- (include "newrelic.common.naming.truncateToDNSWithSuffix" ( dict "name" "local-data" "suffix" "superagent-config" )) -}}
+{{- include "newrelic.common.naming.truncateToDNSWithSuffix" ( dict "name" "local-data" "suffix" "superagent-config" ) -}}
 {{- end -}}
+
+
+
+{{- /*
+Return the agents part that should go in the super agent config. It is created from `.Values.config.subAgents`.
+*/ -}}
+{{- define "newrelic-super-agent.config.agents.yaml" -}}
+{{- if (.Values.config).subAgents -}}
+{{- $agents := dict -}}
+{{- range $subAgentName, $subAgentConfig := (.Values.config).subAgents -}}
+  {{- if not $subAgentConfig.type -}}
+    {{- fail (printf "Agent %s does not have agent type" $subAgentName) -}}
+  {{- end -}}
+  {{- $_ := dict $subAgentName (dict "agent_type" $subAgentConfig.type "content" $subAgentConfig.content) | mustMerge $agents -}}
+{{- end -}}
+{{- $agents | toYaml -}}
+{{- else -}}
+{{- /* Default agents for Kubernetes */ -}}
+open-telemetry:
+  type: newrelic/io.opentelemetry.collector:0.2.0
+  content:
+    chart_values:
+      licenseKey: ${nr-env:NR_LICENSE_KEY}
+      cluster: ${nr-env:NR_CLUSTER_NAME}
+{{- end -}}
+{{- end -}}
+
+
+
+{{- /*
+Return to which endpoint should the super agent connect to get opamp data
+*/ -}}
+{{- define "newrelic-super-agent.config.endpoints.opamp" -}}
+{{- $region := include "newrelic.common.region" . -}}
+
+{{- if eq $region "Staging" -}}
+  https://opamp.staging-service.newrelic.com/v1/opamp
+{{- else if eq $region "EU" -}}
+  https://opamp.service.eu.newrelic.com/v1/opamp
+{{- else if eq $region "US" -}}
+  https://opamp.service.newrelic.com/v1/opamp
+{{- else if eq $region "Local" -}}
+  {{- /* Accessing the value directly without protection. A developer should now how to read the error. */ -}}
+  {{ .Values.development.backend.opamp }}
+{{- else -}}
+  {{- fail "Unknown/unsupported region set for this chart" -}}
+{{- end -}}
+{{- end -}}
+
+
 
 {{- /*
 Return to which endpoint should the super agent ask to renew its token
 */ -}}
 {{- define "newrelic-super-agent.config.endpoints.tokenRenewal" -}}
-{{- if include "newrelic.common.nrStaging" . -}}
+{{- $region := include "newrelic.common.region" . -}}
+
+{{- if eq $region "Staging" -}}
   https://system-identity-oauth.staging-service.newrelic.com/oauth2/token
-{{- else if .Values.euEndpoints -}}
+{{- else if eq $region "EU" -}}
   https://system-identity-oauth.service.eu.newrelic.com/oauth2/token
-{{- else -}}
+{{- else if eq $region "US" -}}
   https://system-identity-oauth.service.newrelic.com/oauth2/token
+{{- else if eq $region "Local" -}}
+  {{- /* Accessing the value directly without protection. A developer should now how to read the error. */ -}}
+  {{ .Values.development.backend.tokenRenewal }}
+{{- else -}}
+  {{- fail "Unknown/unsupported region set for this chart" -}}
 {{- end -}}
 {{- end -}}
 
@@ -24,12 +81,19 @@ Return to which endpoint should the super agent ask to renew its token
 Return to which endpoint should the super agent register its system identity
 */ -}}
 {{- define "newrelic-super-agent.config.endpoints.systemIdentityRegistration" -}}
-{{- if include "newrelic.common.nrStaging" . -}}
+{{- $region := include "newrelic.common.region" . -}}
+
+{{- if eq $region "Staging" -}}
   https://staging-api.newrelic.com/graphql
-{{- else if .Values.euEndpoints -}}
+{{- else if eq $region "EU" -}}
   https://api.eu.newrelic.com/graphql
-{{- else -}}
+{{- else if eq $region "US" -}}
   https://api.newrelic.com/graphql
+{{- else if eq $region "Local" -}}
+  {{- /* Accessing the value directly without protection. A developer should now how to read the error. */ -}}
+  {{ .Values.development.backend.systemIdentityRegistration }}
+{{- else -}}
+  {{- fail "Unknown/unsupported region set for this chart" -}}
 {{- end -}}
 {{- end -}}
 
@@ -41,32 +105,27 @@ cluster name, licenses, and custom attributes
 */ -}}
 {{- define "newrelic-super-agent.config.content" -}}
 {{- /*
-This snippet should execute always to block all unsupported features from the common-lirary that are not yet supported
-by this chart.
-
-{{- /*
-TODO: There are a lot of TODOs to be made in this chart yet and some of them are going to impact the YAML that holds 
+TODO: There are a lot of TODOs to be made in this chart yet and some of them are going to impact the YAML that holds
 the config.
 
 If you need a list of TODOs, just `grep TODO` on the `values.yaml` and look for things that are yet to be implemented.
 */ -}}
-{{- $config := .Values.config.superAgent.content | default dict -}}
-{{- $config = mustMergeOverwrite (dict "k8s" (dict "cluster_name" (include "newrelic.common.cluster" .))) $config -}}
-{{- $config = mustMergeOverwrite (dict "k8s" (dict "namespace" .Release.Namespace)) $config -}}
 
-{{- if .Values.config.superAgent.content -}}
-{{- if .Values.config.superAgent.content.opamp -}}
-{{- if .Values.config.auth }}
+{{- $opamp := (dict "endpoint" (include "newrelic-super-agent.config.endpoints.opamp" .)) -}}
+{{- $k8s := (dict "cluster_name" (include "newrelic.common.cluster" .) "namespace" .Release.Namespace) -}}
+
 {{- if .Values.config.auth.enabled -}}
-{{- $opamp := (dict "opamp" (dict "auth_config" (dict "token_url" (include "newrelic-super-agent.config.endpoints.tokenRenewal" .) "provider" "local" "private_key_path" "/etc/newrelic-super-agent/keys/from-secret.key"))) -}}
-{{- $_ := $opamp | mustMergeOverwrite $config -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+  {{- $auth_config := dict "token_url" (include "newrelic-super-agent.config.endpoints.tokenRenewal" .) "provider" "local" "private_key_path" "/etc/newrelic-super-agent/keys/from-secret.key" -}}
+  {{- $_ := mustMerge $opamp (dict "auth_config" $auth_config) -}}
 {{- end -}}
 
+{{- $config := dict "opamp" $opamp "k8s" $k8s "agents" (include "newrelic-super-agent.config.agents.yaml" . | fromYaml) -}}
+
+{{- $_ := deepCopy (.Values.config.superAgent.content | default dict) | mustMergeOverwrite $config -}}
 {{- $config | toYaml -}}
 {{- end -}}
+
+
 
 {{- /* These are the defaults that are used for all the containers in this chart */ -}}
 {{- define "newrelic-super-agent.securityContext.containerDefaults" -}}
@@ -75,6 +134,8 @@ runAsGroup: 2000
 allowPrivilegeEscalation: false
 readOnlyRootFilesystem: true
 {{- end -}}
+
+
 
 {{- /* Allow to change pod defaults dynamically */ -}}
 {{- define "newrelic-super-agent.securityContext.container" -}}
@@ -87,8 +148,6 @@ readOnlyRootFilesystem: true
     {{- toYaml $defaults -}}
 {{- end -}}
 {{- end -}}
-
-
 
 
 
@@ -105,8 +164,116 @@ Return .Values.config.auth.organizationId and fails if it does not exists
 
 
 {{- /*
-Releases with "-auth" suffix.
+Check if .Values.config.auth.secret.name exists and use it to name auth' secret. If it does not exist, fallback to the name
+of the releases with "-auth" suffix.
 */ -}}
 {{- define "newrelic-super-agent.auth.secret.name" -}}
-  {{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "auth") }}
+{{- $secretName := ((((.Values.config).auth).secret).name) -}}
+{{- if $secretName -}}
+  {{- $secretName -}}
+{{- else -}}
+  {{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "auth" ) }}
+{{- end -}}
+{{- end -}}
+
+
+
+{{- /*
+Helper to toggle the creation of the job that creates and registers the system identity.
+*/ -}}
+{{- define "newrelic-super-agent.auth.secret.shouldRunJob" -}}
+{{- $privateKey := include "newrelic-super-agent.auth.secret.privateKey.data" . -}}
+{{- $clientId := include "newrelic-super-agent.auth.secret.clientId.data" . -}}
+
+{{- if and ((.Values.config).auth).enabled (((.Values.config).auth).secret).create (not $privateKey) (not $clientId) -}}
+  true
+{{- end -}}
+{{- end -}}
+
+
+
+{{- /*
+Helper to toggle the creation of the secret that has the system identity as values.
+*/ -}}
+{{- define "newrelic-super-agent.auth.secret.shouldTemplate" -}}
+{{- if and ((.Values.config).auth).enabled (((.Values.config).auth).secret).create -}}
+  {{- $privateKey := include "newrelic-super-agent.auth.secret.privateKey.data" . -}}
+  {{- $clientId := include "newrelic-super-agent.auth.secret.clientId.data" . -}}
+
+  {{- if and $privateKey $clientId -}}
+    true
+  {{- else if or $privateKey $clientId -}}
+    {{- fail "If you provide your own system identity data you have to provide both private key and client id" -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+
+
+{{- /*
+Check if .Values.config.auth.secret.private_key.secret_key exists and use it for the key in the secret contaning the private
+key needed for the system identity. Fallbacks to `private_key`.
+*/ -}}
+{{- define "newrelic-super-agent.auth.secret.privateKey.key" -}}
+{{- $key := (((((.Values.config).auth).secret).private_key).secret_key) -}}
+{{- if $key -}}
+  {{- $key -}}
+{{- else -}}
+  private_key
+{{- end -}}
+{{- end -}}
+
+
+
+{{- /*
+Check if .Values.config.auth.secret.private_key.(plain_pem or base64_pem) exists and use it for as the private certificate for
+auth. If no ceritifcate is provided, it defaults to `""` (empty string) so this helper can be used directly as a test.
+*/ -}}
+{{- define "newrelic-super-agent.auth.secret.privateKey.data" -}}
+{{- $plain_pem := (((((.Values.config).auth).secret).private_key).plain_pem) -}}
+{{- $base64_pem := (((((.Values.config).auth).secret).private_key).base64_pem) -}}
+{{- if and $plain_pem $base64_pem -}}
+  {{- fail "Only one of base64_pem or plain_pem should be provided it you want to provide your own certificate." -}}
+{{- else if $base64_pem -}}
+  {{- $base64_pem }}
+{{- else if $plain_pem -}}
+  {{- $plain_pem | b64enc -}}
+{{- else -}}
+  {{- /* Empty string */ -}}
+{{- end -}}
+{{- end -}}
+
+
+
+{{- /*
+Check if .Values.config.auth.secret.client_id.secret_key exists and use it for the key in the secret containing the client id
+needed for the system identity. Fallbacks to `client_id`.
+*/ -}}
+{{- define "newrelic-super-agent.auth.secret.clientId.key" -}}
+{{- $key := (((((.Values.config).auth).secret).client_id).secret_key) -}}
+{{- if $key -}}
+  {{- $key -}}
+{{- else -}}
+  CLIENT_ID
+{{- end -}}
+{{- end -}}
+
+
+
+{{- /*
+Check if .Values.config.auth.secret.client_id.(plain or base64) exists and use it for as the client id for auth. If no
+value is provided, it defaults to `""` (empty string) so this helper can be used directly as a test.
+*/ -}}
+{{- define "newrelic-super-agent.auth.secret.clientId.data" -}}
+{{- $plain := (((((.Values.config).auth).secret).client_id).plain) -}}
+{{- $base64 := (((((.Values.config).auth).secret).client_id).base64) -}}
+{{- if and $plain $base64 -}}
+  {{- fail "Only one of base64 or plain should be provided it you want to provide your own client id." -}}
+{{- else if $base64 -}}
+  {{- $base64 }}
+{{- else if $plain -}}
+  {{- $plain | b64enc -}}
+{{- else -}}
+  {{- /* Empty string */ -}}
+{{- end -}}
 {{- end -}}

--- a/charts/super-agent/charts/super-agent-deployment/templates/_temporary_helpers.tpl
+++ b/charts/super-agent/charts/super-agent-deployment/templates/_temporary_helpers.tpl
@@ -1,0 +1,14 @@
+{{- /*
+    Auxiliary template until the PR that add these helpers to the common library are merged.
+*/ -}}
+{{- define "newrelic.common.apiKey.secretName" -}}
+api-key-secret
+{{- end -}}
+
+{{- define "newrelic.common.apiKey.secretKeyName" -}}
+a-secret-key
+{{- end -}}
+
+{{- define "newrelic.common.region" -}}
+US
+{{- end -}}

--- a/charts/super-agent/charts/super-agent-deployment/templates/configmap-subagent-configs.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/templates/configmap-subagent-configs.yaml
@@ -1,4 +1,4 @@
-{{- range $subAgentName, $subAgentConfig := .Values.config.subAgents -}}
+{{- range $subAgentName, $subAgentConfig := (include "newrelic-super-agent.config.agents.yaml" . | fromYaml) -}}
 {{- $name := include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" "local-data" "suffix" $subAgentName) }}
 ---
 kind: ConfigMap
@@ -10,6 +10,10 @@ metadata:
     subagent: {{ $subAgentName }}
 apiVersion: v1
 data:
+{{- if not $subAgentConfig.content }}
+  local_config: ""
+{{- else }}
   local_config: |
     {{- $subAgentConfig.content | toYaml | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/super-agent/charts/super-agent-deployment/templates/deployment-superagent.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/templates/deployment-superagent.yaml
@@ -12,6 +12,15 @@ spec:
   template:
     metadata:
       annotations:
+        {{/* TODO: This hash is not reliable anymore. The identity is being generated/patched by a job.
+          With the introduction of this job, this charts is not configurable/instalable with ArgoCD/Flux as the reconcile loop
+          will empty the secret that the job has filled.
+
+          We need the config to be splitable somehow or leave another orphan object on the cluster.
+
+          This comment (and the mechanisim added in the PR when we left this comment) block the automatic upgrade feature.
+
+          See: charts/super-agent/charts/super-agent-deployment/templates/preinstall-job-register-system-identity.yaml */ -}}
         checksum/agent-config: {{ include (print $.Template.BasePath "/configmap-superagent-config.yaml") . | sha256sum }}
         checksum/subagent-config: {{ include (print $.Template.BasePath "/configmap-subagent-configs.yaml") . | sha256sum }}
         {{- with .Values.podAnnotations }}
@@ -55,14 +64,12 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
 
           env:
-          {{- if .Values.config.auth }}
-          {{- if .Values.config.auth.enabled }}
+          {{- if ((.Values.config).auth).enabled }}
             - name: NR_SA_OPAMP__AUTH_CONFIG__CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ include "newrelic-super-agent.auth.secret.name" . }}
-                  key: CLIENT_ID
-          {{- end }}
+                  key: {{ include "newrelic-super-agent.auth.secret.clientId.key" . }}
           {{- end }}
             - name: NR_LICENSE_KEY
               valueFrom:
@@ -71,7 +78,7 @@ spec:
                   key: {{ include "newrelic.common.license.secretKeyName" . }}
             - name: NR_CLUSTER_NAME
               value: {{ include "newrelic.common.cluster" . }}
-          {{- if .Values.config.superAgent.content.opamp }}
+          {{- if (((.Values.config).superAgent).content).opamp }}
             - name: NR_SA_OPAMP__HEADERS__API-KEY
               valueFrom:
                 secretKeyRef:
@@ -91,15 +98,15 @@ spec:
             - name: super-agent-config
               mountPath: /etc/newrelic-super-agent
               readOnly: true
-            # TODO: when releasing we should check if this is still needed and if we need to persist the data.
+            # TODO: when releasing we should check if this is still needed and/or if we need to persist the data.
             - mountPath: /var/lib/newrelic-super-agent
               name: var-lib-newrelic-super-agent
               readOnly: false
-            {{- if .Values.config.auth }}
-            {{- if .Values.config.auth.enabled }}
+            {{- if ((.Values.config).auth).enabled }}
             - name: auth-secret-private-key
-              mountPath: "/etc/newrelic-super-agent/keys"
-            {{- end }}
+              mountPath: "/etc/newrelic-super-agent/keys/from-secret.key"
+              subPath: {{ include "newrelic-super-agent.auth.secret.privateKey.key" . }}
+              readOnly: true
             {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -116,16 +123,11 @@ spec:
                 path: config.yaml
         - name: var-lib-newrelic-super-agent
           emptyDir: {}
-        {{- if .Values.config.auth }}
-        {{- if .Values.config.auth.enabled }}
+        {{- if ((.Values.config).auth).enabled }}
         - name: auth-secret-private-key
           secret:
             secretName: {{ include "newrelic-super-agent.auth.secret.name" . }}
-            items:
-              - key: private_key
-                path: from-secret.key
         {{- end }}
-        {{- end }}          
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/super-agent/charts/super-agent-deployment/templates/preinstall-job-register-system-identity.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/templates/preinstall-job-register-system-identity.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.config.auth -}}
-{{- if and .Values.config.auth.enabled .Values.config.auth.secret.create -}}
+{{- if include "newrelic-super-agent.auth.secret.shouldRunJob" . -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -13,10 +12,16 @@ spec:
   template:
     spec:
       restartPolicy: Never
-      serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}-auth
+      serviceAccountName: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.serviceAccount.name" .) "suffix" "auth" ) }}
       containers:
         - name: register-system-identity
           image: alpine 
+          env:
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "newrelic.common.apiKey.secretName" . }}
+                  key: {{ include "newrelic.common.apiKey.secretKeyName" . }}
           command:
             - ash
           args:
@@ -46,7 +51,7 @@ spec:
                   curl \
                     -s -w "%{http_code}" \
                     -H "Content-Type: application/json" \
-                    -H "API-Key: {{ .Values.config.auth.userApiKey }}" \
+                    -H "API-Key: $API_KEY" \
                     -o "$TEMPORAL_FOLDER/response.json" \
                     --data @- \
                     "{{ include "newrelic-super-agent.config.endpoints.systemIdentityRegistration" . }}"
@@ -111,9 +116,9 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "newrelic.common.serviceAccount.name" . }}-auth
   namespace: {{ .Release.Namespace }}
-{{- end -}}
+{{- end }}
 
-{{ if include "newrelic.common.serviceAccount.create" . }}
+{{- if include "newrelic.common.serviceAccount.create" . }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -128,6 +133,5 @@ metadata:
     {{- include "newrelic.common.labels" . | nindent 4 }}
   name: {{ include "newrelic.common.serviceAccount.name" . }}-auth
   namespace: {{ .Release.Namespace }}
-{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/super-agent/charts/super-agent-deployment/templates/rbac.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/templates/rbac.yaml
@@ -11,7 +11,7 @@ rules:
   - apiGroups:
       - source.toolkit.fluxcd.io
       - helm.toolkit.fluxcd.io
-    resources: ["*"]
+    resources: [ "*" ]
     verbs:
       - get
       - list
@@ -31,7 +31,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups: [ "" ]
-    resources: ["configmaps"]
+    resources: [ "configmaps" ]
     verbs:
       - get
       - list
@@ -41,7 +41,7 @@ rules:
       - patch
       - update
   - apiGroups: [ "" ]
-    resources: ["namespaces"]
+    resources: [ "namespaces" ]
     verbs:
       - get
   - apiGroups: [ "apps" ]

--- a/charts/super-agent/charts/super-agent-deployment/templates/secret-sa-auth.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/templates/secret-sa-auth.yaml
@@ -1,0 +1,13 @@
+{{- if include "newrelic-super-agent.auth.secret.shouldTemplate" . -}}
+---
+kind: Secret
+metadata:
+  name: {{ include "newrelic-super-agent.auth.secret.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "newrelic.common.labels" . | nindent 4 }}
+apiVersion: v1
+data:
+  {{ include "newrelic-super-agent.auth.secret.privateKey.key" . }}: {{ include "newrelic-super-agent.auth.secret.privateKey.data" . }}
+  {{ include "newrelic-super-agent.auth.secret.clientId.key" . }}: {{ include "newrelic-super-agent.auth.secret.clientId.data" . }}
+{{- end }}

--- a/charts/super-agent/charts/super-agent-deployment/templates/serviceaccount.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if include "newrelic.common.serviceAccount.create" . -}}
+{{- if and (include "newrelic.common.serviceAccount.create" .) .Values.rbac.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/super-agent/charts/super-agent-deployment/templates/uninstall-job.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/templates/uninstall-job.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}
       containers:
         - name: delete-managed-resources
-          image: bitnami/kubectl
+          image: bitnami/kubectl  # TODO: Pin version to the latest that we support.
           command:
             - bash
           args:
@@ -42,8 +42,17 @@ spec:
               # Delete the CRs managed by the super-agent if the corresponding CRDs exist
               {{ range $i, $cr := $saCRList }}
               if kubectl api-resources -o name |grep {{ $cr }}; then
-                kubectl delete {{ $cr }} -n {{ $.Release.Namespace }} -l {{ $saResourcesLabelSelector }}
+                kubectl -n {{ $.Release.Namespace }} delete {{ $cr }} -l {{ $saResourcesLabelSelector }}
               fi
-              {{ end -}}
-
+              {{ end }}
+        {{- if include "newrelic-super-agent.auth.secret.shouldRunJob" . }}
+        - name: delete-system-identity
+          image: bitnami/kubectl  # TODO: Pin version to the latest that we support.
+          command:
+            - bash
+          args:
+            - -c
+            - |
+              kubectl -n {{ $.Release.Namespace }} delete secret {{ include "newrelic-super-agent.auth.secret.name" . }}
+        {{- end }}
 {{- end -}}

--- a/charts/super-agent/charts/super-agent-deployment/tests/auth_secret_test.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/tests/auth_secret_test.yaml
@@ -1,0 +1,107 @@
+suite: test super agent deployment's auth configurations
+templates:
+  - templates/secret-sa-auth.yaml
+  - templates/configmap-superagent-config.yaml
+  - templates/configmap-subagent-configs.yaml
+  - templates/deployment-superagent.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+
+tests:
+  - it: authSecret is created and mounted correctly by default
+    set:
+      cluster: test
+      config:
+        auth:
+          secret:
+            private_key:
+              base64_pem: dGVzdC1rZXk=
+            client_id:
+              base64: dGVzdC1rZXk=
+    asserts:
+      - template: templates/deployment-superagent.yaml
+        equal:
+          path: spec.template.spec.containers[0].volumeMounts
+          value:
+            - name: super-agent-config
+              mountPath: /etc/newrelic-super-agent
+              readOnly: true
+            - mountPath: /var/lib/newrelic-super-agent
+              name: var-lib-newrelic-super-agent
+              readOnly: false
+            - mountPath: /etc/newrelic-super-agent/keys/from-secret.key
+              name: auth-secret-private-key
+              readOnly: true
+              subPath: private_key
+      - template: templates/deployment-superagent.yaml
+        equal:
+          path: spec.template.spec.volumes
+          value:
+            - name: super-agent-config
+              configMap:
+                name: local-data-super-agent
+                items:
+                  - key: local_config
+                    path: config.yaml
+            - name: var-lib-newrelic-super-agent
+              emptyDir: {}
+            - name: auth-secret-private-key
+              secret:
+                secretName: my-release-super-agent-deployment-auth
+      - template: templates/secret-sa-auth.yaml
+        equal:
+          path: metadata.name
+          value: my-release-super-agent-deployment-auth
+      - template: templates/secret-sa-auth.yaml
+        equal:
+          path: data.private_key
+          value: dGVzdC1rZXk=
+      - template: templates/secret-sa-auth.yaml
+        equal:
+          path: data.CLIENT_ID
+          value: dGVzdC1rZXk=
+
+  - it: no mount and secret is created when auth is disabled
+    set:
+      cluster: test
+      config:
+        auth:
+          enable: false
+    asserts:
+      - template: templates/deployment-superagent.yaml
+        notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          value:
+            name: auth-secret-private-key
+      - template: templates/deployment-superagent.yaml
+        notContains:
+          path: spec.template.spec.volumes
+          value:
+            name: auth-secret-private-key
+
+  - it: secre creation fails when you only provide private_key
+    set:
+      cluster: test
+      config:
+        auth:
+          secret:
+            private_key:
+              base64_pem: dGVzdC1rZXk=
+    asserts:
+      - template: templates/secret-sa-auth.yaml
+        failedTemplate:
+          errorMessage: If you provide your own system identity data you have to provide both private key and client id
+
+  - it: secre creation fails when you only provide CLIENT_ID
+    set:
+      cluster: test
+      config:
+        auth:
+          secret:
+            client_id:
+              base64: dGVzdC1rZXk=
+    asserts:
+      - template: templates/secret-sa-auth.yaml
+        failedTemplate:
+          errorMessage: If you provide your own system identity data you have to provide both private key and client id

--- a/charts/super-agent/charts/super-agent-deployment/tests/auth_secret_test.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/tests/auth_secret_test.yaml
@@ -72,12 +72,12 @@ tests:
       - template: templates/deployment-superagent.yaml
         notContains:
           path: spec.template.spec.containers[0].volumeMounts
-          value:
+          content:
             name: auth-secret-private-key
       - template: templates/deployment-superagent.yaml
         notContains:
           path: spec.template.spec.volumes
-          value:
+          content:
             name: auth-secret-private-key
 
   - it: secre creation fails when you only provide private_key

--- a/charts/super-agent/charts/super-agent-deployment/tests/configmap_fleet_configs_test.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/tests/configmap_fleet_configs_test.yaml
@@ -12,21 +12,25 @@ tests:
           open-telemetry: null
     asserts:
       - hasDocuments:
-          count: 0
+          count: 1
+
   - it: super agent's config template correctly
     set:
       config:
         subAgents:
           open-telemetry: null
           test-0:
+            type: org.newrelic/test:0.0.0
             content:
               a: test
               value: 0
           test-1:
+            type: org.newrelic/test:0.0.1
             content:
               a: test
               value: 1
           test-2:
+            type: org.newrelic/test:0.0.2
             content:
               a: test
               aYAML:

--- a/charts/super-agent/charts/super-agent-deployment/tests/configmap_fleet_configs_test.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/tests/configmap_fleet_configs_test.yaml
@@ -5,20 +5,19 @@ release:
   name: my-release
   namespace: my-namespace
 tests:
-  - it: default value can be overridden
+  - it: A malformed subAgent fail with a useful error message
     set:
       config:
         subAgents:
           open-telemetry: null
     asserts:
-      - hasDocuments:
-          count: 1
+      - failedTemplate:
+          errorMessage: Agent open-telemetry does not have agent type
 
-  - it: super agent's config template correctly
+  - it: default value can be overridden
     set:
       config:
         subAgents:
-          open-telemetry: null
           test-0:
             type: org.newrelic/test:0.0.0
             content:

--- a/charts/super-agent/charts/super-agent-deployment/tests/configmap_superagent_config_test.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/tests/configmap_superagent_config_test.yaml
@@ -24,10 +24,19 @@ tests:
           value: |
             agents:
               open-telemetry:
-                agent_type: newrelic/io.opentelemetry.collector:0.2.0
+                content:
+                  chart_values:
+                    cluster: my-cluster
+                type: newrelic/io.opentelemetry.collector:0.2.0
             k8s:
               cluster_name: my-cluster
               namespace: my-namespace
+            opamp:
+              auth_config:
+                private_key_path: /etc/newrelic-super-agent/keys/from-secret.key
+                provider: local
+                token_url: https://system-identity-oauth.vip.cf.nr-ops.net/oauth2/token
+              endpoint: https://opamp.service.newrelic.com/v1/opamp
             server:
               enabled: true
   - it: super agent's config templates
@@ -44,10 +53,19 @@ tests:
           value: |
             agents:
               open-telemetry:
-                agent_type: newrelic/io.opentelemetry.collector:0.2.0
+                content:
+                  chart_values:
+                    cluster: my-cluster
+                type: newrelic/io.opentelemetry.collector:0.2.0
             k8s:
               cluster_name: my-cluster
               namespace: my-namespace
+            opamp:
+              auth_config:
+                private_key_path: /etc/newrelic-super-agent/keys/from-secret.key
+                provider: local
+                token_url: https://system-identity-oauth.vip.cf.nr-ops.net/oauth2/token
+              endpoint: https://opamp.service.newrelic.com/v1/opamp
             server:
               enabled: true
             test: value
@@ -69,10 +87,19 @@ tests:
           value: |
             agents:
               open-telemetry:
-                agent_type: newrelic/io.opentelemetry.collector:0.2.0
+                content:
+                  chart_values:
+                    cluster: my-cluster
+                type: newrelic/io.opentelemetry.collector:0.2.0
             k8s:
               cluster_name: config-cluster
               namespace: config-namespace
+            opamp:
+              auth_config:
+                private_key_path: /etc/newrelic-super-agent/keys/from-secret.key
+                provider: local
+                token_url: https://system-identity-oauth.vip.cf.nr-ops.net/oauth2/token
+              endpoint: https://opamp.service.newrelic.com/v1/opamp
             server:
               enabled: true
             test: value

--- a/charts/super-agent/charts/super-agent-deployment/tests/configmap_superagent_config_test.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/tests/configmap_superagent_config_test.yaml
@@ -13,32 +13,6 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-  - it: super agent's config always include cluster_name, namespace and defaults
-    set:
-      cluster: my-cluster
-      config:
-        superAgent: {}
-    asserts:
-      - equal:
-          path: data["local_config"]
-          value: |
-            agents:
-              open-telemetry:
-                content:
-                  chart_values:
-                    cluster: my-cluster
-                type: newrelic/io.opentelemetry.collector:0.2.0
-            k8s:
-              cluster_name: my-cluster
-              namespace: my-namespace
-            opamp:
-              auth_config:
-                private_key_path: /etc/newrelic-super-agent/keys/from-secret.key
-                provider: local
-                token_url: https://system-identity-oauth.vip.cf.nr-ops.net/oauth2/token
-              endpoint: https://opamp.service.newrelic.com/v1/opamp
-            server:
-              enabled: true
   - it: super agent's config templates
     set:
       cluster: my-cluster
@@ -55,7 +29,8 @@ tests:
               open-telemetry:
                 content:
                   chart_values:
-                    cluster: my-cluster
+                    cluster: ${nr-env:NR_CLUSTER_NAME}
+                    licenseKey: ${nr-env:NR_LICENSE_KEY}
                 type: newrelic/io.opentelemetry.collector:0.2.0
             k8s:
               cluster_name: my-cluster
@@ -64,7 +39,7 @@ tests:
               auth_config:
                 private_key_path: /etc/newrelic-super-agent/keys/from-secret.key
                 provider: local
-                token_url: https://system-identity-oauth.vip.cf.nr-ops.net/oauth2/token
+                token_url: https://system-identity-oauth.service.newrelic.com/oauth2/token
               endpoint: https://opamp.service.newrelic.com/v1/opamp
             server:
               enabled: true
@@ -89,7 +64,8 @@ tests:
               open-telemetry:
                 content:
                   chart_values:
-                    cluster: my-cluster
+                    cluster: ${nr-env:NR_CLUSTER_NAME}
+                    licenseKey: ${nr-env:NR_LICENSE_KEY}
                 type: newrelic/io.opentelemetry.collector:0.2.0
             k8s:
               cluster_name: config-cluster
@@ -98,38 +74,38 @@ tests:
               auth_config:
                 private_key_path: /etc/newrelic-super-agent/keys/from-secret.key
                 provider: local
-                token_url: https://system-identity-oauth.vip.cf.nr-ops.net/oauth2/token
+                token_url: https://system-identity-oauth.service.newrelic.com/oauth2/token
               endpoint: https://opamp.service.newrelic.com/v1/opamp
             server:
               enabled: true
             test: value
             test2: value2
-  - it: super agent's config always include cluster_name, namespace and defaults
-    set:
-      cluster: my-cluster
-      config:
-        superAgent:       
-          content:
-            opamp: 
-              endpoint: https://opamp.service.eu.newrelic.com/v1/opamp
-        auth:
-          enabled: true
-      euEndpoints: true
-    asserts:
-      - equal:
-          path: data["local_config"]
-          value: |
-            agents:
-              open-telemetry:
-                agent_type: newrelic/io.opentelemetry.collector:0.2.0
-            k8s:
-              cluster_name: my-cluster
-              namespace: my-namespace
-            opamp:
-              auth_config:
-                private_key_path: /etc/newrelic-super-agent/keys/from-secret.key
-                provider: local
-                token_url: https://system-identity-oauth.service.eu.newrelic.com/oauth2/token
-              endpoint: https://opamp.service.eu.newrelic.com/v1/opamp
-            server:
-              enabled: true
+#  - it: super agent's config always include cluster_name, namespace, defaults and honor the EU endpoint.
+#    set:
+#      cluster: my-cluster
+#      config:
+#        superAgent:       
+#          content:
+#            opamp: 
+#              endpoint: https://opamp.service.eu.newrelic.com/v1/opamp
+#        auth:
+#          enabled: true
+#      euEndpoints: true
+#    asserts:
+#      - equal:
+#          path: data["local_config"]
+#          value: |
+#            agents:
+#              open-telemetry:
+#                agent_type: newrelic/io.opentelemetry.collector:0.2.0
+#            k8s:
+#              cluster_name: my-cluster
+#              namespace: my-namespace
+#            opamp:
+#              auth_config:
+#                private_key_path: /etc/newrelic-super-agent/keys/from-secret.key
+#                provider: local
+#                token_url: https://system-identity-oauth.service.eu.newrelic.com/oauth2/token
+#              endpoint: https://opamp.service.eu.newrelic.com/v1/opamp
+#            server:
+#              enabled: true

--- a/charts/super-agent/charts/super-agent-deployment/tests/deployment_superagent_env_test.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/tests/deployment_superagent_env_test.yaml
@@ -12,9 +12,9 @@ tests:
       cluster: test
       licenseKey: fake-license
     asserts:
-      - equal:
-          path: spec.template.spec.containers[0].env[0]
-          value:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: NR_LICENSE_KEY
             valueFrom:
               secretKeyRef:
@@ -28,9 +28,9 @@ tests:
       customSecretName: "custom-secret"
       customSecretLicenseKey: "custom-key"
     asserts:
-      - equal:
-          path: spec.template.spec.containers[0].env[0]
-          value:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: NR_LICENSE_KEY
             valueFrom:
               secretKeyRef:
@@ -48,9 +48,9 @@ tests:
             opamp:
               endpoint: test
     asserts:
-      - equal:
-          path: spec.template.spec.containers[0].env[2]
-          value:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: NR_SA_OPAMP__HEADERS__API-KEY
             valueFrom:
               secretKeyRef:
@@ -69,9 +69,9 @@ tests:
             opamp:
               endpoint: test
     asserts:
-      - equal:
-          path: spec.template.spec.containers[0].env[2]
-          value:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: NR_SA_OPAMP__HEADERS__API-KEY
             valueFrom:
               secretKeyRef:
@@ -82,9 +82,9 @@ tests:
     set:
       cluster: test
     asserts:
-      - equal:
-          path: spec.template.spec.containers[0].env[1]
-          value:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: NR_CLUSTER_NAME
             value: test
         template: templates/deployment-superagent.yaml

--- a/charts/super-agent/charts/super-agent-deployment/tests/deployment_superagent_subagent_configs_test.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/tests/deployment_superagent_subagent_configs_test.yaml
@@ -14,14 +14,17 @@ tests:
       config:
         subAgents:
           test-0:
+            type: org.newrelic/test:0.0.0
             content:
               a: test
               value: 0
           test-1:
+            type: org.newrelic/test:0.0.1
             content:
               a: test
               value: 1
           test-2:
+            type: org.newrelic/test:0.0.2
             content:
               a: test
               aYAML:
@@ -37,6 +40,10 @@ tests:
             - mountPath: /var/lib/newrelic-super-agent
               name: var-lib-newrelic-super-agent
               readOnly: false
+            - mountPath: /etc/newrelic-super-agent/keys/from-secret.key
+              name: auth-secret-private-key
+              readOnly: true
+              subPath: private_key
       - template: templates/deployment-superagent.yaml
         equal:
           path: spec.template.spec.volumes
@@ -49,6 +56,6 @@ tests:
                     path: config.yaml
             - name: var-lib-newrelic-super-agent
               emptyDir: {}
-
-        
-
+            - name: auth-secret-private-key
+              secret:
+                secretName: my-release-super-agent-deployment-auth

--- a/charts/super-agent/ci/test-values.yaml
+++ b/charts/super-agent/ci/test-values.yaml
@@ -1,3 +1,6 @@
 super-agent-deployment:
   cluster: sa-cluster
   licenseKey: test
+  config:
+    auth:
+      organizationId: test

--- a/charts/super-agent/values.yaml
+++ b/charts/super-agent/values.yaml
@@ -158,13 +158,13 @@ super-agent-deployment:
         # @default -- release name suffixed with "-auth"
         name:
         private_key:
-          # -- Key inside the secret contaning the private key.
+          # -- Key inside the secret containing the private key.
           # @default -- `private_key`
           secret_key:
           base64_pem:
           plain_pem:
         client_id:
-          # -- Key inside the secret contaning the private key.
+          # -- Key inside the secret containing the private key.
           # @default -- `client_id`
           secret_key:
           base64:

--- a/charts/super-agent/values.yaml
+++ b/charts/super-agent/values.yaml
@@ -10,13 +10,13 @@ super-agent-deployment:
   # you know what you are going.
   enabled: true
 
-  # -- TODO: Name of the Kubernetes cluster monitored. Can be configured also with `global.cluster`.
+  # -- Name of the Kubernetes cluster monitored. Can be configured also with `global.cluster`.
   cluster: ""
-  # -- TODO: This set this license key to use. Can be configured also with `global.licenseKey`
+  # -- This set this license key to use. Can be configured also with `global.licenseKey`
   licenseKey: ""
-  # -- TODO: In case you don't want to have the license key in you values, this allows you to point to a user created secret to get the key from there. Can be configured also with `global.customSecretName`
+  # -- In case you don't want to have the license key in you values, this allows you to point to a user created secret to get the key from there. Can be configured also with `global.customSecretName`
   customSecretName: ""
-  # -- TODO: In case you don't want to have the license key in you values, this allows you to point to which secret key is the license key located. Can be configured also with `global.customSecretLicenseKey`
+  # -- In case you don't want to have the license key in you values, this allows you to point to which secret key is the license key located. Can be configured also with `global.customSecretLicenseKey`
   customSecretLicenseKey: ""
 
   # -- Image for the New Relic Super Agent
@@ -94,10 +94,6 @@ super-agent-deployment:
   # @default -- `false`
   nrStaging:
 
-  # -- (bool) Changes default endpoint to point to EU backend.
-  # @default -- `false`
-  euEndpoints:
-
   fedramp:
     # -- (bool) TODO: Enables FedRAMP. Can be configured also with `global.fedramp.enabled`
     # @default -- `false`
@@ -112,13 +108,6 @@ super-agent-deployment:
   cleanupManagedResources: true
 
   config:
-    auth:
-      enabled: false
-      organizationId:
-      userApiKey:
-      secret:
-        create: true
-
     # -- Configuration for the Super Agent.
     # @default -- See `values.yaml`
     superAgent:
@@ -127,10 +116,6 @@ super-agent-deployment:
       # -- Here you can set New Relic' Super Agent configuration.
       # @default -- See `values.yaml` for examples
       content:
-        agents:
-          open-telemetry:
-            agent_type: newrelic/io.opentelemetry.collector:0.2.0
-
         # opamp:
         #   # TODO The endpoint should be set automatically based on the licenseKey and on the nrStaging option if opamp.enable=true
         #   endpoint: https://opamp.service.newrelic.com/v1/opamp
@@ -147,18 +132,43 @@ super-agent-deployment:
     # -- Values that the fleet is going to have in the deployment.
     # @default -- See `values.yaml` for examples
     subAgents:
-      # The values of the fleet depends on the deployment itself. Each subagent has a different set of variables so you have to go to the subagent documentation
-      # find the configuration needed for the subagent.
-      #
-      open-telemetry:
-        content:
-          # chart_version: "0.4.0"
-          chart_values:
-            licenseKey: ${nr-env:NR_LICENSE_KEY}
-            cluster: ${nr-env:NR_CLUSTER_NAME}
-            # TODO the following values are set twice in the config, we have to add some logic to improve UX either in the chart or in the agentType
-            # customSecretName: ""
-            # customSecretLicenseKey: ""
+    # The values of the fleet depends on the deployment itself. Each subagent has a different set of variables so you have to go to the subagent documentation
+    # find the configuration needed for the subagent.
+    #
+    # The example below, open-telemetry, is enabled by default if no subagent is set up.
+    #
+    #  open-telemetry:
+    #    type: newrelic/io.opentelemetry.collector:0.2.0
+    #    content:
+    #      chart_version: "0.4.0"
+    #      chart_values:
+    #        # TODO the following values are set twice in the config, we have to add some logic to improve UX either in the chart or in the agentType
+    #        cluster: ""
+    #        licenseKey: ""
+    #        customSecretName: ""
+    #        customSecretLicenseKey: ""
+
+    auth:
+      enabled: true
+      organization_id:
+      secret:
+        create: true
+        # -- Name auth' secret provided by the user. If the creation of this secret is set to `true`, this is the same the secret
+        # will have.
+        # @default -- release name suffixed with "-auth"
+        name:
+        private_key:
+          # -- Key inside the secret contaning the private key.
+          # @default -- `private_key`
+          secret_key:
+          base64_pem:
+          plain_pem:
+        client_id:
+          # -- Key inside the secret contaning the private key.
+          # @default -- `client_id`
+          secret_key:
+          base64:
+          plain:
 
 
 # -- Values for the Flux chat. Ref.: https://github.com/fluxcd-community/helm-charts/blob/flux2-2.10.2/charts/flux2/values.yaml


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
This adds to the chart the ability to create system identities and register them su the super agent can auth to the testing backend.

#### Checklist
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
