### PR TITLE
[agent-control] Rename L1 values

### DIFF
--- a/charts/agent-control/Chart.yaml
+++ b/charts/agent-control/Chart.yaml
@@ -3,7 +3,7 @@ name: agent-control
 description: Bootstraps New Relic' Agent Control
 
 type: application
-version: 0.0.35-beta
+version: 0.0.36-beta
 
 dependencies:
   - name: flux2

--- a/charts/agent-control/README.md
+++ b/charts/agent-control/README.md
@@ -84,7 +84,7 @@ As of the creation of the chart, it has no particularities and this section can 
 | agent-control-deployment.config.subAgents | string | `{}` (See `values.yaml`) | List of managed agents that will be deployed. The key represents the name of the agent and the value holds the configuration. |
 | agent-control-deployment.containerSecurityContext | object | `{}` | Sets security context (at container level). Can be configured also with `global.containerSecurityContext` |
 | agent-control-deployment.customAttributes | object | `{}` | TODO: Adds extra attributes to the cluster and all the metrics emitted to the backend. Can be configured also with `global.customAttributes` |
-| agent-control-deployment.customL1IdentitySecretName | string | `""` | In case you don't want to have the client_id and client_secret in your values, this allows you to point to a user created secret to get the key from there. |
+| agent-control-deployment.customIdentitySecretName | string | `""` | In case you don't want to have the client_id and client_secret in your values, this allows you to point to a user created secret to get the key from there. |
 | agent-control-deployment.customSecretLicenseKey | string | `""` | In case you don't want to have the license key in you values, this allows you to point to which secret key is the license key located. Can be configured also with `global.customSecretLicenseKey` |
 | agent-control-deployment.customSecretName | string | `""` | In case you don't want to have the license key in you values, this allows you to point to a user created secret to get the key from there. Can be configured also with `global.customSecretName` |
 | agent-control-deployment.dnsConfig | object | `{}` | Sets pod's dnsConfig. Can be configured also with `global.dnsConfig` |
@@ -97,8 +97,8 @@ As of the creation of the chart, it has no particularities and this section can 
 | agent-control-deployment.hostNetwork | bool | `false` | Sets pod's hostNetwork. Can be configured also with `global.hostNetwork` |
 | agent-control-deployment.image | object | See `values.yaml` | Image for the New Relic Agent Control |
 | agent-control-deployment.image.pullSecrets | list | `[]` | The secrets that are needed to pull images from a custom registry. |
-| agent-control-deployment.l1IdentityClientId | string | `""` | L1 identity client_id to use. |
-| agent-control-deployment.l1IdentityClientSecret | string | `""` | L1 identity client_secret to use. |
+| agent-control-deployment.identityClientId | string | `""` | L1 identity client_id to use. |
+| agent-control-deployment.identityClientSecret | string | `""` | L1 identity client_secret to use. |
 | agent-control-deployment.labels | object | `{}` | Additional labels for chart objects. Can be configured also with `global.labels` |
 | agent-control-deployment.licenseKey | string | `""` | This set this license key to use. Can be configured also with `global.licenseKey` |
 | agent-control-deployment.nodeSelector | object | `{}` | Sets pod's node selector. Can be configured also with `global.nodeSelector` |

--- a/charts/agent-control/README.md
+++ b/charts/agent-control/README.md
@@ -97,8 +97,8 @@ As of the creation of the chart, it has no particularities and this section can 
 | agent-control-deployment.hostNetwork | bool | `false` | Sets pod's hostNetwork. Can be configured also with `global.hostNetwork` |
 | agent-control-deployment.image | object | See `values.yaml` | Image for the New Relic Agent Control |
 | agent-control-deployment.image.pullSecrets | list | `[]` | The secrets that are needed to pull images from a custom registry. |
-| agent-control-deployment.identityClientId | string | `""` | L1 identity client_id to use. |
-| agent-control-deployment.identityClientSecret | string | `""` | L1 identity client_secret to use. |
+| agent-control-deployment.identityClientId | string | `""` | identity client_id to use. |
+| agent-control-deployment.identityClientSecret | string | `""` | identity client_secret to use. |
 | agent-control-deployment.labels | object | `{}` | Additional labels for chart objects. Can be configured also with `global.labels` |
 | agent-control-deployment.licenseKey | string | `""` | This set this license key to use. Can be configured also with `global.licenseKey` |
 | agent-control-deployment.nodeSelector | object | `{}` | Sets pod's node selector. Can be configured also with `global.nodeSelector` |

