### PR TITLE
[agent-control] set backoffLimit to pre-install job

### DIFF
--- a/charts/agent-control/Chart.lock
+++ b/charts/agent-control/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 2.13.0
 - name: agent-control-deployment
   repository: ""
-  version: 0.0.35-beta
+  version: 0.0.36-beta
 - name: common-library
   repository: https://helm-charts.newrelic.com
   version: 1.3.0
-digest: sha256:520e65faba269be5084966194bf4681899b59399d4442999a71a4898a10af173
-generated: "2025-01-08T14:32:09.044891+01:00"
+digest: sha256:05dd74f8089facc925bbd9a917dc258153b40e4f223f11e22ec7b2a75e62cd11
+generated: "2025-01-21T16:24:19.02098+01:00"

--- a/charts/agent-control/Chart.yaml
+++ b/charts/agent-control/Chart.yaml
@@ -3,7 +3,7 @@ name: agent-control
 description: Bootstraps New Relic' Agent Control
 
 type: application
-version: 0.0.37-beta
+version: 0.0.38-beta
 
 dependencies:
   - name: flux2
@@ -11,7 +11,7 @@ dependencies:
     version: 2.13.0
     condition: flux2.enabled
   - name: agent-control-deployment
-    version: 0.0.35-beta
+    version: 0.0.36-beta
     condition: agent-control-deployment.enabled
     # The following dependency is needed as sub-dependency of agent-control-deployment
   - name: common-library

--- a/charts/agent-control/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control/charts/agent-control-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 
 type: application
 
-version: 0.0.35-beta
+version: 0.0.36-beta
 
 keywords:
   - newrelic

--- a/charts/agent-control/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml
+++ b/charts/agent-control/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml
@@ -58,6 +58,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   ttlSecondsAfterFinished: 120
+  backoffLimit: 3
   template:
     spec:
       restartPolicy: Never


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR sets a backoffLimit for the agent-control installation job lower than the default in order to improve troubleshooting.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
