### PR TITLE
[agent-control]: remove opamp license-key header [NR-361577]

### DIFF
--- a/charts/agent-control/Chart.lock
+++ b/charts/agent-control/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 2.14.1
 - name: agent-control-deployment
   repository: ""
-  version: 0.0.40-beta
+  version: 0.0.41-beta
 - name: common-library
   repository: https://helm-charts.newrelic.com
   version: 1.3.1
-digest: sha256:81728940ef40bb132f63a5beb9f419397a370191fdd3025332bf819c2159443c
-generated: "2025-02-17T10:50:05.543595+01:00"
+digest: sha256:3e476e8aba7feb6d67f817851a0c77bd6903fdaeb40e1657706e0834902fa164
+generated: "2025-02-20T08:12:30.689804+01:00"

--- a/charts/agent-control/Chart.yaml
+++ b/charts/agent-control/Chart.yaml
@@ -3,7 +3,7 @@ name: agent-control
 description: Bootstraps New Relic' Agent Control
 
 type: application
-version: 0.0.49-beta
+version: 0.0.50-beta
 
 dependencies:
   - name: flux2
@@ -11,7 +11,7 @@ dependencies:
     version: 2.14.1
     condition: flux2.enabled
   - name: agent-control-deployment
-    version: 0.0.40-beta
+    version: 0.0.41-beta
     condition: agent-control-deployment.enabled
     # The following dependency is needed as sub-dependency of agent-control-deployment
   - name: common-library

--- a/charts/agent-control/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control/charts/agent-control-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 
 type: application
 
-version: 0.0.40-beta
+version: 0.0.41-beta
 
 keywords:
   - newrelic

--- a/charts/agent-control/charts/agent-control-deployment/templates/deployment-agentcontrol.yaml
+++ b/charts/agent-control/charts/agent-control-deployment/templates/deployment-agentcontrol.yaml
@@ -70,11 +70,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "newrelic-agent-control.auth.secret.name" . }}
                   key: {{ include "newrelic-agent-control.auth.secret.clientId.key" . }}
-            - name: NR_AC_FLEET_CONTROL__HEADERS__API-KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "newrelic.common.license.secretName" . }}
-                  key: {{ include "newrelic.common.license.secretKeyName" . }}
           {{- end }}
           {{- if include "newrelic.common.verboseLog" . }}
             - name: NR_AC_LOG__LEVEL

--- a/charts/agent-control/charts/agent-control-deployment/tests/deployment_agentcontrol_env_test.yaml
+++ b/charts/agent-control/charts/agent-control-deployment/tests/deployment_agentcontrol_env_test.yaml
@@ -39,48 +39,6 @@ tests:
                 name: custom-secret
         template: templates/deployment-agentcontrol.yaml
 
-  - it: api-key config gets added as env var from secret
-    set:
-      cluster: test
-      licenseKey: fake-license
-      config:
-        agentControl:
-          content:
-            fleet_control:
-              endpoint: test
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: NR_AC_FLEET_CONTROL__HEADERS__API-KEY
-            valueFrom:
-              secretKeyRef:
-                key: licenseKey
-                name: agent-control-license
-        template: templates/deployment-agentcontrol.yaml
-
-  - it: api-key config gets added as env var from custom secret
-    set:
-      cluster: test
-      customSecretName: "custom-secret"
-      customSecretLicenseKey: "custom-key"
-      region: us # With a custom secret we cannot know the region so we have to ask for it.
-      config:
-        agentControl:
-          content:
-            fleet_control:
-              endpoint: test
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: NR_AC_FLEET_CONTROL__HEADERS__API-KEY
-            valueFrom:
-              secretKeyRef:
-                key: custom-key
-                name: custom-secret
-        template: templates/deployment-agentcontrol.yaml
-
   - it: cluster name added as env var
     set:
       cluster: test


### PR DESCRIPTION

#### What this PR does / why we need it:

This PR removes the environment variable used to set up the license-key header in OpAMP communication

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
