### PR TITLE
[nr-ebpf-agent] Stop using host network for Otel Collector

### DIFF
--- a/charts/nr-ebpf-agent/Chart.yaml
+++ b/charts/nr-ebpf-agent/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.18
+version: 0.1.19
 
 dependencies:
   - name: common-library

--- a/charts/nr-ebpf-agent/templates/otel-collector-daemonset.yaml
+++ b/charts/nr-ebpf-agent/templates/otel-collector-daemonset.yaml
@@ -45,6 +45,22 @@ spec:
         image: {{ .Values.otelCollector.image.repository }}:{{ .Values.otelCollector.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.otelCollector.image.pullPolicy }}
         resources: {{- toYaml .Values.otelCollector.resources | nindent 10}}
+        ports:
+          - name: otlp
+            containerPort: 4317
+            protocol: TCP
+        volumeMounts:
+          - name: data
+            mountPath: /etc/otel/config.yaml
+            subPath: config.yaml
+            readOnly: true
+          {{- if (hasKey .Values "tls") }}
+          {{- if eq .Values.tls.enabled true }}
+          - name: cert
+            mountPath: "{{ .Values.tls.autoGenerateCert.certPath }}"
+            readOnly: true
+          {{- end }}
+          {{- end }}
         env:
           - name: KUBE_NODE_NAME
             valueFrom:
@@ -87,22 +103,9 @@ spec:
             value: "{{- .Values.dropDataServiceNameRegex }}"
           - name: ALLOW_SERVICE_NAME_REGEX
             value: "{{- .Values.allowServiceNameRegex }}"
-        ports:
-        - containerPort: 4317
-        volumeMounts:
-          - name: data
-            mountPath: /etc/otel/config.yaml
-            subPath: config.yaml
-            readOnly: true
-          {{- if (hasKey .Values "tls") }}
-          {{- if eq .Values.tls.enabled true }}
-          - name: cert
-            mountPath: "{{ .Values.tls.autoGenerateCert.certPath }}"
-            readOnly: true
-          {{- end }}
-          {{- end }}
-      dnsPolicy: ClusterFirstWithHostNet
-      hostNetwork: true
+
+      dnsPolicy: Default
+      hostNetwork: false
       serviceAccountName: {{ include "nr-ebpf-agent.collector.name" . }}
       terminationGracePeriodSeconds: 30
       volumes:


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No. 
#### What this PR does / why we need it:
Stops us from using the config option `hostNetwork: true` for the otel collector.
This config binds the otel collector's network to the network of the host. 
One byproduct of this is that the port's uses are the same ports of the host. 

By default this is not the case. Ports on a container can bind to any open port on the host. 
However with this option it binds strictly to the same host port. 

This causes an issue if other containers on the node are trying to bind the the same port. 
This is known as a "port conflict" and will only allow one container to bind to the port, leaving the other container in a bad state. 

By decoupling the collector's networking from the host, our otel collector can choose any free port instead of being bound to a specific one. This reduces the likelihood that there will be a port conflict with our project. 
Note however that since the ebpf agent might actually need to be bound to the host's network for traffic scraping, I have not touched its config. 

## Brief description of changes. 
Set `hostNetwork` to `false` for the otel collector. See ^ for more details. 

Moved the networking/volume bind section of the container spec to above the env section for readability. 

##### How did you test/verify this change?
Ran a cluster with a test application and the ebpf agent. 
Scaffolded on my changes. 
To ensure that this was actually resolving port conflicts I added a container to my cluster. 
This additional container used port `4317` and is using the hostNetwork. 
This would cause a port conflict if we were still using the host network due to both the otel collector and this new service using port 4317. But both services came up without issue. 

##### Extra container config 
<img width="438" alt="Screenshot 2025-02-05 at 5 47 55 PM" src="https://github.com/user-attachments/assets/252d54be-ac29-4fdb-b24f-890fa69e365e" />

##### Extra container seems fine. 
<img width="898" alt="Screenshot 2025-02-05 at 5 44 00 PM" src="https://github.com/user-attachments/assets/8497ad9e-43ee-485c-96b5-c9844fb20b93" />

##### Otel Collector came up without issue
<img width="1599" alt="Screenshot 2025-02-05 at 5 44 39 PM" src="https://github.com/user-attachments/assets/383da7e0-47f4-4264-a380-f598ce6cf9a3" />


##### Data reaches NRDB
<img width="1076" alt="Screenshot 2025-02-05 at 5 46 16 PM" src="https://github.com/user-attachments/assets/d8d7a883-7f85-4add-a630-7cf1b30df0fb" />

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
