### PR TITLE
[synthetics-job-manager] update ping-runtime version (1.47.0) and chart version

### DIFF
--- a/charts/synthetics-job-manager/Chart.yaml
+++ b/charts/synthetics-job-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: synthetics-job-manager
 description: New Relic Synthetics Containerized Job Manager
 type: application
-version: 3.0.1
+version: 3.0.2
 appVersion: release-404
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
@@ -24,7 +24,7 @@ keywords:
   - newrelic
 dependencies:
   - name: ping-runtime
-    version: 1.0.21
+    version: 1.0.22
     condition: ping-runtime.enabled
   - name: node-api-runtime
     version: 1.0.37

--- a/charts/synthetics-job-manager/charts/ping-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/ping-runtime/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: ping-runtime
 description: New Relic Synthetics Ping Runtime
 type: application
-version: 1.0.21
-appVersion: 1.46.0
+version: 1.0.22
+appVersion: 1.47.0
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith


### PR DESCRIPTION
#### Is this a new chart
no

#### What this PR does / why we need it:
Updates the synthetics-job-manager chart version to use the latest release of the synthetics-ping-runtime

#### Which issue this PR fixes
  - fixes a permission issue when running the synthetics-ping-runtime as a non-root user

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
