### PR TITLE
[agent-control] build: use specific system identity registration image

### DIFF
--- a/charts/agent-control/Chart.lock
+++ b/charts/agent-control/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 2.13.0
 - name: agent-control-deployment
   repository: ""
-  version: 0.0.36-beta
+  version: 0.0.37-beta
 - name: common-library
   repository: https://helm-charts.newrelic.com
   version: 1.3.0
-digest: sha256:05dd74f8089facc925bbd9a917dc258153b40e4f223f11e22ec7b2a75e62cd11
-generated: "2025-01-21T16:24:19.02098+01:00"
+digest: sha256:7693e33da6495ec8e8ad67d41db7d9adf9c7ad4bdb21aefb3fb36c1353c003dd
+generated: "2025-01-30T16:54:28.395151Z"

--- a/charts/agent-control/Chart.yaml
+++ b/charts/agent-control/Chart.yaml
@@ -3,7 +3,7 @@ name: agent-control
 description: Bootstraps New Relic' Agent Control
 
 type: application
-version: 0.0.40-beta
+version: 0.0.41-beta
 
 dependencies:
   - name: flux2
@@ -11,7 +11,7 @@ dependencies:
     version: 2.13.0
     condition: flux2.enabled
   - name: agent-control-deployment
-    version: 0.0.36-beta
+    version: 0.0.37-beta
     condition: agent-control-deployment.enabled
     # The following dependency is needed as sub-dependency of agent-control-deployment
   - name: common-library

--- a/charts/agent-control/README.md
+++ b/charts/agent-control/README.md
@@ -112,6 +112,7 @@ As of the creation of the chart, it has no particularities and this section can 
 | agent-control-deployment.resources | object | `{}` | Resource limits to be added to all pods created by the integration. |
 | agent-control-deployment.serviceAccount | object | See `values.yaml` | Settings controlling ServiceAccount creation. |
 | agent-control-deployment.serviceAccount.create | bool | `true` | Whether the chart should automatically create the ServiceAccount objects required to run. |
+| agent-control-deployment.systemIdentityRegistration | object | See `values.yaml` | Image for the system identity registration process |
 | agent-control-deployment.tolerations | list | `[]` | Sets pod's tolerations to node taints. Can be configured also with `global.tolerations` |
 | agent-control-deployment.verboseLog | bool | `false` | Sets the debug logs to this integration or all integrations if it is set globally. Can be configured also with `global.verboseLog` |
 | flux2 | object | See `values.yaml` | Values for the Flux chat. Ref.: https://github.com/fluxcd-community/helm-charts/blob/flux2-2.10.2/charts/flux2/values.yaml |

--- a/charts/agent-control/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control/charts/agent-control-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 
 type: application
 
-version: 0.0.36-beta
+version: 0.0.37-beta
 
 keywords:
   - newrelic

--- a/charts/agent-control/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml
+++ b/charts/agent-control/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml
@@ -65,7 +65,7 @@ spec:
       serviceAccountName: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.serviceAccount.name" .) "suffix" "auth" ) }}
       containers:
         - name: register-system-identity
-          image: newrelic/agent-control-system-identity-registration:latest
+          image: "{{ (.Values.systemIdentityRegistration.image).repository | default "newrelic/agent-control-system-identity-registration" }}:{{ (.Values.systemIdentityRegistration.image).tag | default "latest" }}"
           env:
             {{- if or  (include "newrelic.common.userKey._customSecretName" .) (include "newrelic.common.userKey._userKey" .) }}
             - name: USER_KEY

--- a/charts/agent-control/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml
+++ b/charts/agent-control/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml
@@ -65,7 +65,7 @@ spec:
       serviceAccountName: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.serviceAccount.name" .) "suffix" "auth" ) }}
       containers:
         - name: register-system-identity
-          image: alpine
+          image: newrelic/agent-control-system-identity-registration:latest
           env:
             {{- if or  (include "newrelic.common.userKey._customSecretName" .) (include "newrelic.common.userKey._userKey" .) }}
             - name: USER_KEY
