### PR TITLE
[agent-control] fleet_id has now a specific value

### DIFF
--- a/charts/agent-control/Chart.lock
+++ b/charts/agent-control/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 2.13.0
 - name: agent-control-deployment
   repository: ""
-  version: 0.0.32-beta
+  version: 0.0.33-beta
 - name: common-library
   repository: https://helm-charts.newrelic.com
   version: 1.3.0
-digest: sha256:f0ea6c84b777100b9371589dea16a02eafdd70623b4a4b62014488f460a5dd99
-generated: "2024-12-17T09:37:56.710271Z"
+digest: sha256:c003fc9e9396a7e694869a802d8138abafb8fba925fafe0e312b0bb8ae1534fc
+generated: "2024-12-17T17:38:29.951026+01:00"

--- a/charts/agent-control/Chart.yaml
+++ b/charts/agent-control/Chart.yaml
@@ -3,7 +3,7 @@ name: agent-control
 description: Bootstraps New Relic' Agent Control
 
 type: application
-version: 0.0.32-beta
+version: 0.0.33-beta
 
 dependencies:
   - name: flux2
@@ -11,7 +11,7 @@ dependencies:
     version: 2.13.0
     condition: flux2.enabled
   - name: agent-control-deployment
-    version: 0.0.32-beta
+    version: 0.0.33-beta
     condition: agent-control-deployment.enabled
     # The following dependency is needed as sub-dependency of agent-control-deployment
   - name: common-library

--- a/charts/agent-control/README.md
+++ b/charts/agent-control/README.md
@@ -80,6 +80,7 @@ As of the creation of the chart, it has no particularities and this section can 
 | agent-control-deployment.config.fleet_control.auth.secret.private_key.plain_pem | string | `nil` | In case `.config.auth.secret.create` is true, you can set these keys to set private key directly as plain text. This options is mutually exclusive with `base64_pem`. |
 | agent-control-deployment.config.fleet_control.auth.secret.private_key.secret_key | string | `private_key` | Key inside the secret containing the private key. |
 | agent-control-deployment.config.fleet_control.enabled | bool | `true` | Enables or disables the auth against fleet control. It implies to disable any fleet communication and running the agent in stand alone mode where only the agents specified on `.config.subAgents` will be launched. |
+| agent-control-deployment.config.fleet_control.fleet_id | string | `""` | Specify a fleet_id to automatically connect the Agent Control to an existing fleet. |
 | agent-control-deployment.config.subAgents | string | `{}` (See `values.yaml`) | List of managed agents that will be deployed. The key represents the name of the agent and the value holds the configuration. |
 | agent-control-deployment.containerSecurityContext | object | `{}` | Sets security context (at container level). Can be configured also with `global.containerSecurityContext` |
 | agent-control-deployment.customAttributes | object | `{}` | TODO: Adds extra attributes to the cluster and all the metrics emitted to the backend. Can be configured also with `global.customAttributes` |

--- a/charts/agent-control/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control/charts/agent-control-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 
 type: application
 
-version: 0.0.32-beta
+version: 0.0.33-beta
 
 keywords:
   - newrelic

--- a/charts/agent-control/charts/agent-control-deployment/templates/_helpers.tpl
+++ b/charts/agent-control/charts/agent-control-deployment/templates/_helpers.tpl
@@ -112,6 +112,10 @@ If you need a list of TODOs, just `grep TODO` on the `values.yaml` and look for 
 {{- if ((.Values.config).fleet_control).enabled -}}
   {{- $fleet_control := (dict "endpoint" (include "newrelic-agent-control.config.endpoints.fleet_control" .)) -}}
 
+  {{- if ((.Values.config).fleet_control).fleet_id -}}
+  {{- $fleet_control = mustMerge $fleet_control (dict "fleet_id" ((.Values.config).fleet_control).fleet_id) -}}
+  {{- end -}}
+
   {{- $auth_config := dict "token_url" (include "newrelic-agent-control.config.endpoints.tokenRenewal" .) "provider" "local" "private_key_path" "/etc/newrelic-agent-control/keys/from-secret.key" -}}
   {{- $fleet_control = mustMerge $fleet_control (dict "auth_config" $auth_config) -}}
 

--- a/charts/agent-control/charts/agent-control-deployment/tests/configmap_agentcontrol_config_test.yaml
+++ b/charts/agent-control/charts/agent-control-deployment/tests/configmap_agentcontrol_config_test.yaml
@@ -31,6 +31,30 @@ tests:
             server:
               enabled: true
 
+  - it: you can setup a specific fleet_id
+    set:
+      cluster: my-cluster
+      config:
+        fleet_control:
+          fleet_id: abcefg
+    asserts:
+      - equal:
+          path: data["local_config"]
+          value: |
+            agents: {}
+            fleet_control:
+              auth_config:
+                private_key_path: /etc/newrelic-agent-control/keys/from-secret.key
+                provider: local
+                token_url: https://system-identity-oauth.service.newrelic.com/oauth2/token
+              endpoint: https://opamp.service.newrelic.com/v1/opamp
+              fleet_id: abcefg
+            k8s:
+              cluster_name: my-cluster
+              namespace: my-namespace
+            server:
+              enabled: true
+
   - it: agent control's config always include cluster_name, namespace and defaults
     set:
       cluster: my-cluster

--- a/charts/agent-control/values.yaml
+++ b/charts/agent-control/values.yaml
@@ -33,7 +33,7 @@ agent-control-deployment:
   image:
     registry:
     repository: newrelic/newrelic-agent-control
-    tag: "nightly"
+    tag: "0.26.3"
     imagePullPolicy: IfNotPresent
     # -- The secrets that are needed to pull images from a custom registry.
     pullSecrets: []

--- a/charts/agent-control/values.yaml
+++ b/charts/agent-control/values.yaml
@@ -149,6 +149,8 @@ agent-control-deployment:
       # -- Enables or disables the auth against fleet control. It implies to disable any fleet communication and running the agent
       # in stand alone mode where only the agents specified on `.config.subAgents` will be launched.
       enabled: true
+      # -- Specify a fleet_id to automatically connect the Agent Control to an existing fleet.
+      fleet_id: ""
 
       auth:
         # -- Organization ID where fleets will live.


### PR DESCRIPTION

#### Is this a new chart
no
#### What this PR does / why we need it:
with this PR we point to the latest release available of the agent control and we introduce a new `value` for the fleet_id

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
