### PR TITLE
[nr-k8s-otel-collector] - exposing pod EVs to configuration in values file

### DIFF
--- a/charts/nr-k8s-otel-collector/Chart.yaml
+++ b/charts/nr-k8s-otel-collector/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.6
+version: 0.7.7
 
 dependencies:
   - name: common-library

--- a/charts/nr-k8s-otel-collector/README.md
+++ b/charts/nr-k8s-otel-collector/README.md
@@ -87,6 +87,8 @@ daemonset:
 | daemonset.configMap | object | See `values.yaml` | Settings for daemonset configmap |
 | daemonset.configMap.config | object | `{}` | OpenTelemetry config for the daemonset. If set, overrides default config and disables configuration parameters for the daemonset. |
 | daemonset.containerSecurityContext | object | `{"privileged":true}` | Sets security context (at container level) for the daemonset. Overrides `containerSecurityContext` and `global.containerSecurityContext` |
+| daemonset.envs | object | `{}` | Sets additional environment variables for the daemonset. |
+| daemonset.envsFrom | object | `{}` | Sets additional environment variable sources for the daemonset. |
 | daemonset.nodeSelector | object | `{}` | Sets daemonset pod node selector. Overrides `nodeSelector` and `global.nodeSelector` |
 | daemonset.podAnnotations | object | `{}` | Annotations to be added to the daemonset. |
 | daemonset.podSecurityContext | object | `{}` | Sets security context (at pod level) for the daemonset. Overrides `podSecurityContext` and `global.podSecurityContext` |
@@ -96,6 +98,8 @@ daemonset:
 | deployment.configMap | object | See `values.yaml` | Settings for deployment configmap |
 | deployment.configMap.config | object | `{}` | OpenTelemetry config for the deployment. If set, overrides default config and disables configuration parameters for the deployment. |
 | deployment.containerSecurityContext | object | `{}` | Sets security context (at container level) for the deployment. Overrides `containerSecurityContext` and `global.containerSecurityContext` |
+| deployment.envs | object | `{}` | Sets additional environment variables for the deployment. |
+| deployment.envsFrom | object | `{}` | Sets additional environment variable sources for the deployment. |
 | deployment.nodeSelector | object | `{}` | Sets deployment pod node selector. Overrides `nodeSelector` and `global.nodeSelector` |
 | deployment.podAnnotations | object | `{}` | Annotations to be added to the deployment. |
 | deployment.podSecurityContext | object | `{}` | Sets security context (at pod level) for the deployment. Overrides `podSecurityContext` and `global.podSecurityContext` |

--- a/charts/nr-k8s-otel-collector/README.md
+++ b/charts/nr-k8s-otel-collector/README.md
@@ -87,8 +87,8 @@ daemonset:
 | daemonset.configMap | object | See `values.yaml` | Settings for daemonset configmap |
 | daemonset.configMap.config | object | `{}` | OpenTelemetry config for the daemonset. If set, overrides default config and disables configuration parameters for the daemonset. |
 | daemonset.containerSecurityContext | object | `{"privileged":true}` | Sets security context (at container level) for the daemonset. Overrides `containerSecurityContext` and `global.containerSecurityContext` |
-| daemonset.envs | object | `{}` | Sets additional environment variables for the daemonset. |
-| daemonset.envsFrom | object | `{}` | Sets additional environment variable sources for the daemonset. |
+| daemonset.envs | list | `[]` | Sets additional environment variables for the daemonset. |
+| daemonset.envsFrom | list | `[]` | Sets additional environment variable sources for the daemonset. |
 | daemonset.nodeSelector | object | `{}` | Sets daemonset pod node selector. Overrides `nodeSelector` and `global.nodeSelector` |
 | daemonset.podAnnotations | object | `{}` | Annotations to be added to the daemonset. |
 | daemonset.podSecurityContext | object | `{}` | Sets security context (at pod level) for the daemonset. Overrides `podSecurityContext` and `global.podSecurityContext` |
@@ -98,8 +98,8 @@ daemonset:
 | deployment.configMap | object | See `values.yaml` | Settings for deployment configmap |
 | deployment.configMap.config | object | `{}` | OpenTelemetry config for the deployment. If set, overrides default config and disables configuration parameters for the deployment. |
 | deployment.containerSecurityContext | object | `{}` | Sets security context (at container level) for the deployment. Overrides `containerSecurityContext` and `global.containerSecurityContext` |
