### PR TITLE
[agent-control]: add additional env-vars to make subagents config easier

### DIFF
--- a/charts/agent-control/Chart.lock
+++ b/charts/agent-control/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 2.13.0
 - name: agent-control-deployment
   repository: ""
-  version: 0.0.34-beta
+  version: 0.0.35-beta
 - name: common-library
   repository: https://helm-charts.newrelic.com
   version: 1.3.0
-digest: sha256:761cf4bfc4afd0105504db2bda44671ee4419650d010946dca9932d74568cf41
-generated: "2024-12-19T14:07:26.085962+01:00"
+digest: sha256:520e65faba269be5084966194bf4681899b59399d4442999a71a4898a10af173
+generated: "2025-01-08T14:32:09.044891+01:00"

--- a/charts/agent-control/Chart.yaml
+++ b/charts/agent-control/Chart.yaml
@@ -3,7 +3,7 @@ name: agent-control
 description: Bootstraps New Relic' Agent Control
 
 type: application
-version: 0.0.36-beta
+version: 0.0.37-beta
 
 dependencies:
   - name: flux2
@@ -11,7 +11,7 @@ dependencies:
     version: 2.13.0
     condition: flux2.enabled
   - name: agent-control-deployment
-    version: 0.0.34-beta
+    version: 0.0.35-beta
     condition: agent-control-deployment.enabled
     # The following dependency is needed as sub-dependency of agent-control-deployment
   - name: common-library

--- a/charts/agent-control/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control/charts/agent-control-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 
 type: application
 
-version: 0.0.34-beta
+version: 0.0.35-beta
 
 keywords:
   - newrelic

--- a/charts/agent-control/charts/agent-control-deployment/templates/deployment-agentcontrol.yaml
+++ b/charts/agent-control/charts/agent-control-deployment/templates/deployment-agentcontrol.yaml
@@ -89,6 +89,12 @@ spec:
                   key: {{ include "newrelic.common.license.secretKeyName" . }}
             - name: NR_CLUSTER_NAME
               value: {{ include "newrelic.common.cluster" . }}
+            - name: NR_STAGING
+              value: "{{ include "newrelic.common.nrStaging" . | default false }}"
+            - name: NR_LOW_DATA_MODE
+              value: "{{ include "newrelic.common.lowDataMode" . | default false }}"
+            - name: NR_VERBOSE_LOG
+              value: "{{ include "newrelic.common.verboseLog" . | default false }}"
           {{- /* ----- Variables used to send data downstream to subagents */}}
 
           {{- with .Values.extraEnv }}

--- a/charts/agent-control/charts/agent-control-deployment/tests/deployment_agentcontrol_env_test.yaml
+++ b/charts/agent-control/charts/agent-control-deployment/tests/deployment_agentcontrol_env_test.yaml
@@ -80,6 +80,7 @@ tests:
                 key: custom-key
                 name: custom-secret
         template: templates/deployment-agentcontrol.yaml
+
   - it: cluster name added as env var
     set:
       cluster: test
@@ -89,4 +90,63 @@ tests:
           content:
             name: NR_CLUSTER_NAME
             value: test
+        template: templates/deployment-agentcontrol.yaml
+
+  - it: nrStaging added as env var
+    set:
+      cluster: test
+      nrStaging: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NR_STAGING
+            value: "true"
+        template: templates/deployment-agentcontrol.yaml
+
+  - it: lowDataMode added as env var
+    set:
+      cluster: test
+      lowDataMode: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NR_LOW_DATA_MODE
+            value: "true"
+        template: templates/deployment-agentcontrol.yaml
+
+  - it: verboseLog added as env var
+    set:
+      cluster: test
+      verboseLog: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NR_VERBOSE_LOG
+            value: "true"
+        template: templates/deployment-agentcontrol.yaml
+
+  - it: bool env vars as false when they are not set
+    set:
+      cluster: test
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NR_STAGING
+            value: "false"
+        template: templates/deployment-agentcontrol.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NR_LOW_DATA_MODE
+            value: "false"
+        template: templates/deployment-agentcontrol.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NR_VERBOSE_LOG
+            value: "false"
         template: templates/deployment-agentcontrol.yaml


### PR DESCRIPTION

#### Is this a new chart
no

#### What this PR does / why we need it:

Includes additional env-vars in agent-control deployment to allow a centralized configuration of common values.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
