### PR TITLE
[newrelic-logging] Fix env var order

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.22.4
+version: 1.22.5
 appVersion: 2.0.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/templates/daemonset.yaml
+++ b/charts/newrelic-logging/templates/daemonset.yaml
@@ -88,6 +88,10 @@ spec:
                   {{- end }}
             - name: CLUSTER_NAME
               value: {{ include "newrelic-logging.cluster" . }}
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: LOG_LEVEL
               value: {{ .Values.fluentBit.logLevel | quote }}
             - name: LOG_PARSER
@@ -116,10 +120,6 @@ spec:
               value: {{ include "newrelic-logging.lowDataMode" . | default "false" | quote }}
             - name: RETRY_LIMIT
               value: {{ .Values.fluentBit.retryLimit | quote }}
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
             - name: HOSTNAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
The logging chart is broken as of version `newrelic-logging 1.21.0` , where [this change](https://github.com/newrelic/helm-charts/pull/1304/commits/851d32fb2ee48ef8e325446fe2f442dff8203b74#diff-dba7a505c5df68aac95df70ba65d1a43ac0349a7692e6a1ecd2899854ba90894R99-R119) was introduced.
The consequence from that change is that when `mode: persistentVolume` is being used, the `FB_DB` variable does not get properly resolved as the `NODE_NAME` variable is only defined further down the list.
From [k8s docs](https://kubernetes.io/docs/tasks/inject-data-application/define-interdependent-environment-variables/):
```
Note that order matters in the env list. An environment variable is not considered "defined" if it is specified further down the list. 
```

#### Which issue this PR fixes
  - fixes #1408

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