--- a/charts/agent-control/charts/agent-control-deployment/templates/_helpers.tpl
+++ b/charts/agent-control/charts/agent-control-deployment/templates/_helpers.tpl
@@ -290,22 +290,22 @@ value is provided, it defaults to `""` (empty string) so this helper can be used
 
 {{/* check if both L1 ClientID and ClientSecret are provided */}}
 {{- define "newrelic-agent-control.auth.l1Identity" -}}
-{{- if and (include "newrelic-agent-control.auth.l1IdentityClientId" .) (include "newrelic-agent-control.auth.l1IdentityClientSecret" .) -}}
+{{- if and (include "newrelic-agent-control.auth.identityClientId" .) (include "newrelic-agent-control.auth.identityClientSecret" .) -}}
     true
 {{- end -}}
 {{- end -}}
 
 {{/* return L1 ClientID */}}
-{{- define "newrelic-agent-control.auth.l1IdentityClientId" -}}
-{{- if .Values.l1IdentityClientId -}}
-  {{- .Values.l1IdentityClientId -}}
+{{- define "newrelic-agent-control.auth.identityClientId" -}}
+{{- if .Values.identityClientId -}}
+  {{- .Values.identityClientId -}}
 {{- end -}}
 {{- end -}}
 
 {{/* return L1 ClientSecret */}}
-{{- define "newrelic-agent-control.auth.l1IdentityClientSecret" -}}
-{{- if .Values.l1IdentityClientSecret -}}
-  {{- .Values.l1IdentityClientSecret -}}
+{{- define "newrelic-agent-control.auth.identityClientSecret" -}}
+{{- if .Values.identityClientSecret -}}
+  {{- .Values.identityClientSecret -}}
 {{- end -}}
 {{- end -}}
 
@@ -346,9 +346,9 @@ Return the name key for the ClientSecret Key inside the secret.
 {{/*
 Return the name of the secret holding the clientdId and ClientSecret
 */}}
-{{- define "newrelic-agent-control.auth.customl1IdentitySecretName" -}}
-{{- if .Values.customL1IdentitySecretName -}}
-  {{- .Values.customL1IdentitySecretName -}}
+{{- define "newrelic-agent-control.auth.customIdentitySecretName" -}}
+{{- if .Values.customIdentitySecretName -}}
+  {{- .Values.customIdentitySecretName -}}
 {{- end -}}
 {{- end -}}
 
@@ -356,8 +356,8 @@ Return the name of the secret holding the clientdId and ClientSecret
 Return the name key for the ClientID inside the secret.
 */}}
 {{- define "newrelic-agent-control.auth.identityCredentialsL1._customClientIdKey" -}}
-{{- if .Values.customL1IdentityClientIdSecretKey -}}
-  {{- .Values.customL1IdentityClientIdSecretKey -}}
+{{- if .Values.customIdentityClientIdSecretKey -}}
+  {{- .Values.customIdentityClientIdSecretKey -}}
 {{- end -}}
 {{- end -}}
 
@@ -365,8 +365,8 @@ Return the name key for the ClientID inside the secret.
 Return the name key for the ClientSecret inside the secret.
 */}}
 {{- define "newrelic-agent-control.auth.identityCredentialsL1._customClientSecretKey" -}}
-{{- if .Values.customL1IdentityClientSecretSecretKey -}}
-  {{- .Values.customL1IdentityClientSecretSecretKey -}}
+{{- if .Values.customIdentityClientSecretSecretKey -}}
+  {{- .Values.customIdentityClientSecretSecretKey -}}
 {{- end -}}
 {{- end -}}
 
@@ -378,7 +378,7 @@ Return the name key for the ClientSecret inside the secret.
 {{/* Return the custom secret name for the CliendId and ClientSecret with fallback to the generated one */}}
 {{- define "newrelic-agent-control.auth.identityCredentialsSecretName" -}}
 {{- $default := include "newrelic-agent-control.auth.generatedIdentityCredentialsSecretName" . -}}
-{{- include "newrelic-agent-control.auth.customl1IdentitySecretName" . | default $default -}}
+{{- include "newrelic-agent-control.auth.customIdentitySecretName" . | default $default -}}
 {{- end -}}
 
 {{- define "newrelic-agent-control.auth.generatedIdentityCredentialsSecretName" -}}

--- a/charts/agent-control/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml
+++ b/charts/agent-control/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml
@@ -7,8 +7,8 @@ once the installation hook is finished, so I have to add it as a hook.
 
 As both ways co-exist, we'll add a check to ensure at least one exits
 */ -}}
