### PR TITLE
[agent-control-deployment] secret ownership

### DIFF
--- a/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 
 type: application
 
-version: 0.0.46
+version: 0.0.47
 appVersion: "0.37.0"
 
 dependencies:

--- a/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml
+++ b/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml
@@ -290,7 +290,7 @@ spec:
                 {{ include "newrelic-agent-control.auth.secret.name" . }} \
                 --from-literal=CLIENT_ID=$CLIENT_ID \
                 --from-file="private_key=$TEMPORAL_FOLDER/key" | \
-              jq '.metadata.labels += ({{ include "newrelic.common.labels" . | fromYaml | toJson }} + {"app.kubernetes.io/created-by": "ac-auth-job"})' | \
+              jq '.metadata.labels += ({{ include "newrelic.common.labels" . | fromYaml | toJson }} + {"app.kubernetes.io/managed-by": "newrelic-agent-control"} + {"newrelic.io/agent-id": "agent-control"} )' | \
               kubectl apply -n "{{ .Release.Namespace }}" -f -
 ---
 {{ if .Values.rbac.create }}

--- a/charts/agent-control-deployment/templates/uninstall-job.yaml
+++ b/charts/agent-control-deployment/templates/uninstall-job.yaml
@@ -8,7 +8,6 @@ Notice that instrumentations needs to go first since it depends on a chart insta
 */ -}}
 {{- $acCRList := (list "instrumentations.newrelic.com" "helmreleases.helm.toolkit.fluxcd.io" "helmrepositories.source.toolkit.fluxcd.io") -}}
 {{- $acResourcesLabelSelector := "app.kubernetes.io/managed-by=newrelic-agent-control" -}}
-{{- $authJobResourcesLabelSelector := "app.kubernetes.io/created-by=ac-auth-job" -}}
 
 apiVersion: batch/v1
 kind: Job
@@ -59,7 +58,7 @@ spec:
       
               {{- if include "newrelic-agent-control.auth.secret.shouldRunJob" . }}
               # Delete the secrets created in the cluster
-              kubectl delete secrets -n {{ .Release.Namespace }} -l {{ $authJobResourcesLabelSelector }}
+              kubectl delete secrets -n {{ .Release.Namespace }} -l {{ $acResourcesLabelSelector }}
               {{- end }}
 
 {{ if .Values.rbac.create }}

--- a/charts/agent-control-deployment/templates/uninstall-job.yaml
+++ b/charts/agent-control-deployment/templates/uninstall-job.yaml
@@ -56,11 +56,6 @@ spec:
               fi
               {{ end }}
       
-              {{- if include "newrelic-agent-control.auth.secret.shouldRunJob" . }}
-              # Delete the secrets created in the cluster
-              kubectl delete secrets -n {{ .Release.Namespace }} -l {{ $acResourcesLabelSelector }}
-              {{- end }}
-
 {{ if .Values.rbac.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
#### Is this a new chart
no
#### What this PR does / why we need it:
Changes the secret ownership so that it gets deleted by the agent-control-cli
Adding the agent-id to specify which component is leveraging leveraging the secret and to avoid the garbage collector to complain

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
