### PR TITLE
[agent-control]: add chart version to agent-control config [NR-348101]

### DIFF
--- a/charts/agent-control/Chart.lock
+++ b/charts/agent-control/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 2.13.0
 - name: agent-control-deployment
   repository: ""
-  version: 0.0.33-beta
+  version: 0.0.34-beta
 - name: common-library
   repository: https://helm-charts.newrelic.com
   version: 1.3.0
-digest: sha256:c003fc9e9396a7e694869a802d8138abafb8fba925fafe0e312b0bb8ae1534fc
-generated: "2024-12-17T17:38:29.951026+01:00"
+digest: sha256:761cf4bfc4afd0105504db2bda44671ee4419650d010946dca9932d74568cf41
+generated: "2024-12-19T14:07:26.085962+01:00"

--- a/charts/agent-control/Chart.yaml
+++ b/charts/agent-control/Chart.yaml
@@ -3,7 +3,7 @@ name: agent-control
 description: Bootstraps New Relic' Agent Control
 
 type: application
-version: 0.0.34-beta
+version: 0.0.35-beta
 
 dependencies:
   - name: flux2
@@ -11,7 +11,7 @@ dependencies:
     version: 2.13.0
     condition: flux2.enabled
   - name: agent-control-deployment
-    version: 0.0.33-beta
+    version: 0.0.34-beta
     condition: agent-control-deployment.enabled
     # The following dependency is needed as sub-dependency of agent-control-deployment
   - name: common-library

--- a/charts/agent-control/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control/charts/agent-control-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 
 type: application
 
-version: 0.0.33-beta
+version: 0.0.34-beta
 
 keywords:
   - newrelic

--- a/charts/agent-control/charts/agent-control-deployment/templates/_helpers.tpl
+++ b/charts/agent-control/charts/agent-control-deployment/templates/_helpers.tpl
@@ -105,7 +105,7 @@ If you need a list of TODOs, just `grep TODO` on the `values.yaml` and look for 
 {{- $config := dict "server" (dict "enabled" true) -}}
 
 {{- /* Add to config k8s cluster and namespace config */ -}}
-{{- $k8s := (dict "cluster_name" (include "newrelic.common.cluster" .) "namespace" .Release.Namespace) -}}
+{{- $k8s := (dict "cluster_name" (include "newrelic.common.cluster" .) "namespace" .Release.Namespace, "chart_version" .Chart.Version) -}}
 {{- $config = mustMerge $config (dict "k8s" $k8s) -}}
 
 {{- /* Add fleet_control if enabled */ -}}

--- a/charts/agent-control/charts/agent-control-deployment/templates/_helpers.tpl
+++ b/charts/agent-control/charts/agent-control-deployment/templates/_helpers.tpl
@@ -105,7 +105,7 @@ If you need a list of TODOs, just `grep TODO` on the `values.yaml` and look for 
 {{- $config := dict "server" (dict "enabled" true) -}}
 
 {{- /* Add to config k8s cluster and namespace config */ -}}
-{{- $k8s := (dict "cluster_name" (include "newrelic.common.cluster" .) "namespace" .Release.Namespace, "chart_version" .Chart.Version) -}}
+{{- $k8s := (dict "cluster_name" (include "newrelic.common.cluster" .) "namespace" .Release.Namespace "chart_version" .Chart.Version) -}}
 {{- $config = mustMerge $config (dict "k8s" $k8s) -}}
 
 {{- /* Add fleet_control if enabled */ -}}

--- a/charts/agent-control/charts/agent-control-deployment/tests/configmap_agentcontrol_config_test.yaml
+++ b/charts/agent-control/charts/agent-control-deployment/tests/configmap_agentcontrol_config_test.yaml
@@ -4,6 +4,8 @@ templates:
 release:
   name: my-release
   namespace: my-namespace
+chart:
+  version: 1.2.3-beta
 tests:
   - it: agent control's config can be disabled
     set:
@@ -26,6 +28,7 @@ tests:
           value: |
             agents: {}
             k8s:
+              chart_version: 1.2.3-beta
               cluster_name: my-cluster
               namespace: my-namespace
             server:
@@ -50,6 +53,7 @@ tests:
               endpoint: https://opamp.service.newrelic.com/v1/opamp
               fleet_id: abcefg
             k8s:
+              chart_version: 1.2.3-beta
               cluster_name: my-cluster
               namespace: my-namespace
             server:
@@ -72,6 +76,7 @@ tests:
                 token_url: https://system-identity-oauth.service.newrelic.com/oauth2/token
               endpoint: https://opamp.service.newrelic.com/v1/opamp
             k8s:
+              chart_version: 1.2.3-beta
               cluster_name: my-cluster
               namespace: my-namespace
             server:
@@ -97,6 +102,7 @@ tests:
                 token_url: https://system-identity-oauth.service.newrelic.com/oauth2/token
               endpoint: https://opamp.service.newrelic.com/v1/opamp
             k8s:
+              chart_version: 1.2.3-beta
               cluster_name: my-cluster
               namespace: my-namespace
             server:
@@ -127,6 +133,7 @@ tests:
                 token_url: https://system-identity-oauth.service.newrelic.com/oauth2/token
               endpoint: https://opamp.service.newrelic.com/v1/opamp
             k8s:
+              chart_version: 1.2.3-beta
               cluster_name: config-cluster
               namespace: config-namespace
             server:
@@ -150,6 +157,7 @@ tests:
                 token_url: https://system-identity-oauth.service.newrelic.com/oauth2/token
               endpoint: https://opamp.service.eu.newrelic.com/v1/opamp
             k8s:
+              chart_version: 1.2.3-beta
               cluster_name: my-cluster
               namespace: my-namespace
             server:

--- a/charts/agent-control/values.yaml
+++ b/charts/agent-control/values.yaml
@@ -35,7 +35,7 @@ agent-control-deployment:
   image:
     registry:
     repository: newrelic/newrelic-agent-control
-    tag: "0.26.3"
+    tag: "0.27.0"
     imagePullPolicy: IfNotPresent
     # -- The secrets that are needed to pull images from a custom registry.
     pullSecrets: []


### PR DESCRIPTION

#### Is this a new chart

No

#### What this PR does / why we need it:

This PRs includes the chart version in the Agent Control configuration so it can be reported.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
