### PR TITLE
[super-agent] Leverage env var for cluster name

### DIFF
--- a/charts/super-agent/Chart.lock
+++ b/charts/super-agent/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 2.13.0
 - name: super-agent-deployment
   repository: ""
-  version: 0.0.21-beta
+  version: 0.0.22-beta
 - name: common-library
   repository: https://helm-charts.newrelic.com
   version: 1.2.0
-digest: sha256:e6adc107915921837bc843af4426a96f0c6d27a9e5c202204b9a56148b31991e
-generated: "2024-07-25T18:12:09.459639+02:00"
+digest: sha256:b2770b12c9ff3f93eebbc745645f4026cf9b899b1fabc614b298a61dc4b4c9ed
+generated: "2024-08-01T10:11:46.199593+02:00"

--- a/charts/super-agent/Chart.yaml
+++ b/charts/super-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: super-agent
 description: Bootstraps New Relic' Super Agent
 
 type: application
-version: 0.0.16-beta
+version: 0.0.17-beta
 
 dependencies:
   - name: flux2
@@ -11,7 +11,7 @@ dependencies:
     version: 2.13.0
     condition: flux2.enabled
   - name: super-agent-deployment
-    version: 0.0.21-beta
+    version: 0.0.22-beta
     condition: super-agent-deployment.enabled
     # The following dependency is needed as sub-dependency of super-agent-deployment
   - name: common-library

--- a/charts/super-agent/charts/super-agent-deployment/Chart.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Super agent on Kubernetes
 
 type: application
 
-version: 0.0.21-beta
+version: 0.0.22-beta
 
 keywords:
   - newrelic

--- a/charts/super-agent/charts/super-agent-deployment/templates/deployment-superagent.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/templates/deployment-superagent.yaml
@@ -69,6 +69,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "newrelic.common.license.secretName" . }}
                   key: {{ include "newrelic.common.license.secretKeyName" . }}
+            - name: NR_CLUSTER_NAME
+              value: {{ include "newrelic.common.cluster" . }}
           {{- if .Values.config.superAgent.content.opamp }}
             - name: NR_SA_OPAMP__HEADERS__API-KEY
               valueFrom:

--- a/charts/super-agent/charts/super-agent-deployment/tests/deployment_superagent_env_test.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/tests/deployment_superagent_env_test.yaml
@@ -13,16 +13,13 @@ tests:
       licenseKey: fake-license
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].env[0].name
-          value: NR_LICENSE_KEY
-        template: templates/deployment-superagent.yaml
-      - equal:
-          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
-          value: my-release-super-agent-deployment-license
-        template: templates/deployment-superagent.yaml
-      - equal:
-          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.key
-          value: licenseKey
+          path: spec.template.spec.containers[0].env[0]
+          value:
+            name: NR_LICENSE_KEY
+            valueFrom:
+              secretKeyRef:
+                key: licenseKey
+                name: my-release-super-agent-deployment-license
         template: templates/deployment-superagent.yaml
         
   - it: license key gets added as env var from custom secret
@@ -32,16 +29,13 @@ tests:
       customSecretLicenseKey: "custom-key"
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].env[0].name
-          value: NR_LICENSE_KEY
-        template: templates/deployment-superagent.yaml
-      - equal:
-          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
-          value: custom-secret
-        template: templates/deployment-superagent.yaml
-      - equal:
-          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.key
-          value: custom-key
+          path: spec.template.spec.containers[0].env[0]
+          value:
+            name: NR_LICENSE_KEY
+            valueFrom:
+              secretKeyRef:
+                key: custom-key
+                name: custom-secret
         template: templates/deployment-superagent.yaml
  
   - it: api-key config gets added as env var from secret
@@ -55,16 +49,13 @@ tests:
               endpoint: test
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].env[1].name
-          value: NR_SA_OPAMP__HEADERS__API-KEY
-        template: templates/deployment-superagent.yaml
-      - equal:
-          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.name
-          value: my-release-super-agent-deployment-license
-        template: templates/deployment-superagent.yaml
-      - equal:
-          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.key
-          value: licenseKey
+          path: spec.template.spec.containers[0].env[2]
+          value:
+            name: NR_SA_OPAMP__HEADERS__API-KEY
+            valueFrom:
+              secretKeyRef:
+                key: licenseKey
+                name: my-release-super-agent-deployment-license
         template: templates/deployment-superagent.yaml
 
   - it: api-key config gets added as env var from custom secret
@@ -79,15 +70,21 @@ tests:
               endpoint: test
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].env[1].name
-          value: NR_SA_OPAMP__HEADERS__API-KEY
+          path: spec.template.spec.containers[0].env[2]
+          value:
+            name: NR_SA_OPAMP__HEADERS__API-KEY
+            valueFrom:
+              secretKeyRef:
+                key: custom-key
+                name: custom-secret
         template: templates/deployment-superagent.yaml
+  - it: cluster name added as env var
+    set:
+      cluster: test
+    asserts:
       - equal:
-          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.name
-          value: custom-secret
+          path: spec.template.spec.containers[0].env[1]
+          value:
+            name: NR_CLUSTER_NAME
+            value: test
         template: templates/deployment-superagent.yaml
-      - equal:
-          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.key
-          value: custom-key
-        template: templates/deployment-superagent.yaml
-        

--- a/charts/super-agent/ci/test-values.yaml
+++ b/charts/super-agent/ci/test-values.yaml
@@ -1,9 +1,3 @@
 super-agent-deployment:
   cluster: sa-cluster
   licenseKey: test
-  config:
-    subAgents:
-      open-telemetry:
-        content:
-          chart_values:
-            cluster: "sa-cluster"

--- a/charts/super-agent/values.yaml
+++ b/charts/super-agent/values.yaml
@@ -155,8 +155,8 @@ super-agent-deployment:
           # chart_version: "0.4.0"
           chart_values:
             licenseKey: ${nr-env:NR_LICENSE_KEY}
+            cluster: ${nr-env:NR_CLUSTER_NAME}
             # TODO the following values are set twice in the config, we have to add some logic to improve UX either in the chart or in the agentType
-            # cluster: ""
             # customSecretName: ""
             # customSecretLicenseKey: ""
 


### PR DESCRIPTION
#### Is this a new chart
no

#### What this PR does / why we need it:
 - Leveraging env_var for cluster instead of fixed value
 - Improving test structure

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
