### PR TITLE
[NRI-Bundle] Bumping eBPF Agent.

### DIFF
--- a/charts/nri-bundle/Chart.lock
+++ b/charts/nri-bundle/Chart.lock
@@ -28,7 +28,7 @@ dependencies:
   version: 2.1.6
 - name: nr-ebpf-agent
   repository: https://newrelic.github.io/helm-charts
-  version: 0.1.15
+  version: 0.1.17
 - name: k8s-agents-operator
   repository: https://newrelic.github.io/k8s-agents-operator
   version: 0.20.1
@@ -38,5 +38,5 @@ dependencies:
 - name: newrelic-infra-operator
   repository: https://newrelic.github.io/newrelic-infra-operator
   version: 2.13.5
-digest: sha256:e10196059a0afb5596f8b59129bce70abbaec86e2888b576d47db0ffca56c355
-generated: "2025-01-30T16:44:28.101731032Z"
+digest: sha256:6576f28bea1eca934b491e8f42280a8ae1eef468003abc747f925fc84fba7271
+generated: "2025-01-31T11:29:07.338916-08:00"

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -67,7 +67,7 @@ dependencies:
     version: 2.1.6
 
   - name: nr-ebpf-agent
-    version: 0.1.15
+    version: 0.1.17
     condition: newrelic-eapm-agent.enabled
     repository: https://newrelic.github.io/helm-charts
 

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -18,7 +18,7 @@ sources:
   - https://github.com/newrelic/newrelic-infra-operator/tree/master/charts/newrelic-infra-operator
   - https://github.com/newrelic/k8s-agents-operator/tree/master/charts/k8s-agents-operator
 
-version: 5.0.109
+version: 5.0.110
 
 dependencies:
   - name: newrelic-infrastructure


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No. 

#### What this PR does / why we need it:
It bumps the version of the eBPF agent. 
Fixes a bug where helm installs that are not named "nr-ebpf-agent" brick the eBPF Agent. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
