### PR TITLE
fix: fixed test cases and empty cluster name

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.25.0
+version: 1.25.1
 appVersion: 2.2.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg

--- a/charts/newrelic-logging/templates/_helpers.tpl
+++ b/charts/newrelic-logging/templates/_helpers.tpl
@@ -205,7 +205,12 @@ Returns fluentbit config to collect and forward its metrics to New Relic
     add_label            source kubernetes
     add_label            pod_name ${HOSTNAME}
     add_label            node_name ${NODE_NAME}
-    {{- printf "add_label            cluster_name %s" (include "newrelic-logging.cluster" .) | nindent 4 -}}
+    {{- $clusterName := (include "newrelic-logging.cluster" .) -}}
+    {{- if $clusterName -}}
+    {{- printf "add_label            cluster_name %s" $clusterName | nindent 4 -}}
+    {{- else -}}
+    {{- printf "add_label            cluster_name \"%s\"" $clusterName | nindent 4 -}}
+    {{- end -}}
     {{- printf "add_label            namespace %s" .Release.Namespace | nindent 4 -}}
     {{- printf "add_label            daemonset_name %s" (include "newrelic-logging.fullname" .) | nindent 4 -}}
 {{- end -}}

--- a/charts/newrelic-logging/tests/fluentbit_monitoring_config_test.yaml
+++ b/charts/newrelic-logging/tests/fluentbit_monitoring_config_test.yaml
@@ -5,10 +5,17 @@ release:
   name: my-release
   namespace: my-namespace
 tests:
-  - it: "additional labels for entity synthesis are included by default"
-    templates:
-      - templates/configmap.yaml
+  - it: "additional labels for entity synthesis are included by default with cluster name empty"
+    set:
+      cluster: ""
     asserts:
       - matchRegex:
           path: data["fluent-bit.conf"]
-          pattern: (?s)add_label\s+cluster_name \n\s*add_label\s+namespace my-namespace\n\s*add_label\s+daemonset_name my-release-newrelic-logging
+          pattern: (?s)add_label\s+cluster_name \"\"\n\s*add_label\s+namespace my-namespace\n\s*add_label\s+daemonset_name my-release-newrelic-logging
+  - it: "additional labels for entity synthesis are included by default when cluster name is set"
+    set:
+      cluster: my-cluster
+    asserts:
+      - matchRegex:
+          path: data["fluent-bit.conf"]
+          pattern: (?s)add_label\s+cluster_name my-cluster\n\s*add_label\s+namespace my-namespace\n\s*add_label\s+daemonset_name my-release-newrelic-logging

--- a/charts/newrelic-logging/tests/fluentbit_monitoring_config_test.yaml
+++ b/charts/newrelic-logging/tests/fluentbit_monitoring_config_test.yaml
@@ -5,19 +5,21 @@ release:
   name: my-release
   namespace: my-namespace
 tests:
-  - it: "additional labels for entity synthesis are included by default with cluster name empty"
+  - it: "includes additional labels with cluster name empty"
     set:
       cluster: ""
     asserts:
       - matchRegex:
           path: data["fluent-bit.conf"]
           pattern: (?s)add_label\s+cluster_name \"\"\n\s*add_label\s+namespace my-namespace\n\s*add_label\s+daemonset_name my-release-newrelic-logging
-  - it: "additional labels for entity synthesis are included by default with cluster name null"
+
+  - it: "includes additional labels with cluster name null"
     asserts:
       - matchRegex:
           path: data["fluent-bit.conf"]
           pattern: (?s)add_label\s+cluster_name \"\"\n\s*add_label\s+namespace my-namespace\n\s*add_label\s+daemonset_name my-release-newrelic-logging
-  - it: "additional labels for entity synthesis are included by default with cluster name  setting null"
+
+  - it: "includes additional labels with cluster name setting null"
     set:
       cluster: 
     asserts:
