### PR TITLE
[agent-control] improve naming

### DIFF
--- a/charts/agent-control/Chart.yaml
+++ b/charts/agent-control/Chart.yaml
@@ -3,7 +3,7 @@ name: agent-control
 description: Bootstraps New Relic' Agent Control
 
 type: application
-version: 0.0.33-beta
+version: 0.0.34-beta
 
 dependencies:
   - name: flux2

--- a/charts/agent-control/charts/agent-control-deployment/tests/auth_secret_test.yaml
+++ b/charts/agent-control/charts/agent-control-deployment/tests/auth_secret_test.yaml
@@ -49,14 +49,14 @@ tests:
               emptyDir: {}
             - name: auth-secret-private-key
               secret:
-                secretName: my-release-agent-control-deployment-auth
+                secretName: my-release-agent-control-auth
                 items:
                   - key: private_key
                     path: from-secret.key
       - template: templates/secret-sa-auth.yaml
         equal:
           path: metadata.name
-          value: my-release-agent-control-deployment-auth
+          value: my-release-agent-control-auth
       - template: templates/secret-sa-auth.yaml
         equal:
           path: data.private_key

--- a/charts/agent-control/charts/agent-control-deployment/tests/deployment_agentcontrol_env_test.yaml
+++ b/charts/agent-control/charts/agent-control-deployment/tests/deployment_agentcontrol_env_test.yaml
@@ -4,7 +4,7 @@ templates:
   - templates/configmap-agentcontrol-config.yaml
   - templates/configmap-subagent-configs.yaml
 release:
-  name: my-release
+  name: agent-control
   namespace: my-namespace
 tests:
   - it: license key gets added as env var from secret
@@ -19,7 +19,7 @@ tests:
             valueFrom:
               secretKeyRef:
                 key: licenseKey
-                name: my-release-agent-control-deployment-license
+                name: agent-control-license
         template: templates/deployment-agentcontrol.yaml
 
   - it: license key gets added as env var from custom secret
@@ -56,7 +56,7 @@ tests:
             valueFrom:
               secretKeyRef:
                 key: licenseKey
-                name: my-release-agent-control-deployment-license
+                name: agent-control-license
         template: templates/deployment-agentcontrol.yaml
 
   - it: api-key config gets added as env var from custom secret

--- a/charts/agent-control/charts/agent-control-deployment/tests/deployment_agentcontrol_subagent_configs_test.yaml
+++ b/charts/agent-control/charts/agent-control-deployment/tests/deployment_agentcontrol_subagent_configs_test.yaml
@@ -4,7 +4,7 @@ templates:
   - templates/configmap-agentcontrol-config.yaml
   - templates/configmap-subagent-configs.yaml
 release:
-  name: my-release
+  name: agent-control
   namespace: my-namespace
 tests:
   - it: there is no subagent configuration
@@ -57,7 +57,7 @@ tests:
               emptyDir: {}
             - name: auth-secret-private-key
               secret:
-                secretName: my-release-agent-control-deployment-auth
+                secretName: agent-control-auth
                 items:
                   - key: private_key
                     path: from-secret.key

--- a/charts/agent-control/charts/agent-control-deployment/tests/preinstall_job_test.yaml
+++ b/charts/agent-control/charts/agent-control-deployment/tests/preinstall_job_test.yaml
@@ -2,7 +2,7 @@ suite: pre-install job template
 templates:
   - templates/preinstall-job-register-system-identity.yaml
 release:
-  name: my-release
+  name: agent-control
   namespace: my-namespace
 set:
   cluster: test
@@ -76,7 +76,7 @@ tests:
               valueFrom:
                 secretKeyRef:
                   key: userKey
-                  name: my-release-agent-control-deployment-preinstall-user-key
+                  name: agent-control-preinstall-user-key
 
   - it: with identityCredentialsL1 set, the job should template correctly.
     set:
@@ -100,12 +100,12 @@ tests:
               valueFrom:
                 secretKeyRef:
                   key: clientIdKey
-                  name: my-release-agent-control-deployme-preinstall-client-credentials
+                  name: agent-control-preinstall-client-credentials
             - name: NEW_RELIC_AUTH_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   key: clientSecretKey
-                  name: my-release-agent-control-deployme-preinstall-client-credentials
+                  name: agent-control-preinstall-client-credentials
 
   - it: with a custom secret for userKey, the secret should not be created.
     set:

--- a/charts/agent-control/values.yaml
+++ b/charts/agent-control/values.yaml
@@ -10,6 +10,8 @@ agent-control-deployment:
   # you know what you are going.
   enabled: true
 
+  # -- Override the name of the chart used to template resource names.
+  nameOverride: "agent-control"
   # -- Name of the Kubernetes cluster monitored. Can be configured also with `global.cluster`.
   cluster: ""
   # -- This set this license key to use. Can be configured also with `global.licenseKey`


### PR DESCRIPTION
#### Is this a new chart
no
#### What this PR does / why we need it:

After we moved to a sub-chart approach naming got compromised, now we have something like:
```
# pod
agent-control-agent-control-deployment-6b9496bcb9-g5ncj
# service account
agent-control-agent-control-deployment
```
In particular we have a repetition and a -deployment suffix


After this PR, we are aligning the two chartName so that we forget about the `-deployment` suffix and the suplication
```
# pod
agent-control-86d6dd7ddf-r64lm
# service account
agent-control
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
