### PR TITLE
feat(dev): add option for dynamicAgent

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,6 +20,6 @@
 /charts/synthetics-job-manager/ @newrelic/proactive-monitoring
 
 # Infrastructure-related charts
-/charts/nri-statsd/ @newrelic/caos
-/charts/super-agent-deployment/ @newrelic/coreint @newrelic/caos
-/charts/super-agent/ @newrelic/coreint @newrelic/caos
+/charts/nri-statsd/ @newrelic/ohai
+/charts/super-agent-deployment/ @newrelic/ac @newrelic/ohai
+/charts/super-agent/ @newrelic/ac @newrelic/ohai

--- a/charts/super-agent/Chart.lock
+++ b/charts/super-agent/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 2.13.0
 - name: super-agent-deployment
   repository: ""
-  version: 0.0.26-beta
+  version: 0.0.27-beta
 - name: common-library
   repository: https://helm-charts.newrelic.com
   version: 1.3.0
-digest: sha256:55ec5d7556e8ea4a5628d8aaa7e21975b0fb6441717bfb2f082de540508c3d38
-generated: "2024-11-04T13:03:03.888745-01:00"
+digest: sha256:7da311726a72e9fca667861e0717fc0a79f768b529ca44b0d46b8d8f535f8f70
+generated: "2024-11-15T08:53:29.020878-01:00"

--- a/charts/super-agent/Chart.yaml
+++ b/charts/super-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: super-agent
 description: Bootstraps New Relic' Super Agent
 
 type: application
-version: 0.0.23-beta
+version: 0.0.24-beta
 
 dependencies:
   - name: flux2
@@ -11,7 +11,7 @@ dependencies:
     version: 2.13.0
     condition: flux2.enabled
   - name: super-agent-deployment
-    version: 0.0.26-beta
+    version: 0.0.27-beta
     condition: super-agent-deployment.enabled
     # The following dependency is needed as sub-dependency of super-agent-deployment
   - name: common-library

--- a/charts/super-agent/README.md
+++ b/charts/super-agent/README.md
@@ -26,12 +26,40 @@ means that it honors a wide range of defaults and globals common to most New Rel
 Options that can be defined globally include `affinity`, `nodeSelector`, `tolerations`, `proxy` and others. The full list can be found at
 [user's guide of the common library](https://github.com/newrelic/helm-charts/blob/master/library/common-library/README.md).
 
+## Test custom agentTypes
+
+In order to test custom agentTypes is possible to leverage `extraVolumeMounts` and `extraVolumes` once you have created the configMap in the namespace.
+
+You can run the following commands to create in the newrelic namespace a configMap containing a dynamic agentType:
+```bash
+$ kubectl create configmap dynamic-agent --from-file=dynamic-agent-type=./local/values-dynamic-agent-type.yaml -n default
+```
+
+Then you can mount such agentType leveraging extra volumes in the values.yaml
+```yaml
+super-agent-deployment:
+# [...]
+  extraVolumeMounts:
+    - name: dynamic
+      mountPath: /etc/newrelic-super-agent/dynamic-agent-type.yaml
+      subPath: dynamic-agent-type.yaml
+      readOnly: true
+  extraVolumes:
+    - name: dynamic
+      configMap:
+        name: dynamic-agent
+        items:
+          - key: dynamic-agent-type
+            path: dynamic-agent-type.yaml
+```
+
 ## Chart particularities
 
 > **TODO:** Here is where you should add particularities for this chart like what does the chart do with the privileged and
 low data modes or any other quirk that it could have.
 
 As of the creation of the chart, it has no particularities and this section can be removed safely.
+
 
 ## Values
 

--- a/charts/super-agent/charts/super-agent-deployment/Chart.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Super agent on Kubernetes
 
 type: application
 
-version: 0.0.26-beta
+version: 0.0.27-beta
 
 keywords:
   - newrelic

--- a/charts/super-agent/charts/super-agent-deployment/templates/deployment-superagent.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/templates/deployment-superagent.yaml
@@ -103,8 +103,9 @@ spec:
 
           volumeMounts:
             - name: super-agent-config
-              mountPath: /etc/newrelic-super-agent
+              mountPath: /etc/newrelic-super-agent/config.yaml
               readOnly: true
+              subPath: config.yaml
             # TODO: when releasing we should check if this is still needed and/or if we need to persist the data.
             - mountPath: /var/lib/newrelic-super-agent
               name: var-lib-newrelic-super-agent

--- a/charts/super-agent/charts/super-agent-deployment/tests/auth_secret_test.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/tests/auth_secret_test.yaml
@@ -26,8 +26,9 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts
           value:
             - name: super-agent-config
-              mountPath: /etc/newrelic-super-agent
+              mountPath: /etc/newrelic-super-agent/config.yaml
               readOnly: true
+              subPath: config.yaml
             - mountPath: /var/lib/newrelic-super-agent
               name: var-lib-newrelic-super-agent
               readOnly: false

--- a/charts/super-agent/charts/super-agent-deployment/tests/deployment_superagent_subagent_configs_test.yaml
+++ b/charts/super-agent/charts/super-agent-deployment/tests/deployment_superagent_subagent_configs_test.yaml
@@ -34,8 +34,9 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts
           value:
             - name: super-agent-config
-              mountPath: /etc/newrelic-super-agent
+              mountPath: /etc/newrelic-super-agent/config.yaml
               readOnly: true
+              subPath: config.yaml
             - mountPath: /var/lib/newrelic-super-agent
               name: var-lib-newrelic-super-agent
               readOnly: false


### PR DESCRIPTION
#### Is this a new chart
no
#### What this PR does / why we need it:
follow up of https://github.com/newrelic/helm-charts/pull/1482


In the past there was a similar PR and @gsanchezgavier suggested to use extra volumes. I needed to modify how we mount the agent Control configMap to allow such approach

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [] Variables are documented in the README.md -> Expected not to be exposed
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
