### PR TITLE
[synthetics-job-manager] chore: add engineers to sjm chart maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,13 +11,13 @@
 /charts/nr-ebpf-agent/ @newrelic/ebpf
 
 # Logging chart
-/charts/newrelic-logging/ @newrelic/logging 
+/charts/newrelic-logging/ @newrelic/logging
 
 # synthetics-minion
-/charts/synthetics-minion/ @newrelic/proactive-monitoring
+/charts/synthetics-minion/ @newrelic/pmon
 
 # synthetics-job-manager
-/charts/synthetics-job-manager/ @newrelic/proactive-monitoring
+/charts/synthetics-job-manager/ @newrelic/pmon
 
 # Infrastructure-related charts
 /charts/nri-statsd/ @newrelic/ohai

--- a/charts/synthetics-job-manager/Chart.yaml
+++ b/charts/synthetics-job-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: synthetics-job-manager
 description: New Relic Synthetics Containerized Job Manager
 type: application
-version: 3.0.2
+version: 3.0.3
 appVersion: release-404
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
@@ -10,12 +10,12 @@ maintainers:
   - name: sidnaiknewrelic
   - name: Philip-R-Beckwith
   - name: sshah-nr
-  - name: vkasanneni-nr
   - name: marcusperezNR
-  - name: mderemer-nr
   - name: sadafarshad
-  - name: lromer22
   - name: kondracek-nr
+  - name: mfarhan-nr
+  - name: schakraborty-nr
+  - name: shashank-srirangam
     email: team_proactive-monitoring@newrelic.com
 keywords:
   - synthetics


### PR DESCRIPTION
#### Is this a new chart
no

#### What this PR does / why we need it:
adds some current synthetics engineers to sjm chart maintainers list


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
