### PR TITLE
[newrelic-logging] Bump newrelic-fluentbit-output image to 2.0.2

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.22.4
-appVersion: 2.0.0
+version: 1.23.0
+appVersion: 2.0.2
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:

--- a/charts/newrelic-logging/tests/images_test.yaml
+++ b/charts/newrelic-logging/tests/images_test.yaml
@@ -17,16 +17,16 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: newrelic/newrelic-fluentbit-output:2.0.0
+          value: newrelic/newrelic-fluentbit-output:2.0.2
         template: templates/daemonset.yaml
       - equal:
           path: spec.template.spec.containers[0].image
-          value: newrelic/newrelic-fluentbit-output:2.0.0-windows-ltsc-2019
+          value: newrelic/newrelic-fluentbit-output:2.0.2-windows-ltsc-2019
         template: templates/daemonset-windows.yaml
         documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].image
-          value: newrelic/newrelic-fluentbit-output:2.0.0-windows-ltsc-2022
+          value: newrelic/newrelic-fluentbit-output:2.0.2-windows-ltsc-2022
         template: templates/daemonset-windows.yaml
         documentIndex: 1
   - it: global registry is used if set


### PR DESCRIPTION
#### Is this a new chart
No.
#### What this PR does / why we need it:
This PR bumps the image for newrelic-logging integration, it uses the plugin version 2.0.2 that user fluent-bit 3.1.2 for docker images. Related PR: https://github.com/newrelic/newrelic-fluent-bit-output/pull/166 
#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #NR-310459
This fixes trivy ticket of the image [cf-registry.nr-ops.net/maas/docker-atlantis-fluent-bit](http://cf-registry.nr-ops.net/maas/docker-atlantis-fluent-bit). 
#### Special notes for your reviewer:
##### Testing done.
1. Unit test: helm unittest charts/newrelic-logging
2. Installation successful: `helm upgrade --install newrelic-bundle --set licenseKey=key /Users/mjha/work/helm-charts/charts/newrelic-logging -n newrelic`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ x] Title of the PR starts with chart name (e.g. `[mychartname]`)