@@ -25,7 +27,7 @@ tests:
           path: data["fluent-bit.conf"]
           pattern: (?s)add_label\s+cluster_name \"\"\n\s*add_label\s+namespace my-namespace\n\s*add_label\s+daemonset_name my-release-newrelic-logging
 
-  - it: "additional labels for entity synthesis are included by default when cluster name is set"
+  - it: "includes additional labels when cluster name is set"
     set:
       cluster: my-cluster
     asserts:

--- a/charts/newrelic-logging/tests/fluentbit_monitoring_config_test.yaml
+++ b/charts/newrelic-logging/tests/fluentbit_monitoring_config_test.yaml
@@ -13,8 +13,6 @@ tests:
           path: data["fluent-bit.conf"]
           pattern: (?s)add_label\s+cluster_name \"\"\n\s*add_label\s+namespace my-namespace\n\s*add_label\s+daemonset_name my-release-newrelic-logging
   - it: "additional labels for entity synthesis are included by default with cluster name null"
-    set:
-      cluster: 
     asserts:
       - matchRegex:
           path: data["fluent-bit.conf"]

--- a/charts/newrelic-logging/tests/fluentbit_monitoring_config_test.yaml
+++ b/charts/newrelic-logging/tests/fluentbit_monitoring_config_test.yaml
@@ -26,7 +26,13 @@ tests:
       - matchRegex:
           path: data["fluent-bit.conf"]
           pattern: (?s)add_label\s+cluster_name \"\"\n\s*add_label\s+namespace my-namespace\n\s*add_label\s+daemonset_name my-release-newrelic-logging
-
+  - it: "includes additional labels with cluster name setting null value"
+    set:
+      cluster: null
+    asserts:
+      - matchRegex:
+          path: data["fluent-bit.conf"]
+          pattern: (?s)add_label\s+cluster_name \"\"\n\s*add_label\s+namespace my-namespace\n\s*add_label\s+daemonset_name my-release-newrelic-logging
   - it: "includes additional labels when cluster name is set"
     set:
       cluster: my-cluster

--- a/charts/newrelic-logging/tests/fluentbit_monitoring_config_test.yaml
+++ b/charts/newrelic-logging/tests/fluentbit_monitoring_config_test.yaml
@@ -12,13 +12,18 @@ tests:
       - matchRegex:
           path: data["fluent-bit.conf"]
           pattern: (?s)add_label\s+cluster_name \"\"\n\s*add_label\s+namespace my-namespace\n\s*add_label\s+daemonset_name my-release-newrelic-logging
-
+  - it: "includes additional labels with cluster name empty with single quote"
+    set:
+      cluster: ''
+    asserts:
+      - matchRegex:
+          path: data["fluent-bit.conf"]
+          pattern: (?s)add_label\s+cluster_name \"\"\n\s*add_label\s+namespace my-namespace\n\s*add_label\s+daemonset_name my-release-newrelic-logging
   - it: "includes additional labels with cluster name null"
     asserts:
       - matchRegex:
           path: data["fluent-bit.conf"]
           pattern: (?s)add_label\s+cluster_name \"\"\n\s*add_label\s+namespace my-namespace\n\s*add_label\s+daemonset_name my-release-newrelic-logging
-
   - it: "includes additional labels with cluster name setting null"
     set:
       cluster: 
@@ -40,3 +45,10 @@ tests:
       - matchRegex:
           path: data["fluent-bit.conf"]
           pattern: (?s)add_label\s+cluster_name my-cluster\n\s*add_label\s+namespace my-namespace\n\s*add_label\s+daemonset_name my-release-newrelic-logging
+  - it: "includes additional labels when cluster name is set with double quotes"
+    set:
+      cluster: "my-cluster"
+    asserts:
+      - matchRegex:
+          path: data["fluent-bit.conf"]
+          pattern: (?s)add_label\s+cluster_name my-cluster\n\s*add_label\s+namespace my-namespace\n\s*add_label\s+daemonset_name my-release-newrelic-logging          

