### PR TITLE
[synthetics-job-manager] update runtimes (node-api v1.2.86 and node browser v.2.3.69)

### DIFF
--- a/charts/synthetics-job-manager/Chart.yaml
+++ b/charts/synthetics-job-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: synthetics-job-manager
 description: New Relic Synthetics Containerized Job Manager
 type: application
-version: 2.0.12
+version: 2.0.13
 appVersion: release-386
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
@@ -27,8 +27,8 @@ dependencies:
     version: 1.0.20
     condition: ping-runtime.enabled
   - name: node-api-runtime
-    version: 1.0.35
+    version: 1.0.36
     condition: node-api-runtime.enabled
   - name: node-browser-runtime
-    version: 1.0.42
+    version: 1.0.43
     condition: node-browser-runtime.enabled

--- a/charts/synthetics-job-manager/charts/node-api-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/node-api-runtime/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: node-api-runtime
 description: New Relic Synthetics Api Runtime
 type: application
-version: 1.0.35
-appVersion: 1.2.84
+version: 1.0.36
+appVersion: 1.2.86
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith

--- a/charts/synthetics-job-manager/charts/node-browser-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/node-browser-runtime/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: node-browser-runtime
 description: New Relic Synthetics Browser Runtime
 type: application
-version: 1.0.42
-appVersion: 2.3.41
+version: 1.0.43
+appVersion: 2.3.69
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No.

#### What this PR does / why we need it:

Updates the synthetics node-api and node-browser runtime versions to the latest releases

#### Which issue this PR fixes
  - fixes CVEs related to the ubuntu version and node package dependencies in both runtimes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
