### PR TITLE
[nr-k8s-otel-collector] Add DaemonSet and Deployment container port configuration options

### DIFF
--- a/charts/nr-k8s-otel-collector/Chart.yaml
+++ b/charts/nr-k8s-otel-collector/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.4
+version: 0.8.5
 
 dependencies:
   - name: common-library
@@ -32,7 +32,7 @@ dependencies:
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.8.0"
+appVersion: "0.8.3"
 
 maintainers:
   - name: csongnr

--- a/charts/nr-k8s-otel-collector/README.md
+++ b/charts/nr-k8s-otel-collector/README.md
@@ -86,6 +86,7 @@ gkeAutopilot: false
 | daemonset.nodeSelector | object | `{}` | Sets daemonset pod node selector. Overrides `nodeSelector` and `global.nodeSelector` |
 | daemonset.podAnnotations | object | `{}` | Annotations to be added to the daemonset. |
 | daemonset.podSecurityContext | object | `{}` | Sets security context (at pod level) for the daemonset. Overrides `podSecurityContext` and `global.podSecurityContext` |
+| daemonset.ports | object | `{}` | Container ports to be added to the Daemonset. |
 | daemonset.resources | object | `{}` | Sets resources for the daemonset. |
 | daemonset.tolerations | list | `[]` | Sets daemonset pod tolerations. Overrides `tolerations` and `global.tolerations` |
 | deployment.affinity | object | `{}` | Sets deployment pod affinities. Overrides `affinity` and `global.affinity` |
@@ -97,6 +98,7 @@ gkeAutopilot: false
 | deployment.nodeSelector | object | `{}` | Sets deployment pod node selector. Overrides `nodeSelector` and `global.nodeSelector` |
 | deployment.podAnnotations | object | `{}` | Annotations to be added to the deployment. |
 | deployment.podSecurityContext | object | `{}` | Sets security context (at pod level) for the deployment. Overrides `podSecurityContext` and `global.podSecurityContext` |
+| deployment.ports | object | `{}` | Container ports to be added to the Deployment. |
 | deployment.resources | object | `{}` | Sets resources for the deployment. |
 | deployment.tolerations | list | `[]` | Sets deployment pod tolerations. Overrides `tolerations` and `global.tolerations` |
 | dnsConfig | object | `{}` | Sets pod's dnsConfig. Can be configured also with `global.dnsConfig` |

--- a/charts/nr-k8s-otel-collector/templates/_ports.tpl
+++ b/charts/nr-k8s-otel-collector/templates/_ports.tpl
@@ -1,0 +1,23 @@
+{{/* Build the list of port for the DaemonSet pods */}}
+{{- define "nrKubernetesOtel.daemonset.ports" -}}
+{{- $ports := deepCopy .Values.daemonset.ports -}}
+{{- range $key, $port := $ports }}
+{{- if $port.enabled }}
+- name: {{ $key }}
+  containerPort: {{ $port.containerPort }}
+  protocol: {{ $port.protocol }}
+{{- end}}
+{{- end }}
+{{- end }}
+
+{{/* Build the list of port for the Deployment pod */}}
+{{- define "nrKubernetesOtel.deployment.ports" -}}
+{{- $ports := deepCopy .Values.deployment.ports -}}
+{{- range $key, $port := $ports }}
+{{- if $port.enabled }}
+- name: {{ $key }}
+  containerPort: {{ $port.containerPort }}
+  protocol: {{ $port.protocol }}
+{{- end}}
+{{- end }}
+{{- end }}

--- a/charts/nr-k8s-otel-collector/templates/daemonset.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset.yaml
@@ -78,6 +78,11 @@ spec:
             {{- with .Values.daemonset.envs }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
+          {{- $ports := include "nrKubernetesOtel.daemonset.ports" .}}
+          {{- if $ports }}
+          ports:
+            {{- $ports | indent 12 }}
+          {{- end }}
           volumeMounts:
             {{- if not .Values.gkeAutopilot }}
             - name: host-fs

--- a/charts/nr-k8s-otel-collector/templates/deployment.yaml
+++ b/charts/nr-k8s-otel-collector/templates/deployment.yaml
@@ -69,10 +69,11 @@ spec:
             {{- with .Values.deployment.envs }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
+          {{- $ports := include "nrKubernetesOtel.deployment.ports" .}}
+          {{- if $ports }}
           ports:
-            - name: http
-              containerPort: 4318
-              protocol: TCP
+            {{- $ports | indent 12 }}
+          {{- end }}
           volumeMounts:
             - name: deployment-config
               mountPath: /config

--- a/charts/nr-k8s-otel-collector/values.yaml
+++ b/charts/nr-k8s-otel-collector/values.yaml
@@ -64,7 +64,21 @@ daemonset:
   # -- Sets additional environment variable sources for the daemonset.
   envsFrom: []
   # -- Settings for daemonset configmap
-  # @default -- See `values.yaml`
+  # @default -- See `values.yaml`\
+  ports: 
+    metrics:
+      enabled: true
+      containerPort: 8888
+      servicePort: 8888
+      protocol: TCP 
+    http:
+      enabled: true
+      containerPort: 4318
+      protocol: TCP
+    grpc:
+      enabled: true
+      containerPort: 4317
+      protocol: TCP
   configMap:
     # -- OpenTelemetry config for the daemonset. If set, overrides default config and disables configuration parameters for the daemonset.
     config: {}
@@ -90,6 +104,20 @@ deployment:
   envsFrom: []
   # -- Settings for deployment configmap
   # @default -- See `values.yaml`
+  ports:
+    metrics:
+      enabled: true
+      containerPort: 8888
+      servicePort: 8888
+      protocol: TCP 
+    http:
+      enabled: true
+      containerPort: 4318
+      protocol: TCP
+    grpc:
+      enabled: true
+      containerPort: 4317
+      protocol: TCP
   configMap:
     # -- OpenTelemetry config for the deployment. If set, overrides default config and disables configuration parameters for the deployment.
     config: {}


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

Adds the ability for users to specify what container ports need to be open for both the DaemonSet and Deployment.  For example, if a user wants to collect OTel internal telemetry, port 8888 needs to be open.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