--- a/charts/newrelic-logging/tests/fluentbit_monitoring_config_test.yaml
+++ b/charts/newrelic-logging/tests/fluentbit_monitoring_config_test.yaml
@@ -17,6 +17,13 @@ tests:
       - matchRegex:
           path: data["fluent-bit.conf"]
           pattern: (?s)add_label\s+cluster_name \"\"\n\s*add_label\s+namespace my-namespace\n\s*add_label\s+daemonset_name my-release-newrelic-logging
+  - it: "additional labels for entity synthesis are included by default with cluster name  setting null"
+    set:
+      cluster: 
+    asserts:
+      - matchRegex:
+          path: data["fluent-bit.conf"]
+          pattern: (?s)add_label\s+cluster_name \"\"\n\s*add_label\s+namespace my-namespace\n\s*add_label\s+daemonset_name my-release-newrelic-logging
 
   - it: "additional labels for entity synthesis are included by default when cluster name is set"
     set:

--- a/charts/newrelic-logging/tests/fluentbit_monitoring_config_test.yaml
+++ b/charts/newrelic-logging/tests/fluentbit_monitoring_config_test.yaml
@@ -12,6 +12,14 @@ tests:
       - matchRegex:
           path: data["fluent-bit.conf"]
           pattern: (?s)add_label\s+cluster_name \"\"\n\s*add_label\s+namespace my-namespace\n\s*add_label\s+daemonset_name my-release-newrelic-logging
+  - it: "additional labels for entity synthesis are included by default with cluster name null"
+    set:
+      cluster: 
+    asserts:
+      - matchRegex:
+          path: data["fluent-bit.conf"]
+          pattern: (?s)add_label\s+cluster_name \"\"\n\s*add_label\s+namespace my-namespace\n\s*add_label\s+daemonset_name my-release-newrelic-logging
+
   - it: "additional labels for entity synthesis are included by default when cluster name is set"
     set:
       cluster: my-cluster

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -3,6 +3,7 @@
 #
 # Optionally, specify a cluster name and log records can
 # be filtered by cluster.
+# Cluster name is required to be set in order to create relationship with Daemonset 
 # cluster:
 #
 # or Specify secret which contains New Relic API key

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -5,7 +5,6 @@
 # be filtered by cluster.
 # Cluster name is required to be set in order to create relationship with Daemonset 
 # cluster:
-#
 # or Specify secret which contains New Relic API key
 # customSecretName: secret_name
 # customSecretLicenseKey: secret_key

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -4,6 +4,7 @@
 # Optionally, specify a cluster name and log records can
 # be filtered by cluster.
 # Cluster name is required to be set in order to create relationship with Daemonset 
+#
 # cluster:
 # or Specify secret which contains New Relic API key
 # customSecretName: secret_name

--- a/charts/newrelic-logging/values.yaml
+++ b/charts/newrelic-logging/values.yaml
@@ -3,7 +3,7 @@
 #
 # Optionally, specify a cluster name and log records can
 # be filtered by cluster.
-# Cluster name is required to be set in order to create relationship with Daemonset 
+# Cluster name is required to be set in order to create relationship with Daemonset entity in NR platform.
 #
 # cluster:
 # or Specify secret which contains New Relic API key


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart No

#### What this PR does / why we need it:
This Pull Request addresses a bug where the cluster name was not included in the values file, resulting in an inability to append an empty cluster name when adding labels. This fix ensures that an empty cluster name is appended by default, thereby allowing labels to be correctly appended in the Prometheus scraper configuration.

Details
Issue: The absence of a cluster name in the values file prevented the addition of an empty value for the cluster name during the label configuration in Prometheus scrapers.
Fix: The values file has been updated to include an empty cluster name by default. This update facilitates the proper addition of labels, even when no specific cluster name is provided.
Impact: Ensures that Prometheus scrapers can append labels successfully, thereby maintaining consistent and accurate monitoring metrics.
#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
