### PR TITLE
[agent-control] chore(deps): update helm release flux2 to 2.15.0

### DIFF
--- a/.github/workflows/lint_test_charts.yaml
+++ b/.github/workflows/lint_test_charts.yaml
@@ -82,7 +82,7 @@ jobs:
         uses: manusa/actions-setup-minikube@v2.13.1
         with:
           minikube version: v1.35.0
-          kubernetes version: v1.28.11
+          kubernetes version: v1.30.0
           github token: ${{ secrets.GITHUB_TOKEN }}
           driver: docker
           start args: "--container-runtime=containerd"

--- a/charts/agent-control/Chart.lock
+++ b/charts/agent-control/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: flux2
   repository: https://fluxcd-community.github.io/helm-charts
-  version: 2.14.1
+  version: 2.15.0
 - name: agent-control-deployment
   repository: ""
   version: 0.0.43-beta
 - name: common-library
   repository: https://helm-charts.newrelic.com
   version: 1.3.1
-digest: sha256:c48931832ecebf5cf8572616cdb15580df0f0b1c11b008d4ec741a4f35dcc83c
-generated: "2025-03-05T16:37:35.732903+01:00"
+digest: sha256:ee8870a8a8409453d766f6b2524cd0fa106bfefa6dd29c3fcac25c5b21ebabd8
+generated: "2025-03-25T14:46:00.346112+01:00"

--- a/charts/agent-control/Chart.yaml
+++ b/charts/agent-control/Chart.yaml
@@ -3,12 +3,12 @@ name: agent-control
 description: Bootstraps New Relic' Agent Control
 
 type: application
-version: 0.0.55-beta
+version: 0.0.56-beta
 
 dependencies:
   - name: flux2
     repository: https://fluxcd-community.github.io/helm-charts
-    version: 2.14.1
+    version: 2.15.0
     condition: flux2.enabled
   - name: agent-control-deployment
     version: 0.0.43-beta


### PR DESCRIPTION
#### What this PR does / why we need it:

We are bumping the flux version used by the agent-control to the latest version to allow adding the attribute disableTakeOwnership.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