@@ -96,8 +96,6 @@ spec:
             - -c
             - |
               set -euo pipefail
-              apk update
-              apk add kubectl
 
               echo Checking if the secret '{{ include "newrelic-agent-control.auth.secret.name" . }}' is already present in the cluster
               if kubectl get secret {{ include "newrelic-agent-control.auth.secret.name" . }}; then
@@ -106,7 +104,6 @@ spec:
               fi
 
               echo Generating the Keys...
-              apk add curl jq openssl
               TEMPORAL_FOLDER=gen-folder
               mkdir $TEMPORAL_FOLDER
               openssl genrsa -out "$TEMPORAL_FOLDER/key" 4096

--- a/charts/agent-control/charts/agent-control-deployment/tests/preinstall_job_test.yaml
+++ b/charts/agent-control/charts/agent-control-deployment/tests/preinstall_job_test.yaml
@@ -197,3 +197,69 @@ tests:
                 secretKeyRef:
                   key: test-client-secret-key
                   name: test-client-name
+
+  - it: without specific image for system identity registration, uses the one provided by default
+    set:
+      customUserKeySecretName: test-secret
+      customUserKeySecretKey: test-key
+      config:
+        fleet_control:
+          auth:
+            organizationId: test
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: newrelic/agent-control-system-identity-registration:latest
+
+  - it: setting specific image for system identity registration but no tag should use the default tag
+    set:
+      customUserKeySecretName: test-secret
+      customUserKeySecretKey: test-key
+      config:
+        fleet_control:
+          auth:
+            organizationId: test
+      systemIdentityRegistration:
+        image:
+          repository: some_namespace/test-image
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: some_namespace/test-image:latest
+
+  - it: setting specific image for system identity registration with tag should use the provided tag
+    set:
+      customUserKeySecretName: test-secret
+      customUserKeySecretKey: test-key
+      config:
+        fleet_control:
+          auth:
+            organizationId: test
+      systemIdentityRegistration:
+        image:
+          tag: 1.0.0
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: newrelic/agent-control-system-identity-registration:1.0.0
+
+  - it: setting specific image for system identity registration with tag should use the provided data
+    set:
+      customUserKeySecretName: test-secret
+      customUserKeySecretKey: test-key
+      config:
+        fleet_control:
+          auth:
+            organizationId: test
+      systemIdentityRegistration:
+        image:
+          repository: some_namespace/test-image
+          tag: 1.0.0
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: some_namespace/test-image:1.0.0

--- a/charts/agent-control/values.yaml
+++ b/charts/agent-control/values.yaml
@@ -185,6 +185,14 @@ agent-control-deployment:
             # This options is mutually exclusive with `base64`.
             plain:
 
+  # -- Image for the system identity registration process
+  # @default -- See `values.yaml`
+  systemIdentityRegistration:
+    image:
+      repository: newrelic/nri-system-identity-registration
+      tag: "latest"
+      imagePullPolicy: IfNotPresent
+
 # -- Values for the Flux chat. Ref.: https://github.com/fluxcd-community/helm-charts/blob/flux2-2.10.2/charts/flux2/values.yaml
 # @default -- See `values.yaml`
 flux2:

--- a/charts/agent-control/values.yaml
+++ b/charts/agent-control/values.yaml
@@ -189,8 +189,8 @@ agent-control-deployment:
   # @default -- See `values.yaml`
   systemIdentityRegistration:
     image:
-      repository: newrelic/nri-system-identity-registration
-      tag: "latest"
+      repository: newrelic/agent-control-system-identity-registration
+      tag: latest
       imagePullPolicy: IfNotPresent
 
 # -- Values for the Flux chat. Ref.: https://github.com/fluxcd-community/helm-charts/blob/flux2-2.10.2/charts/flux2/values.yaml


### PR DESCRIPTION
#### What this PR does / why we need it:

Uses a dedicated image for the system identity registration step for Agent Control deployments.

#### Which issue this PR fixes
https://new-relic.atlassian.net/browse/NR-362687

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
