### PR TITLE
[agent-control] drop unused permission

### DIFF
--- a/charts/agent-control/Chart.lock
+++ b/charts/agent-control/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 2.14.1
 - name: agent-control-deployment
   repository: ""
-  version: 0.0.41-beta
+  version: 0.0.42-beta
 - name: common-library
   repository: https://helm-charts.newrelic.com
   version: 1.3.1
-digest: sha256:3e476e8aba7feb6d67f817851a0c77bd6903fdaeb40e1657706e0834902fa164
-generated: "2025-02-20T08:12:30.689804+01:00"
+digest: sha256:af3a56b5b32d661139441f50887c99a69ad3cf4c32e393b1cec71e38c257fcdf
+generated: "2025-02-27T12:26:06.411355+01:00"

--- a/charts/agent-control/Chart.yaml
+++ b/charts/agent-control/Chart.yaml
@@ -3,7 +3,7 @@ name: agent-control
 description: Bootstraps New Relic' Agent Control
 
 type: application
-version: 0.0.51-beta
+version: 0.0.52-beta
 
 dependencies:
   - name: flux2
@@ -11,7 +11,7 @@ dependencies:
     version: 2.14.1
     condition: flux2.enabled
   - name: agent-control-deployment
-    version: 0.0.41-beta
+    version: 0.0.42-beta
     condition: agent-control-deployment.enabled
     # The following dependency is needed as sub-dependency of agent-control-deployment
   - name: common-library

--- a/charts/agent-control/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control/charts/agent-control-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 
 type: application
 
-version: 0.0.41-beta
+version: 0.0.42-beta
 
 keywords:
   - newrelic

--- a/charts/agent-control/charts/agent-control-deployment/templates/rbac.yaml
+++ b/charts/agent-control/charts/agent-control-deployment/templates/rbac.yaml
@@ -25,7 +25,6 @@ rules:
     resources:
       - deployments
       - daemonsets
-      - replicasets
       - statefulsets
     verbs:
       - get


### PR DESCRIPTION

#### Is this a new chart
no
#### What this PR does / why we need it:
drops a permission that is not needed anymore
This is blocked till [this](https://github.com/newrelic/newrelic-agent-control/pull/1086) is merged and released 


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