-| deployment.envs | object | `{}` | Sets additional environment variables for the deployment. |
-| deployment.envsFrom | object | `{}` | Sets additional environment variable sources for the deployment. |
+| deployment.envs | list | `[]` | Sets additional environment variables for the deployment. |
+| deployment.envsFrom | list | `[]` | Sets additional environment variable sources for the deployment. |
 | deployment.nodeSelector | object | `{}` | Sets deployment pod node selector. Overrides `nodeSelector` and `global.nodeSelector` |
 | deployment.podAnnotations | object | `{}` | Annotations to be added to the deployment. |
 | deployment.podSecurityContext | object | `{}` | Sets security context (at pod level) for the deployment. Overrides `podSecurityContext` and `global.podSecurityContext` |
@@ -167,6 +167,5 @@ Error scraping metrics	{"kind": "receiver", "name": "hostmetrics", "data_type": 
 
 ## Maintainers
 
-* [juanjjaramillo](https://github.com/juanjjaramillo)
 * [csongnr](https://github.com/csongnr)
 * [dbudziwojskiNR](https://github.com/dbudziwojskiNR)

--- a/charts/nr-k8s-otel-collector/templates/daemonset.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset.yaml
@@ -46,7 +46,7 @@ spec:
             {{- toYaml .Values.daemonset.resources | nindent 12 }}
           {{- with .Values.daemonset.envsFrom }}
           envFrom:
-          {{- . | toYaml | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
           env:
             - name: HOST_IP

--- a/charts/nr-k8s-otel-collector/templates/daemonset.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset.yaml
@@ -44,6 +44,10 @@ spec:
           args: ["--config", "/config/daemonset-config.yaml"]
           resources:
             {{- toYaml .Values.daemonset.resources | nindent 12 }}
+          {{- with .Values.daemonset.envsFrom }}
+          envFrom:
+          {{- . | toYaml | nindent 12 }}
+          {{- end }}
           env:
             - name: HOST_IP
               valueFrom: 
@@ -71,6 +75,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "newrelic.common.license.secretName" . }}
                   key: {{ include "newrelic.common.license.secretKeyName" . }}
+            {{- with .Values.daemonset.envs }}
+            {{- . | toYaml | nindent 12 }}
+            {{- end }}
           volumeMounts:
             # TODO (chris): this is a linux specific configuration
             {{- if include "newrelic.common.privileged" . }}

--- a/charts/nr-k8s-otel-collector/templates/deployment.yaml
+++ b/charts/nr-k8s-otel-collector/templates/deployment.yaml
@@ -46,6 +46,10 @@ spec:
           args: ["--config", "/config/deployment-config.yaml"]
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
+          {{- with .Values.deployment.envsFrom }}
+          envFrom:
+          {{- . | toYaml | nindent 12 }}
+          {{- end }}
           env:
             - name: KUBE_NODE_NAME
               valueFrom:
@@ -62,6 +66,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "newrelic.common.license.secretName" . }}
                   key: {{ include "newrelic.common.license.secretKeyName" . }}
+            {{- with .Values.deployment.envs }}
+            {{- . | toYaml | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 4318

--- a/charts/nr-k8s-otel-collector/templates/deployment.yaml
+++ b/charts/nr-k8s-otel-collector/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
           {{- with .Values.deployment.envsFrom }}
           envFrom:
-          {{- . | toYaml | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
           env:
             - name: KUBE_NODE_NAME

--- a/charts/nr-k8s-otel-collector/tests/env_vars_from_test.yaml
+++ b/charts/nr-k8s-otel-collector/tests/env_vars_from_test.yaml
@@ -1,0 +1,51 @@
+suite: envVarsFrom
+templates:
+  - templates/deployment.yaml
+  - templates/deployment-configmap.yaml
+  - templates/daemonset.yaml
+  - templates/daemonset-configmap.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+tests:
+  - it: Test adding additional env sources from Values file using 'nr-otel-for-k8s-license' secret
+    set:
+      cluster: my-cluster
+      licenseKey: us-whatever
+      deployment:
+        envsFrom:
+        - secretRef:
+            name: test-secret
+        - configMapRef:
+            name: test-configmap
+      daemonset:
+        envsFrom:
+        - secretRef:
+            name: test-secret
+        - configMapRef:
+            name: test-configmap
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef: 
+              name: test-secret
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: test-configmap
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef: 
+              name: test-secret
+        template: templates/daemonset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: test-configmap
+        template: templates/daemonset.yaml

--- a/charts/nr-k8s-otel-collector/tests/env_vars_from_test.yaml
+++ b/charts/nr-k8s-otel-collector/tests/env_vars_from_test.yaml
@@ -8,44 +8,107 @@ release:
   name: my-release
   namespace: my-namespace
 tests:
-  - it: Test adding additional env sources from Values file using 'nr-otel-for-k8s-license' secret
+  - it: does not set envFrom by default
+    set:
+      cluster: my-cluster
+      licenseKey: us-whatever
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].envFrom
+        template: templates/deployment.yaml
+      - notExists:
+          path: spec.template.spec.containers[0].envFrom
+        template: templates/daemonset.yaml
+  - it: adds additional deployment env sources from Values file using 'nr-otel-for-k8s-license' secret
     set:
       cluster: my-cluster
       licenseKey: us-whatever
       deployment:
         envsFrom:
         - secretRef:
-            name: test-secret
+            name: test-secret-dep
         - configMapRef:
-            name: test-configmap
-      daemonset:
-        envsFrom:
-        - secretRef:
-            name: test-secret
-        - configMapRef:
-            name: test-configmap
+            name: test-configmap-dep
     asserts:
       - contains:
           path: spec.template.spec.containers[0].envFrom
           content:
             secretRef: 
-              name: test-secret
+              name: test-secret-dep
         template: templates/deployment.yaml
       - contains:
           path: spec.template.spec.containers[0].envFrom
           content:
             configMapRef:
-              name: test-configmap
+              name: test-configmap-dep
         template: templates/deployment.yaml
+      - notExists:
+          path: spec.template.spec.containers[0].envFrom
+        template: templates/daemonset.yaml
+  - it: adds additional daemonset env sources from Values file using 'nr-otel-for-k8s-license' secret
+    set:
+      cluster: my-cluster
+      licenseKey: us-whatever
+      daemonset:
+        envsFrom:
+          - secretRef:
+              name: test-secret-dae
+          - configMapRef:
+              name: test-configmap-dae
+    asserts:
       - contains:
           path: spec.template.spec.containers[0].envFrom
           content:
-            secretRef: 
-              name: test-secret
+            secretRef:
+              name: test-secret-dae
         template: templates/daemonset.yaml
       - contains:
           path: spec.template.spec.containers[0].envFrom
           content:
             configMapRef:
-              name: test-configmap
+              name: test-configmap-dae
+        template: templates/daemonset.yaml
+      - notExists:
+          path: spec.template.spec.containers[0].envFrom
+        template: templates/deployment.yaml
+  - it: adds additional deployment and daemonset env sources from Values file using 'nr-otel-for-k8s-license' secret
+    set:
+      cluster: my-cluster
+      licenseKey: us-whatever
+      deployment:
+        envsFrom:
+          - secretRef:
+              name: test-secret-dep
+          - configMapRef:
+              name: test-configmap-dep
+      daemonset:
+        envsFrom:
+          - secretRef:
+              name: test-secret-dae
+          - configMapRef:
+              name: test-configmap-dae
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: test-secret-dep
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: test-configmap-dep
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: test-secret-dae
+        template: templates/daemonset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: test-configmap-dae
         template: templates/daemonset.yaml

--- a/charts/nr-k8s-otel-collector/tests/env_vars_test.yaml
+++ b/charts/nr-k8s-otel-collector/tests/env_vars_test.yaml
@@ -8,22 +8,87 @@ release:
   name: my-release
   namespace: my-namespace
 tests:
-  - it: sets pod environment variables from values
+  - it: does not set pod environment variables by default
+    set:
+      cluster: my-cluster
+      licenseKey: us-whatever
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers[0].env
+          count: 3
+        template: templates/deployment.yaml
+      - lengthEqual:
+          path: spec.template.spec.containers[0].env
+          count: 7
+        template: templates/daemonset.yaml
+  - it: sets deployment pod environment variables from values
     set:
       cluster: my-cluster
       licenseKey: us-whatever
       deployment:
         envs:
-        - name: "TEST_ENV_VAR"
-          value: "my-test-value"
-      daemonset:
-        envs:
-        - name: "TEST_ENV_VAR"
-          value: "my-test-value"
+          - name: "TEST_DEP_ENV_VAR"
+            value: "my-dep-value"
     asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers[0].env
+          count: 4
+        template: templates/deployment.yaml
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: "TEST_ENV_VAR"
-            value: "my-test-value"
+            name: "TEST_DEP_ENV_VAR"
+            value: "my-dep-value"
         template: templates/deployment.yaml
+  - it: sets daemonset pod environment variables from values
+    set:
+      cluster: my-cluster
+      licenseKey: us-whatever
+      daemonset:
+        envs:
+          - name: "TEST_DAE_ENV_VAR"
+            value: "my-dae-value"
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers[0].env
+          count: 8
+        template: templates/daemonset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: "TEST_DAE_ENV_VAR"
+            value: "my-dae-value"
+        template: templates/daemonset.yaml
+  - it: sets deployment and daemonset pod environment variables from values
+    set:
+      cluster: my-cluster
+      licenseKey: us-whatever
+      deployment:
+        envs:
+        - name: "TEST_DEP_ENV_VAR"
+          value: "my-dep-value"
+      daemonset:
+        envs:
+        - name: "TEST_DAE_ENV_VAR"
+          value: "my-dae-value"
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers[0].env
+          count: 4
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: "TEST_DEP_ENV_VAR"
+            value: "my-dep-value"
+        template: templates/deployment.yaml
+      - lengthEqual:
+          path: spec.template.spec.containers[0].env
+          count: 8
+        template: templates/daemonset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: "TEST_DAE_ENV_VAR"
+            value: "my-dae-value"
+        template: templates/daemonset.yaml

--- a/charts/nr-k8s-otel-collector/tests/env_vars_test.yaml
+++ b/charts/nr-k8s-otel-collector/tests/env_vars_test.yaml
@@ -1,0 +1,29 @@
+suite: envVars
+templates:
+  - templates/deployment.yaml
+  - templates/deployment-configmap.yaml
+  - templates/daemonset.yaml
+  - templates/daemonset-configmap.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+tests:
+  - it: sets pod environment variables from values
+    set:
+      cluster: my-cluster
+      licenseKey: us-whatever
+      deployment:
+        envs:
+        - name: "TEST_ENV_VAR"
+          value: "my-test-value"
+      daemonset:
+        envs:
+        - name: "TEST_ENV_VAR"
+          value: "my-test-value"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: "TEST_ENV_VAR"
+            value: "my-test-value"
+        template: templates/deployment.yaml

--- a/charts/nr-k8s-otel-collector/values.yaml
+++ b/charts/nr-k8s-otel-collector/values.yaml
@@ -60,6 +60,10 @@ daemonset:
     privileged: true
   # -- Sets resources for the daemonset.
   resources: {}
+  # -- Sets additional environment variables for the daemonset.
+  envs: []
+  # -- Sets additional environment variable sources for the daemonset.
+  envsFrom: []
   # -- Settings for daemonset configmap
   # @default -- See `values.yaml`
   configMap:
@@ -81,6 +85,10 @@ deployment:
   containerSecurityContext: {}
   # -- Sets resources for the deployment.
   resources: {}
+  # -- Sets additional environment variables for the deployment.
+  envs: []
+  # -- Sets additional environment variable sources for the deployment.
+  envsFrom: []
   # -- Settings for deployment configmap
   # @default -- See `values.yaml`
   configMap:


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No. This is a modification to 'nr-otel-for-k8s', which is currently maintained by @csongnr and @dbudziwojskiNR 

#### What this PR does / why we need it:
This PR exposes the option to add additional pod EVs to the deployment and daemonset running on kubernetes. I ran into a use case where I needed to be able to customize the 'nr-otel-for-k8s' service with a custom collector config, but once I did so I was unable to securely pass values to that config. In order to securely pass values to a custom config, having access from the values file to provide additional EVs is helpful.

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