-{{- if and (not (include "newrelic.common.userKey._customSecretName" .)) (not (include "newrelic.common.userKey._userKey" .)) (not (include "newrelic-agent-control.auth.customl1IdentitySecretName" .)) (not (include "newrelic-agent-control.auth.l1Identity" .)) -}}
-  {{- fail "You must specify a userKey/customUserKeySecretName or l1Identity/customl1IdentitySecretName" -}}
+{{- if and (not (include "newrelic.common.userKey._customSecretName" .)) (not (include "newrelic.common.userKey._userKey" .)) (not (include "newrelic-agent-control.auth.customIdentitySecretName" .)) (not (include "newrelic-agent-control.auth.l1Identity" .)) -}}
+  {{- fail "You must specify a userKey/customUserKeySecretName or l1Identity/customIdentitySecretName" -}}
 {{- end -}}
 
 {{- if and (not (include "newrelic.common.userKey._customSecretName" .)) (include "newrelic.common.userKey._userKey" .) }}
@@ -29,7 +29,7 @@ data:
 {{- end }}
 
 {{/* L1/L2 Client Credentials */}}
-{{- if and (not (include "newrelic-agent-control.auth.customl1IdentitySecretName" .)) (include "newrelic-agent-control.auth.l1Identity" .) }}
+{{- if and (not (include "newrelic-agent-control.auth.customIdentitySecretName" .)) (include "newrelic-agent-control.auth.l1Identity" .) }}
 ---
 apiVersion: v1
 kind: Secret
@@ -43,8 +43,8 @@ metadata:
   name: {{ include "newrelic-agent-control.auth.generatedIdentityCredentialsSecretName" . }}
   namespace: {{ .Release.Namespace }}
 data:
-  {{ include "newrelic-agent-control.auth.l1IdentityCredentialsKey.clientIdKeyName" . }}: {{ include "newrelic-agent-control.auth.l1IdentityClientId" . | b64enc }}
-  {{ include "newrelic-agent-control.auth.l1IdentityCredentialsKey.clientSecretKeyName" . }}: {{ include "newrelic-agent-control.auth.l1IdentityClientSecret" . | b64enc }}
+  {{ include "newrelic-agent-control.auth.l1IdentityCredentialsKey.clientIdKeyName" . }}: {{ include "newrelic-agent-control.auth.identityClientId" . | b64enc }}
+  {{ include "newrelic-agent-control.auth.l1IdentityCredentialsKey.clientSecretKeyName" . }}: {{ include "newrelic-agent-control.auth.identityClientSecret" . | b64enc }}
 {{- end }}
 ---
 apiVersion: batch/v1
@@ -77,7 +77,7 @@ spec:
                   {{- end }}
                   key: {{ include "newrelic.common.userKey.secretKeyName" . }}
             {{- end }}
-            {{- if or (include "newrelic-agent-control.auth.customl1IdentitySecretName" .) (include "newrelic-agent-control.auth.l1Identity" .) }}
+            {{- if or (include "newrelic-agent-control.auth.customIdentitySecretName" .) (include "newrelic-agent-control.auth.l1Identity" .) }}
             - name: NEW_RELIC_AUTH_CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/charts/agent-control/charts/agent-control-deployment/tests/preinstall_job_test.yaml
+++ b/charts/agent-control/charts/agent-control-deployment/tests/preinstall_job_test.yaml
@@ -11,7 +11,7 @@ tests:
   - it: by default it fails with missing values
     asserts:
       - failedTemplate:
-          errorMessage: You must specify a userKey/customUserKeySecretName or l1Identity/customl1IdentitySecretName
+          errorMessage: You must specify a userKey/customUserKeySecretName or l1Identity/customIdentitySecretName
 
   - it: if userKey is set, it should fail with missing organization id
     set:
@@ -25,7 +25,7 @@ tests:
       identityCredentialsL1: {}
     asserts:
       - failedTemplate:
-          errorMessage: You must specify a userKey/customUserKeySecretName or l1Identity/customl1IdentitySecretName
+          errorMessage: You must specify a userKey/customUserKeySecretName or l1Identity/customIdentitySecretName
 
   - it: if identityCredentialsL1 is set but any fields empty, it should fail
     set:
@@ -34,7 +34,7 @@ tests:
         clientSecret: ""
     asserts:
       - failedTemplate:
-          errorMessage: You must specify a userKey/customUserKeySecretName or l1Identity/customl1IdentitySecretName
+          errorMessage: You must specify a userKey/customUserKeySecretName or l1Identity/customIdentitySecretName
 
   - it: if identityCredentialsL1 is set but any fields empty, it should fail
     set:
@@ -43,7 +43,7 @@ tests:
         clientSecret: "test"
     asserts:
       - failedTemplate:
-          errorMessage: You must specify a userKey/customUserKeySecretName or l1Identity/customl1IdentitySecretName
+          errorMessage: You must specify a userKey/customUserKeySecretName or l1Identity/customIdentitySecretName
 
   - it: if organizationId is set, it should fail with missing userKey
     set:
@@ -53,7 +53,7 @@ tests:
             organizationId: test
     asserts:
       - failedTemplate:
-          errorMessage: You must specify a userKey/customUserKeySecretName or l1Identity/customl1IdentitySecretName
+          errorMessage: You must specify a userKey/customUserKeySecretName or l1Identity/customIdentitySecretName
 
   - it: with legacy userKey set, the job should template correctly.
     set:
@@ -80,8 +80,8 @@ tests:
 
   - it: with identityCredentialsL1 set, the job should template correctly.
     set:
-      l1IdentityClientId: test
-      l1IdentityClientSecret: test
+      identityClientId: test
+      identityClientSecret: test
       config:
         fleet_control:
           auth:
@@ -133,9 +133,9 @@ tests:
 
   - it: with a custom secret for clientId and clientSecret, the secret should not be created.
     set:
-      customL1IdentitySecretName: test-client-name
-      customL1IdentityClientIdSecretKey: test-client-id-key
-      customL1IdentityClientSecretSecretKey: test-client-secret-key
+      customIdentitySecretName: test-client-name
+      customIdentityClientIdSecretKey: test-client-id-key
+      customIdentityClientSecretSecretKey: test-client-secret-key
       config:
         fleet_control:
           auth:
@@ -165,9 +165,9 @@ tests:
     set:
       customUserKeySecretName: test-secret
       customUserKeySecretKey: test-key
-      customL1IdentitySecretName: test-client-name
-      customL1IdentityClientIdSecretKey: test-client-id-key
-      customL1IdentityClientSecretSecretKey: test-client-secret-key
+      customIdentitySecretName: test-client-name
+      customIdentityClientIdSecretKey: test-client-id-key
+      customIdentityClientSecretSecretKey: test-client-secret-key
       config:
         fleet_control:
           auth:

--- a/charts/agent-control/values.yaml
+++ b/charts/agent-control/values.yaml
@@ -21,14 +21,14 @@ agent-control-deployment:
   # -- In case you don't want to have the license key in you values, this allows you to point to which secret key is the license key located. Can be configured also with `global.customSecretLicenseKey`
   customSecretLicenseKey: ""
 
-  # -- L1 identity client_id to use.
-  l1IdentityClientId: ""
-  # -- L1 identity client_secret to use.
-  l1IdentityClientSecret: ""
+  # -- Identity client_id to use.
+  identityClientId: ""
+  # -- Identity client_secret to use.
+  identityClientSecret: ""
   # -- In case you don't want to have the client_id and client_secret in your values, this allows you to point to a user created secret to get the key from there.
-  customL1IdentitySecretName: ""
-  customL1IdentityClientIdSecretKey: ""
-  customL1IdentityClientSecretSecretKey: ""
+  customIdentitySecretName: ""
+  customIdentityClientIdSecretKey: ""
+  customIdentityClientSecretSecretKey: ""
 
   # -- Image for the New Relic Agent Control
   # @default -- See `values.yaml`
@@ -163,24 +163,25 @@ agent-control-deployment:
           # will have.
           # @default -- release name suffixed with "-auth"
           name:
+          ## If private_key and client_id values are specified, their creation is disabled and the `preinstall-user-key` job is not executed
           private_key:
             # -- Key inside the secret containing the private key.
             # @default -- `private_key`
             secret_key:
-            # -- In case `.config.auth.secret.create` is true, you can set these keys to set private key directly as base64.
+            # -- In case `.config.auth.secret.create` is true, you can set these keys to set private key directly as base64 if you want to skip its creation.
             # This options is mutually exclusive with `plain_pem`.
             base64_pem:
-            # -- In case `.config.auth.secret.create` is true, you can set these keys to set private key directly as plain text.
+            # -- In case `.config.auth.secret.create` is true, you can set these keys to set private key directly as plain text if you want to skip its creation.
             # This options is mutually exclusive with `base64_pem`.
             plain_pem:
           client_id:
             # -- Key inside the secret containing the client ID.
             # @default -- `client_id`
             secret_key:
-            # -- In case `.config.auth.secret.create` is true, you can set these keys to set client ID directly as base64.
+            # -- In case `.config.auth.secret.create` is true, you can set these keys to set client ID directly as base64 if you want to skip its creation.
             # This options is mutually exclusive with `plain`.
             base64:
-            # -- In case `.config.auth.secret.create` is true, you can set these keys to set client ID directly as plain text.
+            # -- In case `.config.auth.secret.create` is true, you can set these keys to set client ID directly as plain text if you want to skip its creation.
             # This options is mutually exclusive with `base64`.
             plain:
 


### PR DESCRIPTION
#### Is this a new chart
no
#### What this PR does / why we need it:
removing the L1 info from the values name

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
