### PR TITLE
Openshift support 

### DIFF
--- a/charts/nr-k8s-otel-collector/README.md
+++ b/charts/nr-k8s-otel-collector/README.md
@@ -109,6 +109,7 @@ openshift: true
 | deployment.tolerations | list | `[]` | Sets deployment pod tolerations. Overrides `tolerations` and `global.tolerations` |
 | dnsConfig | object | `{}` | Sets pod's dnsConfig. Can be configured also with `global.dnsConfig` |
 | gkeAutopilot | bool | `false` | If deploying to a GKE autopilot cluster, set to true |
+| openshift | bool | `false` | If deploying to Openshift cluster, set to true |
 | image.pullPolicy | string | `"IfNotPresent"` | The pull policy is defaulted to IfNotPresent, which skips pulling an image if it already exists. If pullPolicy is defined without a specific value, it is also set to Always. |
 | image.repository | string | `"newrelic/nr-otel-collector"` | OTel collector image to be deployed. You can use your own collector as long it accomplish the following requirements mentioned below. |
 | image.tag | string | `"0.7.1"` | Overrides the image tag whose default is the chart appVersion. |

--- a/charts/nr-k8s-otel-collector/README.md
+++ b/charts/nr-k8s-otel-collector/README.md
@@ -68,6 +68,14 @@ If using GKE Autopilot, please set the following configuration in your values.ya
 gkeAutopilot: false
 ```
 
+## Openshift
+
+If using Openshift, please set the following configuration in your values.yaml file in order for the agent to work with Openshift.
+
+```
+openshift: true
+```
+
 ## Values
 
 | Key | Type | Default | Description |

--- a/charts/nr-k8s-otel-collector/templates/clusterrole.yaml
+++ b/charts/nr-k8s-otel-collector/templates/clusterrole.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "newrelic.common.labels" . | nindent 4 }}
 rules: 
-{{- if .Values.openshift.enabled }}
+{{- if .Values.openshift }}
   # required for openshift resource detection
   - apiGroups: ["config.openshift.io"]
     resources: ["infrastructures", "infrastructures/status"]
@@ -39,7 +39,7 @@ rules:
     - nodes/proxy
     # following required for filelog receiver
     - pods/logs
-  {{- if .Values.openshift.enabled }}
+  {{- if .Values.openshift }}
     # following required for resourcedetection
     - configmaps
   {{- end }}

--- a/charts/nr-k8s-otel-collector/templates/clusterrole.yaml
+++ b/charts/nr-k8s-otel-collector/templates/clusterrole.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     {{- include "newrelic.common.labels" . | nindent 4 }}
 rules: 
+  # required for openshift resource detection
+  - apiGroups: ["config.openshift.io"]
+    resources: ["infrastructures", "infrastructures/status"]
+    verbs: ["get", "watch", "list"]
   - apiGroups:
     - ""
     resources:
@@ -33,6 +37,8 @@ rules:
     - nodes/proxy
     # following required for filelog receiver
     - pods/logs
+    # following required for resourcedetection
+    - configmaps
     verbs:
     - get
   # following required for prometheus receiver

--- a/charts/nr-k8s-otel-collector/templates/clusterrole.yaml
+++ b/charts/nr-k8s-otel-collector/templates/clusterrole.yaml
@@ -6,10 +6,12 @@ metadata:
   labels:
     {{- include "newrelic.common.labels" . | nindent 4 }}
 rules: 
+{{- if .Values.openshift.enabled }}
   # required for openshift resource detection
   - apiGroups: ["config.openshift.io"]
     resources: ["infrastructures", "infrastructures/status"]
     verbs: ["get", "watch", "list"]
+{{- end }}
   - apiGroups:
     - ""
     resources:
@@ -37,8 +39,10 @@ rules:
     - nodes/proxy
     # following required for filelog receiver
     - pods/logs
+  {{- if .Values.openshift.enabled }}
     # following required for resourcedetection
     - configmaps
+  {{- end }}
     verbs:
     - get
   # following required for prometheus receiver

--- a/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
@@ -130,6 +130,7 @@ data:
         exclude:
           # Exclude logs from opentelemetry containers
           # filelog paths for containerd and CRI-O
+          - /var/log/pods/*/openshift*/*.log
           - /var/log/pods/*/otel-collector-daemonset/*.log
           - /var/log/pods/*/otel-collector-deployment/*.log
           - /var/log/pods/*/containers/*-exec.log
@@ -139,74 +140,12 @@ data:
           - /var/log/container/otel-collector-daemonset/*.log
           - /var/log/container/otel-collector-deployment/*.log
           - /var/log/containers/*-exec.log
-        start_at: beginning
         include_file_path: true
         include_file_name: true
         operators:
-          - type: router
-            id: get-format
-            routes:
-              - output: parser-docker
-                expr: 'body matches "^\\{"'
-              - output: parser-crio
-                expr: 'body matches "^[^ Z]+ "'
-              - output: parser-containerd
-                expr: 'body matches "^[^ Z]+Z"'
-          # CRI-O format
-          - type: regex_parser
-            id: parser-crio
-            regex:
-              '^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$'
-            output: extract_metadata_from_filepath
-            timestamp:
-              parse_from: attributes.time
-              layout_type: gotime
-              layout: '2006-01-02T15:04:05.999999999Z07:00'
-          # Parse CRI-Containerd format
-          - type: regex_parser
-            id: parser-containerd
-            regex:
-              '^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$'
-            output: extract_metadata_from_filepath
-            timestamp:
-              parse_from: attributes.time
-              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-          # Parse Docker format
-          - type: json_parser
-            id: parser-docker
-            output: extract_metadata_from_filepath
-            timestamp:
-              parse_from: attributes.time
-              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-          - type: move
-            from: attributes.log
-            to: body
-          # Extract metadata from file path
-          - type: regex_parser
-            id: extract_metadata_from_filepath
-            regex: '^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$'
-            parse_from: attributes["log.file.path"]
-            cache:
-              size: 128
-          # Rename attributes
-          - type: move
-            from: attributes.stream
-            to: attributes["log.iostream"]
-          - type: move
-            from: attributes.container_name
-            to: resource["k8s.container.name"]
-          - type: move
-            from: attributes.namespace
-            to: resource["k8s.namespace.name"]
-          - type: move
-            from: attributes.pod_name
-            to: resource["k8s.pod.name"]
-          - type: move
-            from: attributes.restart_count
-            to: resource["k8s.container.restart_count"]
-          - type: move
-            from: attributes.uid
-            to: resource["k8s.pod.uid"]
+        - id: container-parser
+          type: container
+      
 
     processors:
       metricstransform/ldm:
@@ -453,8 +392,15 @@ data:
         system:
           hostname_sources: ["os"]
           resource_attributes:
-            host.id:
-              enabled: true
+            host.id: 
+            # TODO host.id does not work, is it required, does it work on containerized environments?
+            # https://github.com/open-telemetry/opentelemetry-go/pull/4317
+              enabled: false
+
+      resourcedetection/openshift:
+        detectors: ["openshift"]
+        override: true              
+
 
       resourcedetection/cloudproviders:
         detectors: [gcp, eks, azure, aks, ec2, ecs]
@@ -464,7 +410,7 @@ data:
           resource_attributes:
             host.name:
               enabled: false
-
+              
       resource:
         attributes:
           - key: host.id
@@ -544,8 +490,8 @@ data:
         send_batch_size : 800
 
     exporters:
-      otlphttp/newrelic:
-        endpoint: {{ include "nrKubernetesOtel.endpoint" . }}
+      otlp/newr:
+        endpoint: https://otlp.nr-data.net:4318
         headers:
           api-key: ${env:NR_LICENSE_KEY}
       # TODO(chris): revisit using the gateway collector
@@ -595,7 +541,10 @@ data:
             - filter/exclude_network
             - attributes/exclude_system_paging
             - resourcedetection/env
-            - resourcedetection/cloudproviders
+            - resourcedetection/openshift
+           # TODO openshift resource detection already obtains some cloud provider details, revisit, resourcedetection/cloudproviders fails to obtain more attributes
+           # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor/internal/openshift/documentation.md
+           #- resourcedetection/cloudproviders
             - resource
             {{- if include "nrKubernetesOtel.lowDataMode" . }}
             - transform/low_data_mode_inator
@@ -607,7 +556,8 @@ data:
             - cumulativetodelta
             - batch
           exporters:
-            - otlphttp/newrelic
+            #- otlphttp/newrelic
+            - otlp/newr
         {{- end }}
         {{- if .Values.receivers.filelog.enabled }}
         logs:
@@ -619,6 +569,7 @@ data:
             - k8sattributes
             - batch
           exporters:
-            - otlphttp/newrelic
+            #- otlphttp/newrelic
+             - otlp/newr
         {{- end }}
     {{- end }}

--- a/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
@@ -130,7 +130,9 @@ data:
         exclude:
           # Exclude logs from opentelemetry containers
           # filelog paths for containerd and CRI-O
+          {{- if .Values.openshift.enabled }}
           - /var/log/pods/*/openshift*/*.log
+          {{- end }}
           - /var/log/pods/*/otel-collector-daemonset/*.log
           - /var/log/pods/*/otel-collector-deployment/*.log
           - /var/log/pods/*/containers/*-exec.log
@@ -393,14 +395,18 @@ data:
           hostname_sources: ["os"]
           resource_attributes:
             host.id: 
+            {{- if .Values.openshift.enabled }}
             # TODO host.id does not work, is it required, does it work on containerized environments?
             # https://github.com/open-telemetry/opentelemetry-go/pull/4317
               enabled: false
-
+            {{- else }}
+              enabled: true
+            {{- end }}
+    {{- if .Values.openshift.enabled }}
       resourcedetection/openshift:
         detectors: ["openshift"]
         override: true              
-
+    {{- end }}
 
       resourcedetection/cloudproviders:
         detectors: [gcp, eks, azure, aks, ec2, ecs]
@@ -490,8 +496,8 @@ data:
         send_batch_size : 800
 
     exporters:
-      otlp/newr:
-        endpoint: https://otlp.nr-data.net:4318
+      otlphttp/newrelic:
+        endpoint: {{ include "nrKubernetesOtel.endpoint" . }}
         headers:
           api-key: ${env:NR_LICENSE_KEY}
       # TODO(chris): revisit using the gateway collector
@@ -541,10 +547,14 @@ data:
             - filter/exclude_network
             - attributes/exclude_system_paging
             - resourcedetection/env
+          {{- if .Values.openshift.enabled }}
             - resourcedetection/openshift
            # TODO openshift resource detection already obtains some cloud provider details, revisit, resourcedetection/cloudproviders fails to obtain more attributes
            # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor/internal/openshift/documentation.md
            #- resourcedetection/cloudproviders
+            {{- else  }}
+            - resourcedetection/cloudproviders
+            {{- end }}
             - resource
             {{- if include "nrKubernetesOtel.lowDataMode" . }}
             - transform/low_data_mode_inator
@@ -556,8 +566,7 @@ data:
             - cumulativetodelta
             - batch
           exporters:
-            #- otlphttp/newrelic
-            - otlp/newr
+            - otlphttp/newrelic
         {{- end }}
         {{- if .Values.receivers.filelog.enabled }}
         logs:
@@ -569,7 +578,6 @@ data:
             - k8sattributes
             - batch
           exporters:
-            #- otlphttp/newrelic
-             - otlp/newr
+            - otlphttp/newrelic
         {{- end }}
     {{- end }}

--- a/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
@@ -97,6 +97,9 @@ data:
                 - action: replace
                   target_label: job_label
                   replacement: cadvisor
+                - source_labels: [__meta_kubernetes_node_name]
+                  regex: ${KUBE_NODE_NAME}
+                  action: keep
               scheme: https
               tls_config:
                 ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
@@ -130,7 +133,7 @@ data:
         exclude:
           # Exclude logs from opentelemetry containers
           # filelog paths for containerd and CRI-O
-          {{- if .Values.openshift.enabled }}
+          {{- if .Values.openshift }}
           - /var/log/pods/*/openshift*/*.log
           {{- end }}
           - /var/log/pods/*/otel-collector-daemonset/*.log
@@ -395,28 +398,26 @@ data:
           hostname_sources: ["os"]
           resource_attributes:
             host.id: 
-            {{- if .Values.openshift.enabled }}
+            {{- if .Values.openshift }}
             # TODO host.id does not work, is it required, does it work on containerized environments?
             # https://github.com/open-telemetry/opentelemetry-go/pull/4317
               enabled: false
             {{- else }}
               enabled: true
             {{- end }}
-    {{- if .Values.openshift.enabled }}
+    {{- if .Values.openshift }}
       resourcedetection/openshift:
         detectors: ["openshift"]
         override: true              
     {{- end }}
-
       resourcedetection/cloudproviders:
-        detectors: [gcp, eks, azure, aks, ec2, ecs]
+        detectors: [gcp, eks, azure, aks, ec2]
         timeout: 2s
         override: false
         ec2:
           resource_attributes:
             host.name:
               enabled: false
-              
       resource:
         attributes:
           - key: host.id
@@ -471,11 +472,14 @@ data:
       attributes/self:
         actions:
           - key: k8s.pod.name
-            action: update
+            action: upsert
             from_attribute: pod
           - key: k8s.deployment.name
             action: update
             from_attribute: deployment
+          - key: k8s.daemonset.name
+            action: update
+            from_attribute: daemonset
           - key: k8s.node.name
             action: update
             from_attribute: node
@@ -547,7 +551,7 @@ data:
             - filter/exclude_network
             - attributes/exclude_system_paging
             - resourcedetection/env
-          {{- if .Values.openshift.enabled }}
+          {{- if .Values.openshift }}
             - resourcedetection/openshift
            # TODO openshift resource detection already obtains some cloud provider details, revisit, resourcedetection/cloudproviders fails to obtain more attributes
            # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor/internal/openshift/documentation.md
@@ -560,8 +564,8 @@ data:
             - transform/low_data_mode_inator
             - resource/low_data_mode_inator
             {{- end }}
-            - k8sattributes
             - attributes/self
+            - k8sattributes
             - memory_limiter
             - cumulativetodelta
             - batch

--- a/charts/nr-k8s-otel-collector/templates/daemonset.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset.yaml
@@ -68,10 +68,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+            {{- if .Values.openshift.enabled }}
             # probably fixed on newer version hostmetrics receiver
             # Work around for open /mounts error: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35990
             - name: HOST_PROC_MOUNTINFO
               value: ""
+            {{- end }}
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: service.instance.id=$(POD_NAME),k8s.pod.uid=$(POD_UID)
             - name: NR_LICENSE_KEY

--- a/charts/nr-k8s-otel-collector/templates/daemonset.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset.yaml
@@ -68,7 +68,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-            {{- if .Values.openshift.enabled }}
+            {{- if .Values.openshift }}
             # probably fixed on newer version hostmetrics receiver
             # Work around for open /mounts error: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35990
             - name: HOST_PROC_MOUNTINFO

--- a/charts/nr-k8s-otel-collector/templates/daemonset.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset.yaml
@@ -68,6 +68,10 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+            # probably fixed on newer version hostmetrics receiver
+            # Work around for open /mounts error: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35990
+            - name: HOST_PROC_MOUNTINFO
+              value: ""
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: service.instance.id=$(POD_NAME),k8s.pod.uid=$(POD_UID)
             - name: NR_LICENSE_KEY

--- a/charts/nr-k8s-otel-collector/templates/deployment-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/deployment-configmap.yaml
@@ -28,11 +28,13 @@ data:
                   regex: kube-state-metrics
                   source_labels:
                     - __meta_kubernetes_pod_label_app_kubernetes_io_name
+                {{- if .Values.openshift.enabled }}
                 # this is using our ksm deployment not the one deployed by openshift in namespace openshift-monitoring
                 - action: keep
                   source_labels:
                   - __address__
                   regex: .*:8080$
+                {{- end }}
                 - action: replace
                   target_label: job_label
                   replacement: kube-state-metrics
@@ -46,15 +48,27 @@ data:
                 - role: endpoints
                   namespaces:
                     names:
+                    {{- if .Values.openshift.enabled }}
                       - openshift-kube-apiserver
+                    {{- else }}
+                      - default
+                    {{- end }}
               scheme: https
               tls_config:
                 ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                {{- if .Values.openshift.enabled }}
                 insecure_skip_verify: true
+                {{- else }}
+                insecure_skip_verify: false
+                {{- end }}
               bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
               relabel_configs:
               - action: keep
+              {{- if .Values.openshift.enabled }}
                 regex: openshift-kube-apiserver;apiserver;https
+              {{- else  }}
+                regex: default;kubernetes;https
+              {{- end }}
                 source_labels:
                 - __meta_kubernetes_namespace
                 - __meta_kubernetes_service_name
@@ -77,15 +91,27 @@ data:
                 - role: endpoints
                   namespaces:
                     names:
+                    {{- if .Values.openshift.enabled }}
                       - openshift-kube-controller-manager
+                    {{- else }} 
+                      - default
+                    {{- end }}
               scheme: https
               tls_config:
                 ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                {{- if .Values.openshift.enabled }}
                 insecure_skip_verify: true
+                {{- else }}
+                insecure_skip_verify: false
+                {{- end }}
               bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
               relabel_configs:
               - action: keep
+              {{- if .Values.openshift.enabled }}
                 regex: openshift-kube-controller-manager;kube-controller-manager;https
+              {{- else }}
+                regex: default;kubernetes;https
+              {{- end }}
                 source_labels:
                 - __meta_kubernetes_namespace
                 - __meta_kubernetes_service_name
@@ -111,15 +137,27 @@ data:
                 - role: endpoints
                   namespaces:
                       names:
+                      {{- if .Values.openshift.enabled }}
                         - openshift-kube-scheduler
+                      {{- else }} 
+                        - default
+                      {{- end }}
               scheme: https
               tls_config:
                 ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                {{- if .Values.openshift.enabled }}
                 insecure_skip_verify: true
+                {{- else }}
+                insecure_skip_verify: false
+                {{- end }}
               bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
               relabel_configs:
               - action: keep
+              {{- if .Values.openshift.enabled }}
                 regex: openshift-kube-scheduler;scheduler;https
+              {{- else }} 
+                regex: default;kubernetes;https
+              {{- end }}
                 source_labels:
                 - __meta_kubernetes_namespace
                 - __meta_kubernetes_service_name
@@ -410,13 +448,19 @@ data:
           hostname_sources: ["os"]
           resource_attributes:
             host.id:
+            {{- if .Values.openshift.enabled }}
             # TODO host.id does not work, is it required, does it work on containerized environments?
             # https://github.com/open-telemetry/opentelemetry-go/pull/4317
               enabled: false
-
+            {{- else }}
+              enabled: true
+            {{- end }}
+    
+    {{- if .Values.openshift.enabled }}
       resourcedetection/openshift:
         detectors: ["openshift"]
         override: true
+    {{- end }}
 
       resourcedetection/cloudproviders:
         detectors: [gcp, eks, azure, aks, ec2, ecs]
@@ -530,15 +574,10 @@ data:
         send_batch_size : 800
 
     exporters:
-      otlp/newr:
-        endpoint: https://otlp.nr-data.net:4318
+      otlphttp/newrelic:
+        endpoint: {{ include "nrKubernetesOtel.endpoint" . }}
         headers:
           api-key: ${env:NR_LICENSE_KEY}
-
-    #  otlphttp/newrelic:
-    #    endpoint: {{ include "nrKubernetesOtel.endpoint" . }}
-    #    headers:
-    #      api-key: ${env:NR_LICENSE_KEY}
     service:
       {{- if include "newrelic.common.verboseLog" . }}
       telemetry:
@@ -566,16 +605,19 @@ data:
             {{- end }}
             - resource/metrics
             - resourcedetection/env
+            {{- if .Values.openshift.enabled }}
             - resourcedetection/openshift
-            # TODO openshift resource detection already obtains some cloud provider details, revisit, resourcedetection/cloudproviders fails to obtain more attributes
-            # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor/internal/openshift/documentation.md
-            #- resourcedetection/cloudproviders
+           # TODO openshift resource detection already obtains some cloud provider details, revisit, resourcedetection/cloudproviders fails to obtain more attributes
+           # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor/internal/openshift/documentation.md
+           #- resourcedetection/cloudproviders
+            {{- else  }}
+            - resourcedetection/cloudproviders
+            {{- end }}
             - batch
             - groupbyattrs
             - transform/ksm
           exporters:
-          #  - otlphttp/newrelic
-            - otlp/newr
+            - otlphttp/newrelic
         {{- end }}
         {{- if .Values.receivers.prometheus.enabled }}
         metrics:
@@ -598,8 +640,7 @@ data:
             - cumulativetodelta
             - batch
           exporters:
-            #- otlphttp/newrelic
-             - otlp/newr
+            - otlphttp/newrelic
         {{- end }}
         # TODO(chris): revisit using the gateway collector
         # logs:
@@ -616,7 +657,6 @@ data:
             - resource/events
             - batch
           exporters:
-           # - otlphttp/newrelic
-            - otlp/newr
+            - otlphttp/newrelic
         {{- end }}
     {{- end }}

--- a/charts/nr-k8s-otel-collector/templates/deployment-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/deployment-configmap.yaml
@@ -28,6 +28,11 @@ data:
                   regex: kube-state-metrics
                   source_labels:
                     - __meta_kubernetes_pod_label_app_kubernetes_io_name
+                # this is using our ksm deployment not the one deployed by openshift in namespace openshift-monitoring
+                - action: keep
+                  source_labels:
+                  - __address__
+                  regex: .*:8080$
                 - action: replace
                   target_label: job_label
                   replacement: kube-state-metrics
@@ -41,15 +46,15 @@ data:
                 - role: endpoints
                   namespaces:
                     names:
-                      - default
+                      - openshift-kube-apiserver
               scheme: https
               tls_config:
                 ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                insecure_skip_verify: false
+                insecure_skip_verify: true
               bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
               relabel_configs:
               - action: keep
-                regex: default;kubernetes;https
+                regex: openshift-kube-apiserver;apiserver;https
                 source_labels:
                 - __meta_kubernetes_namespace
                 - __meta_kubernetes_service_name
@@ -70,14 +75,17 @@ data:
               metrics_path: /metrics
               kubernetes_sd_configs:
                 - role: endpoints
+                  namespaces:
+                    names:
+                      - openshift-kube-controller-manager
               scheme: https
               tls_config:
                 ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                insecure_skip_verify: false
+                insecure_skip_verify: true
               bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
               relabel_configs:
               - action: keep
-                regex: default;kubernetes;https
+                regex: openshift-kube-controller-manager;kube-controller-manager;https
                 source_labels:
                 - __meta_kubernetes_namespace
                 - __meta_kubernetes_service_name
@@ -101,6 +109,9 @@ data:
               scrape_interval: {{ .Values.receivers.prometheus.scrapeInterval }}
               kubernetes_sd_configs:
                 - role: endpoints
+                  namespaces:
+                      names:
+                        - openshift-kube-scheduler
               scheme: https
               tls_config:
                 ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
@@ -108,7 +119,7 @@ data:
               bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
               relabel_configs:
               - action: keep
-                regex: default;kubernetes;https
+                regex: openshift-kube-scheduler;scheduler;https
                 source_labels:
                 - __meta_kubernetes_namespace
                 - __meta_kubernetes_service_name
@@ -399,7 +410,13 @@ data:
           hostname_sources: ["os"]
           resource_attributes:
             host.id:
-              enabled: true
+            # TODO host.id does not work, is it required, does it work on containerized environments?
+            # https://github.com/open-telemetry/opentelemetry-go/pull/4317
+              enabled: false
+
+      resourcedetection/openshift:
+        detectors: ["openshift"]
+        override: true
 
       resourcedetection/cloudproviders:
         detectors: [gcp, eks, azure, aks, ec2, ecs]
@@ -513,10 +530,15 @@ data:
         send_batch_size : 800
 
     exporters:
-      otlphttp/newrelic:
-        endpoint: {{ include "nrKubernetesOtel.endpoint" . }}
+      otlp/newr:
+        endpoint: https://otlp.nr-data.net:4318
         headers:
           api-key: ${env:NR_LICENSE_KEY}
+
+    #  otlphttp/newrelic:
+    #    endpoint: {{ include "nrKubernetesOtel.endpoint" . }}
+    #    headers:
+    #      api-key: ${env:NR_LICENSE_KEY}
     service:
       {{- if include "newrelic.common.verboseLog" . }}
       telemetry:
@@ -544,12 +566,16 @@ data:
             {{- end }}
             - resource/metrics
             - resourcedetection/env
-            - resourcedetection/cloudproviders
+            - resourcedetection/openshift
+            # TODO openshift resource detection already obtains some cloud provider details, revisit, resourcedetection/cloudproviders fails to obtain more attributes
+            # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor/internal/openshift/documentation.md
+            #- resourcedetection/cloudproviders
             - batch
             - groupbyattrs
             - transform/ksm
           exporters:
-            - otlphttp/newrelic
+          #  - otlphttp/newrelic
+            - otlp/newr
         {{- end }}
         {{- if .Values.receivers.prometheus.enabled }}
         metrics:
@@ -572,7 +598,8 @@ data:
             - cumulativetodelta
             - batch
           exporters:
-            - otlphttp/newrelic
+            #- otlphttp/newrelic
+             - otlp/newr
         {{- end }}
         # TODO(chris): revisit using the gateway collector
         # logs:
@@ -589,6 +616,7 @@ data:
             - resource/events
             - batch
           exporters:
-            - otlphttp/newrelic
+           # - otlphttp/newrelic
+            - otlp/newr
         {{- end }}
     {{- end }}

--- a/charts/nr-k8s-otel-collector/templates/deployment-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/deployment-configmap.yaml
@@ -27,9 +27,9 @@ data:
                 - action: keep
                   regex: kube-state-metrics
                   source_labels:
-                    - __meta_kubernetes_pod_label_app_kubernetes_io_name
-                {{- if .Values.openshift.enabled }}
-                # this is using our ksm deployment not the one deployed by openshift in namespace openshift-monitoring
+                  - __meta_kubernetes_pod_label_app_kubernetes_io_name
+                {{- if .Values.openshift }}
+                # this is targeting our ksm deployment label app_kubernetes_io_name=kube-state-metrics
                 - action: keep
                   source_labels:
                   - __address__
@@ -48,7 +48,7 @@ data:
                 - role: endpoints
                   namespaces:
                     names:
-                    {{- if .Values.openshift.enabled }}
+                    {{- if .Values.openshift }}
                       - openshift-kube-apiserver
                     {{- else }}
                       - default
@@ -56,7 +56,7 @@ data:
               scheme: https
               tls_config:
                 ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                {{- if .Values.openshift.enabled }}
+                {{- if .Values.openshift }}
                 insecure_skip_verify: true
                 {{- else }}
                 insecure_skip_verify: false
@@ -64,15 +64,10 @@ data:
               bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
               relabel_configs:
               - action: keep
-              {{- if .Values.openshift.enabled }}
-                regex: openshift-kube-apiserver;apiserver;https
-              {{- else  }}
-                regex: default;kubernetes;https
-              {{- end }}
                 source_labels:
-                - __meta_kubernetes_namespace
-                - __meta_kubernetes_service_name
-                - __meta_kubernetes_endpoint_port_name
+                - __meta_kubernetes_pod_name
+                - __address__
+                regex: .*apiserver.*;.*:6443$  
               - action: replace
                 source_labels:
                 - __meta_kubernetes_namespace
@@ -88,18 +83,18 @@ data:
               scrape_interval: {{ .Values.receivers.prometheus.scrapeInterval }}
               metrics_path: /metrics
               kubernetes_sd_configs:
-                - role: endpoints
+                - role: pod
                   namespaces:
                     names:
-                    {{- if .Values.openshift.enabled }}
+                    {{- if .Values.openshift }}
                       - openshift-kube-controller-manager
                     {{- else }} 
-                      - default
+                      - kube-system
                     {{- end }}
               scheme: https
               tls_config:
                 ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                {{- if .Values.openshift.enabled }}
+                {{- if .Values.openshift }}
                 insecure_skip_verify: true
                 {{- else }}
                 insecure_skip_verify: false
@@ -107,15 +102,10 @@ data:
               bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
               relabel_configs:
               - action: keep
-              {{- if .Values.openshift.enabled }}
-                regex: openshift-kube-controller-manager;kube-controller-manager;https
-              {{- else }}
-                regex: default;kubernetes;https
-              {{- end }}
                 source_labels:
-                - __meta_kubernetes_namespace
-                - __meta_kubernetes_service_name
-                - __meta_kubernetes_endpoint_port_name
+                - __meta_kubernetes_pod_name
+                - __address__
+                regex: .*controller-manager.*;.*:10257$   
               - action: replace
                 source_labels:
                 - __meta_kubernetes_namespace
@@ -133,19 +123,20 @@ data:
                 replacement: controller-manager
             - job_name: scheduler
               scrape_interval: {{ .Values.receivers.prometheus.scrapeInterval }}
+              metrics_path: /metrics
               kubernetes_sd_configs:
-                - role: endpoints
+                - role: pod
                   namespaces:
-                      names:
-                      {{- if .Values.openshift.enabled }}
-                        - openshift-kube-scheduler
-                      {{- else }} 
-                        - default
-                      {{- end }}
+                    names:
+                    {{- if .Values.openshift }}
+                      - openshift-kube-scheduler
+                    {{- else }} 
+                      - kube-system
+                    {{- end }}
               scheme: https
               tls_config:
                 ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                {{- if .Values.openshift.enabled }}
+                {{- if .Values.openshift }}
                 insecure_skip_verify: true
                 {{- else }}
                 insecure_skip_verify: false
@@ -153,19 +144,18 @@ data:
               bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
               relabel_configs:
               - action: keep
-              {{- if .Values.openshift.enabled }}
-                regex: openshift-kube-scheduler;scheduler;https
-              {{- else }} 
-                regex: default;kubernetes;https
-              {{- end }}
                 source_labels:
-                - __meta_kubernetes_namespace
-                - __meta_kubernetes_service_name
-                - __meta_kubernetes_endpoint_port_name
+                - __meta_kubernetes_pod_name
+                - __address__
+                regex: .*scheduler.*;.*:10259$        
               - action: replace
                 source_labels:
                 - __meta_kubernetes_namespace
                 target_label: namespace
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_pod_name
+                target_label: pod
               - action: replace
                 source_labels:
                 - __meta_kubernetes_service_name
@@ -448,7 +438,7 @@ data:
           hostname_sources: ["os"]
           resource_attributes:
             host.id:
-            {{- if .Values.openshift.enabled }}
+            {{- if .Values.openshift }}
             # TODO host.id does not work, is it required, does it work on containerized environments?
             # https://github.com/open-telemetry/opentelemetry-go/pull/4317
               enabled: false
@@ -456,7 +446,7 @@ data:
               enabled: true
             {{- end }}
     
-    {{- if .Values.openshift.enabled }}
+    {{- if .Values.openshift }}
       resourcedetection/openshift:
         detectors: ["openshift"]
         override: true
@@ -605,7 +595,7 @@ data:
             {{- end }}
             - resource/metrics
             - resourcedetection/env
-            {{- if .Values.openshift.enabled }}
+            {{- if .Values.openshift }}
             - resourcedetection/openshift
            # TODO openshift resource detection already obtains some cloud provider details, revisit, resourcedetection/cloudproviders fails to obtain more attributes
            # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor/internal/openshift/documentation.md

--- a/charts/nr-k8s-otel-collector/templates/scc.yaml
+++ b/charts/nr-k8s-otel-collector/templates/scc.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.openshift }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "newrelic.common.naming.fullname" . }}-scc
+  labels:
+    {{- include "newrelic.common.labels" . | nindent 4 }}
+rules:
+  - verbs:
+      - use
+    apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - privileged
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "newrelic.common.naming.fullname" . }}-scc
+  labels:
+    {{- include "newrelic.common.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "newrelic.common.serviceAccount.name" . }}
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ include "newrelic.common.serviceAccount.name" . }}-kube-state-metrics
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "newrelic.common.naming.fullname" . }}-scc
+{{- end }}
+
+
+
+

--- a/charts/nr-k8s-otel-collector/values.yaml
+++ b/charts/nr-k8s-otel-collector/values.yaml
@@ -7,13 +7,13 @@ kube-state-metrics:
   # This is mandatory if `infrastructure.enabled` is set to `true` and the user does not provide its own instance of KSM version >=1.8 and <=2.0. Note, kube-state-metrics v2+ disables labels/annotations
   # metrics by default. You can enable the target labels/annotations metrics to be monitored by using the metricLabelsAllowlist/metricAnnotationsAllowList options described [here](https://github.com/prometheus-community/helm-charts/blob/159cd8e4fb89b8b107dcc100287504bb91bf30e0/charts/kube-state-metrics/values.yaml#L274) in
   # your Kubernetes clusters.
-  enabled: false
+  enabled: true
   # -- Disable prometheus from auto-discovering KSM and potentially scraping duplicated data
   prometheusScrape: false
 
 image:
   # -- OTel collector image to be deployed. You can use your own collector as long it accomplish the following requirements mentioned below.
-  repository: otel/opentelemetry-collector-contrib
+  repository: newrelic/nr-otel-collector
   # -- The pull policy is defaulted to IfNotPresent, which skips pulling an image if it already exists. If pullPolicy is defined without a specific value, it is also set to Always.
   pullPolicy: IfNotPresent
   # --  Overrides the image tag whose default is the chart appVersion.

--- a/charts/nr-k8s-otel-collector/values.yaml
+++ b/charts/nr-k8s-otel-collector/values.yaml
@@ -13,12 +13,12 @@ kube-state-metrics:
 
 image:
   # -- OTel collector image to be deployed. You can use your own collector as long it accomplish the following requirements mentioned below.
-  repository: newrelic/nr-otel-collector
+  repository: otel/opentelemetry-collector-contrib
   # -- The pull policy is defaulted to IfNotPresent, which skips pulling an image if it already exists. If pullPolicy is defined without a specific value, it is also set to Always.
   pullPolicy: IfNotPresent
   # --  Overrides the image tag whose default is the chart appVersion.
-  tag: "0.8.3"
-
+  # tag: "0.8.10"
+  tag: "0.119.0"
 # -- Name of the Kubernetes cluster monitored. Mandatory. Can be configured also with `global.cluster`
 cluster: ""
 # -- This set this license key to use. Can be configured also with `global.licenseKey`

--- a/charts/nr-k8s-otel-collector/values.yaml
+++ b/charts/nr-k8s-otel-collector/values.yaml
@@ -13,12 +13,11 @@ kube-state-metrics:
 
 image:
   # -- OTel collector image to be deployed. You can use your own collector as long it accomplish the following requirements mentioned below.
-  repository: otel/opentelemetry-collector-contrib
+  repository: newrelic/nr-otel-collector
   # -- The pull policy is defaulted to IfNotPresent, which skips pulling an image if it already exists. If pullPolicy is defined without a specific value, it is also set to Always.
   pullPolicy: IfNotPresent
   # --  Overrides the image tag whose default is the chart appVersion.
-  # tag: "0.8.10"
-  tag: "0.119.0"
+  tag: "0.8.10"
 # -- Name of the Kubernetes cluster monitored. Mandatory. Can be configured also with `global.cluster`
 cluster: ""
 # -- This set this license key to use. Can be configured also with `global.licenseKey`
@@ -162,3 +161,7 @@ receivers:
 # -- (bool) Send only the [metrics required](https://github.com/newrelic/helm-charts/tree/master/charts/nr-k8s-otel-collector/docs/metrics-lowDataMode.md) to light up the NR kubernetes UI
 # @default -- `true`
 lowDataMode:
+
+openshift:
+  # -- (bool) Specifies whether the OpenShift specific configuration should be applied
+  enabled: false

--- a/charts/nr-k8s-otel-collector/values.yaml
+++ b/charts/nr-k8s-otel-collector/values.yaml
@@ -7,17 +7,17 @@ kube-state-metrics:
   # This is mandatory if `infrastructure.enabled` is set to `true` and the user does not provide its own instance of KSM version >=1.8 and <=2.0. Note, kube-state-metrics v2+ disables labels/annotations
   # metrics by default. You can enable the target labels/annotations metrics to be monitored by using the metricLabelsAllowlist/metricAnnotationsAllowList options described [here](https://github.com/prometheus-community/helm-charts/blob/159cd8e4fb89b8b107dcc100287504bb91bf30e0/charts/kube-state-metrics/values.yaml#L274) in
   # your Kubernetes clusters.
-  enabled: true
+  enabled: false
   # -- Disable prometheus from auto-discovering KSM and potentially scraping duplicated data
   prometheusScrape: false
 
 image:
   # -- OTel collector image to be deployed. You can use your own collector as long it accomplish the following requirements mentioned below.
-  repository: newrelic/nr-otel-collector
+  repository: otel/opentelemetry-collector-contrib
   # -- The pull policy is defaulted to IfNotPresent, which skips pulling an image if it already exists. If pullPolicy is defined without a specific value, it is also set to Always.
   pullPolicy: IfNotPresent
   # --  Overrides the image tag whose default is the chart appVersion.
-  tag: "0.8.10"
+  tag: "0.8.3"
 # -- Name of the Kubernetes cluster monitored. Mandatory. Can be configured also with `global.cluster`
 cluster: ""
 # -- This set this license key to use. Can be configured also with `global.licenseKey`
@@ -41,6 +41,10 @@ dnsConfig: {}
 # -- If deploying to a GKE autopilot cluster, set to true
 # @default -- `false`
 gkeAutopilot: false
+
+# -- If deploying on Openshift cluster, set to true
+# @default -- `false`
+openshift: true
 
 daemonset:
   # -- Sets daemonset pod node selector. Overrides `nodeSelector` and `global.nodeSelector`
@@ -162,6 +166,3 @@ receivers:
 # @default -- `true`
 lowDataMode:
 
-openshift:
-  # -- (bool) Specifies whether the OpenShift specific configuration should be applied
-  enabled: false

--- a/charts/nr-k8s-otel-collector/values.yaml
+++ b/charts/nr-k8s-otel-collector/values.yaml
@@ -165,4 +165,3 @@ receivers:
 # -- (bool) Send only the [metrics required](https://github.com/newrelic/helm-charts/tree/master/charts/nr-k8s-otel-collector/docs/metrics-lowDataMode.md) to light up the NR kubernetes UI
 # @default -- `true`
 lowDataMode:
-


### PR DESCRIPTION
Adds Openshift support

newrelic/nr-otel-collector will need to be upgraded to support container_parser in the filelogreceiver
https://opentelemetry.io/blog/2024/otel-collector-container-log-parser/

deploys the required clusterrole and clusterrolebinding to allow service accounts nr-k8s-otel-collector and 
nr-k8s-otel-collector-kube-state-metrics to use privileged security context constraint 