### PR TITLE
[nr-ebpf-agent] Support nri-bundle supplied secrets. 

### DIFF
--- a/charts/nr-ebpf-agent/Chart.lock
+++ b/charts/nr-ebpf-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: https://helm-charts.newrelic.com
-  version: 1.1.1
-digest: sha256:3c9053021f3c22aa3cdfc6781d3498bcbedb0b973af9121b1722469744fb5162
-generated: "2024-07-22T22:06:19.122775417Z"
+  version: 1.3.0
+digest: sha256:2e1da613fd8a52706bde45af077779c5d69e9e1641bdf5c982eaf6d1ac67a443
+generated: "2024-11-06T20:45:23.428463-08:00"

--- a/charts/nr-ebpf-agent/Chart.yaml
+++ b/charts/nr-ebpf-agent/Chart.yaml
@@ -13,10 +13,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.8
+version: 0.1.9
 dependencies:
   - name: common-library
-    version: 1.1.1
+    version: 1.3.0
     repository: "https://helm-charts.newrelic.com"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nr-ebpf-agent/templates/_helpers.tpl
+++ b/charts/nr-ebpf-agent/templates/_helpers.tpl
@@ -40,3 +40,42 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Return the licenseKey
+*/}}
+{{- define "nr-ebpf-agent.licenseKey" -}}
+{{- if .Values.global }}
+  {{- if .Values.global.licenseKey }}
+    {{- .Values.global.licenseKey -}}
+  {{ else if .Values.global.insightsKey }}
+    {{- .Values.global.insightsKey -}}
+  {{ else }}
+    {{- .Values.licenseKey | default "" -}}
+  {{ end }}
+{{- else -}}
+    {{- .Values.licenseKey | default "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the customSecretName
+*/}}
+{{- define "nr-ebpf-agent.customSecretName" -}}
+{{- if .Values.global }}
+    {{- .Values.global.customSecretName | default "" -}}
+{{- else -}}
+    {{- "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the customSecretLicenseKey
+*/}}
+{{- define "nr-ebpf-agent.customSecretKey" -}}
+{{- if .Values.global }}
+    {{- .Values.customSecretLicenseKey | default "" -}}
+{{- else -}}
+    {{- "" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/nr-ebpf-agent/templates/otel-collector-daemonset.yaml
+++ b/charts/nr-ebpf-agent/templates/otel-collector-daemonset.yaml
@@ -38,8 +38,13 @@ spec:
           - name: NR_LICENSE_KEY
             valueFrom:
               secretKeyRef:
+                {{- if (include "nr-ebpf-agent.licenseKey" .) }}
                 key: NR_LICENSE_KEY
                 name: nr-ebpf-agent-secrets
+                {{- else }}
+                name: {{ include "nr-ebpf-agent.customSecretName" . }}
+                key: {{ include "nr-ebpf-agent.customSecretLicenseKey" . }}
+                {{- end }}
           - name: NR_OTLP_ENDPOINT
             {{- if .Values.proxy }}
             value: "{{- .Values.proxy }}"

--- a/charts/nr-ebpf-agent/templates/secrets.yaml
+++ b/charts/nr-ebpf-agent/templates/secrets.yaml
@@ -1,10 +1,10 @@
 {{- $licenseKey := include "nr-ebpf-agent.licenseKey" . -}}
 {{- $customSecretLicenseKey := include "nr-ebpf-agent.customSecretKey" . -}}
-
 apiVersion: v1
 kind: Secret
 metadata:
   name: nr-ebpf-agent-secrets
+type: Opaque
 data:
   {{- if .Values.licenseKey}}
   NR_LICENSE_KEY: {{ .Values.licenseKey | b64enc }}
@@ -14,4 +14,4 @@ data:
   NR_LICENSE_KEY: ""
   {{- else }}
   NR_LICENSE_KEY: {{ required "secrets.licenseKey is required" .Values.licenseKey | b64enc | quote }}
-  {{ end }}type: Opaque
+  {{ end }}

--- a/charts/nr-ebpf-agent/templates/secrets.yaml
+++ b/charts/nr-ebpf-agent/templates/secrets.yaml
@@ -1,7 +1,17 @@
+{{- $licenseKey := include "nr-ebpf-agent.licenseKey" . -}}
+{{- $customSecretLicenseKey := include "nr-ebpf-agent.customSecretKey" . -}}
+
 apiVersion: v1
 kind: Secret
 metadata:
   name: nr-ebpf-agent-secrets
 data:
+  {{- if .Values.licenseKey}}
+  NR_LICENSE_KEY: {{ .Values.licenseKey | b64enc }}
+  {{- else if $licenseKey}}
+  NR_LICENSE_KEY: {{ $licenseKey | b64enc }}
+  {{ else if $customSecretLicenseKey}}
+  NR_LICENSE_KEY: ""
+  {{- else }}
   NR_LICENSE_KEY: {{ required "secrets.licenseKey is required" .Values.licenseKey | b64enc | quote }}
-type: Opaque
+  {{ end }}type: Opaque


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No.

#### What this PR does / why we need it:
This chart adds support for some environment variables/secrets that are documented in the NRI-bundle. 
This removes the need for the user to supply separate secrets specifically for the eBPF agent. 
This change will allow for a more seamless install for the customers who choose to install the eBPF agent as part of the nri bundle. (When the eBPF agent is added to the bundle.)

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes # N/A

#### Special notes for your reviewer:
Support for global ingest keys is documented in the nri-bundle/read.me. 
If users are installing this chart by itself, they should use the values.licenseKey not global vars supplied by the bundle.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
