### PR TITLE
[nr-k8s-otel-collector] Apply groupbyattr and transform ksm with correct k8sattributes in daemonset

### DIFF
--- a/charts/nr-k8s-otel-collector/Chart.yaml
+++ b/charts/nr-k8s-otel-collector/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.21
+version: 0.8.22
 
 dependencies:
   - name: common-library

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/clusterrole.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/clusterrole.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.19
-rules: 
+    helm.sh/chart: nr-k8s-otel-collector-0.8.21
+rules:
   - apiGroups:
     - ""
     resources:

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/clusterrole.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/clusterrole.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.21
+    helm.sh/chart: nr-k8s-otel-collector-0.8.22
 rules:
   - apiGroups:
     - ""

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/clusterrolebinding.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/clusterrolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.19
+    helm.sh/chart: nr-k8s-otel-collector-0.8.21
 subjects:
   - kind: ServiceAccount
     name: example-nr-k8s-otel-collector

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/clusterrolebinding.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/clusterrolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.21
+    helm.sh/chart: nr-k8s-otel-collector-0.8.22
 subjects:
   - kind: ServiceAccount
     name: example-nr-k8s-otel-collector

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/daemonset-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.19
+    helm.sh/chart: nr-k8s-otel-collector-0.8.21
 data:
   daemonset-config.yaml: |
     receivers:
@@ -142,77 +142,95 @@ data:
           - /var/log/container/otel-collector-daemonset/*.log
           - /var/log/container/otel-collector-deployment/*.log
           - /var/log/containers/*-exec.log
-        start_at: beginning
         include_file_path: true
         include_file_name: true
         operators:
-          - type: router
-            id: get-format
-            routes:
-              - output: parser-docker
-                expr: 'body matches "^\\{"'
-              - output: parser-crio
-                expr: 'body matches "^[^ Z]+ "'
-              - output: parser-containerd
-                expr: 'body matches "^[^ Z]+Z"'
-          # CRI-O format
-          - type: regex_parser
-            id: parser-crio
-            regex:
-              '^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$'
-            output: extract_metadata_from_filepath
-            timestamp:
-              parse_from: attributes.time
-              layout_type: gotime
-              layout: '2006-01-02T15:04:05.999999999Z07:00'
-          # Parse CRI-Containerd format
-          - type: regex_parser
-            id: parser-containerd
-            regex:
-              '^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$'
-            output: extract_metadata_from_filepath
-            timestamp:
-              parse_from: attributes.time
-              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-          # Parse Docker format
-          - type: json_parser
-            id: parser-docker
-            output: extract_metadata_from_filepath
-            timestamp:
-              parse_from: attributes.time
-              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-          - type: move
-            from: attributes.log
-            to: body
-          # Extract metadata from file path
-          - type: regex_parser
-            id: extract_metadata_from_filepath
-            regex: '^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$'
-            parse_from: attributes["log.file.path"]
-            cache:
-              size: 128
-          # Rename attributes
-          - type: move
-            from: attributes.stream
-            to: attributes["log.iostream"]
-          - type: move
-            from: attributes.container_name
-            to: resource["k8s.container.name"]
-          - type: move
-            from: attributes.namespace
-            to: resource["k8s.namespace.name"]
-          - type: move
-            from: attributes.pod_name
-            to: resource["k8s.pod.name"]
-          - type: move
-            from: attributes.restart_count
-            to: resource["k8s.container.restart_count"]
-          - type: move
-            from: attributes.uid
-            to: resource["k8s.pod.uid"]
+        - id: container-parser
+          type: container
+
 
     processors:
       
+
+      groupbyattrs:
+        keys:
+          - pod
+          - uid
+          - container
+          - daemonset
+          - replicaset
+          - statefulset
+          - deployment
+          - cronjob
+          - configmap
+          - job
+          - job_name
+          - horizontalpodautoscaler
+          - persistentvolume
+          - persistentvolumeclaim
+          - endpoint
+          - mutatingwebhookconfiguration
+          - validatingwebhookconfiguration
+          - lease
+          - storageclass
+          - secret
+          - service
+          - resourcequota
+          - node
+          - namespace
+
+      transform/ksm:
+        metric_statements:
+          - delete_key(resource.attributes, "k8s.node.name")
+          - delete_key(resource.attributes, "k8s.namespace.name")
+          - delete_key(resource.attributes, "k8s.pod.uid")
+          - delete_key(resource.attributes, "k8s.pod.name")
+          - delete_key(resource.attributes, "k8s.container.name")
+          - delete_key(resource.attributes, "k8s.replicaset.name")
+          - delete_key(resource.attributes, "k8s.deployment.name")
+          - delete_key(resource.attributes, "k8s.statefulset.name")
+          - delete_key(resource.attributes, "k8s.daemonset.name")
+          - delete_key(resource.attributes, "k8s.job.name")
+          - delete_key(resource.attributes, "k8s.cronjob.name")
+          - delete_key(resource.attributes, "k8s.replicationcontroller.name")
+          - delete_key(resource.attributes, "k8s.hpa.name")
+          - delete_key(resource.attributes, "k8s.resourcequota.name")
+          - delete_key(resource.attributes, "k8s.volume.name")
+          - set(resource.attributes["k8s.pod.uid"], resource.attributes["uid"])
+          - set(resource.attributes["k8s.node.name"], resource.attributes["node"])
+          - set(resource.attributes["k8s.namespace.name"], resource.attributes["namespace"])
+          - set(resource.attributes["k8s.pod.name"], resource.attributes["pod"])
+          - set(resource.attributes["k8s.container.name"], resource.attributes["container"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["replicaset"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["deployment"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["statefulset"])
+          - set(resource.attributes["k8s.daemonset.name"], resource.attributes["daemonset"])
+          - set(resource.attributes["k8s.job.name"], resource.attributes["job_name"])
+          - set(resource.attributes["k8s.cronjob.name"], resource.attributes["cronjob"])
+          - set(resource.attributes["k8s.replicationcontroller.name"], resource.attributes["replicationcontroller"])
+          - set(resource.attributes["k8s.hpa.name"], resource.attributes["horizontalpodautoscaler"])
+          - set(resource.attributes["k8s.resourcequota.name"], resource.attributes["resourcequota"])
+          - set(resource.attributes["k8s.volume.name"], resource.attributes["volumename"])
+          - set(resource.attributes["k8s.volume.name"], resource.attributes["persistentvolume"])
+          - set(resource.attributes["k8s.pvc.name"], resource.attributes["persistentvolumeclaim"])
+          - delete_key(resource.attributes, "uid")
+          - delete_key(resource.attributes, "node")
+          - delete_key(resource.attributes, "namespace")
+          - delete_key(resource.attributes, "pod")
+          - delete_key(resource.attributes, "container")
+          - delete_key(resource.attributes, "replicaset")
+          - delete_key(resource.attributes, "deployment")
+          - delete_key(resource.attributes, "statefulset")
+          - delete_key(resource.attributes, "daemonset")
+          - delete_key(resource.attributes, "job_name")
+          - delete_key(resource.attributes, "cronjob")
+          - delete_key(resource.attributes, "replicationcontroller")
+          - delete_key(resource.attributes, "horizontalpodautoscaler")
+          - delete_key(resource.attributes, "resourcequota")
+          - delete_key(resource.attributes, "volumename")
+          - delete_key(resource.attributes, "persistentvolume")
+          - delete_key(resource.attributes, "persistentvolumeclaim")
+
 
       metricstransform/ldm:
         transforms:
@@ -452,11 +470,22 @@ data:
           - key: type
             action: delete
 
+      resourcedetection/env:
+        detectors: ["env", "system"]
+        override: false
+        system:
+          hostname_sources: ["os"]
+          resource_attributes:
+            host.id:
+              enabled: true
       resourcedetection/cloudproviders:
-        detectors: [gcp, eks, ec2, aks, azure]
+        detectors: [gcp, eks, azure, aks, ec2]
         timeout: 2s
         override: false
-
+        ec2:
+          resource_attributes:
+            host.name:
+              enabled: false
       resource:
         attributes:
           # We set the cluster name to what the customer specified in the helm chart
@@ -468,7 +497,7 @@ data:
             value: 'true'
           - key: "newrelic.chart.version"
             action: upsert
-            value: 0.8.19
+            value: 0.8.21
           - key: service.name
             action: delete
           - key: service_name
@@ -495,108 +524,6 @@ data:
           - key: net.host.port
             action: delete
 
-      attributes/self:
-        actions:
-          - key: k8s.node.name
-            action: upsert
-            from_attribute: node
-          - key: k8s.namespace.name
-            action: upsert
-            from_attribute: namespace
-          - key: k8s.pod.name
-            action: upsert
-            from_attribute: pod
-          - key: k8s.container.name
-            action: upsert
-            from_attribute: container
-          - key: k8s.replicaset.name
-            action: upsert
-            from_attribute: replicaset
-          - key: k8s.deployment.name
-            action: upsert
-            from_attribute: deployment
-          - key: k8s.statefulset.name
-            action: upsert
-            from_attribute: statefulset
-          - key: k8s.daemonset.name
-            action: upsert
-            from_attribute: daemonset
-          - key: k8s.job.name
-            action: upsert
-            from_attribute: job_name
-          - key: k8s.cronjob.name
-            action: upsert
-            from_attribute: cronjob
-          - key: k8s.replicationcontroller.name
-            action: upsert
-            from_attribute: replicationcontroller
-          - key: k8s.hpa.name
-            action: upsert
-            from_attribute: horizontalpodautoscaler
-          - key: k8s.resourcequota.name
-            action: upsert
-            from_attribute: resourcequota
-          - key: k8s.volume.name
-            action: upsert
-            from_attribute: volumename
-          - key: k8s.volume.name
-            action: upsert
-            from_attribute: persistentvolume
-          - key: k8s.pvc.name
-            action: upsert
-            from_attribute: persistentvolumeclaim
-          - key: node
-            action: delete
-          - key: namespace
-            action: delete
-          - key: pod
-            action: delete
-          - key: container
-            action: delete
-          - key: replicaset
-            action: delete
-          - key: deployment
-            action: delete
-          - key: statefulset
-            action: delete
-          - key: daemonset
-            action: delete
-          - key: job_name
-            action: delete
-          - key: cronjob
-            action: delete
-          - key: replicationcontroller
-            action: delete
-          - key: horizontalpodautoscaler
-            action: delete
-          - key: resourcequota
-            action: delete
-          - key: volumename
-            action: delete
-          - key: persistentvolume
-            action: delete
-          - key: persistentvolumeclaim
-            action: delete
-
-      k8sattributes:
-        auth_type: "serviceAccount"
-        passthrough: false
-        filter:
-          node_from_env_var: KUBE_NODE_NAME
-        extract:
-          metadata:
-            - k8s.pod.name
-            - k8s.pod.uid
-            - k8s.deployment.name
-            - k8s.daemonset.name
-            - k8s.namespace.name
-            - k8s.node.name
-            - k8s.pod.start_time
-        pod_association:
-          - sources:
-            - from: resource_attribute
-              name: k8s.pod.uid
-
       memory_limiter:
          check_interval: 1s
          limit_percentage: 80
@@ -604,6 +531,33 @@ data:
 
       cumulativetodelta:
 
+      k8sattributes/ksm:
+        # Metadata attached by this processor is reliant on the uid & pod name. This would be sufficient for most types
+        # of metrics but there are cases of metrics where a uid would not be present and thus metadata would
+        # not be attached. To address cases like these, metadata attributes must be annotated in a different manner
+        # such as by preserving some of the attributes presented by KSM.
+        auth_type: "serviceAccount"
+        passthrough: false
+        filter:
+          node_from_env_var: KUBE_NODE_NAME
+        extract:
+          metadata:
+            - k8s.deployment.name
+            - k8s.daemonset.name
+            - k8s.namespace.name
+            - k8s.node.name
+            - k8s.pod.start_time
+            - k8s.replicaset.name
+            - k8s.statefulset.name
+            - k8s.cronjob.name
+            - k8s.job.name
+        pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.name
       batch:
         send_batch_max_size: 1000
         timeout: 30s
@@ -620,7 +574,7 @@ data:
         verbosity: detailed
         sampling_initial: 5
         sampling_thereafter: 200
-    
+
     connectors:
       
       routing/nr_pipelines:
@@ -647,7 +601,7 @@ data:
             pipelines: [metrics/nr]
           - context: metric
             condition: instrumentation_scope.name == "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
-            pipelines: [metrics/nr]
+            pipelines: [metrics/nr_prometheus_cadv_kubelet]
           - context: metric
             condition: instrumentation_scope.name == "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver"
             pipelines: [metrics/nr]
@@ -685,12 +639,35 @@ data:
             - filter/exclude_system_paging
             - filter/exclude_network
             - attributes/exclude_system_paging
+            - resourcedetection/env
             - resourcedetection/cloudproviders
             - resource
             - transform/low_data_mode_inator
             - resource/low_data_mode_inator
-            - attributes/self
-            - k8sattributes
+            - k8sattributes/ksm
+            - cumulativetodelta
+            - batch
+          exporters:
+            - otlphttp/newrelic
+            - debug
+        metrics/nr_prometheus_cadv_kubelet:
+          receivers:
+            - routing/nr_pipelines
+          processors:
+            - memory_limiter
+            - metricstransform/ldm
+            - metricstransform/cadvisor
+            - metricstransform/kubelet
+            - filter/exclude_metrics_low_data_mode
+            - transform/truncate
+            - resourcedetection/env
+            - resourcedetection/cloudproviders
+            - resource
+            - transform/low_data_mode_inator
+            - resource/low_data_mode_inator
+            - groupbyattrs
+            - transform/ksm
+            - k8sattributes/ksm
             - cumulativetodelta
             - batch
           exporters:
@@ -710,7 +687,7 @@ data:
             - memory_limiter
             - transform/truncate
             - resource
-            - k8sattributes
+            - k8sattributes/ksm
             - batch
           exporters:
             - otlphttp/newrelic

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/daemonset-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.21
+    helm.sh/chart: nr-k8s-otel-collector-0.8.22
 data:
   daemonset-config.yaml: |
     receivers:
@@ -497,7 +497,7 @@ data:
             value: 'true'
           - key: "newrelic.chart.version"
             action: upsert
-            value: 0.8.21
+            value: 0.8.22
           - key: service.name
             action: delete
           - key: service_name

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/daemonset.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.19
+    helm.sh/chart: nr-k8s-otel-collector-0.8.21
 spec:
   selector:
     matchLabels:
@@ -24,7 +24,7 @@ spec:
         app.kubernetes.io/name: nr-k8s-otel-collector
         component: daemonset
       annotations:
-        checksum/config: fe8517f1792e9613079e3fe84e2e4f3d393dfbd8a3d0e1d5829b24ca8d1112ee
+        checksum/config: c27445e2dc1b10bbc4cd8162376cada3f999cf641e20b3748e6db721f978a872
     spec:
       serviceAccountName: example-nr-k8s-otel-collector
       containers:

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/daemonset.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.21
+    helm.sh/chart: nr-k8s-otel-collector-0.8.22
 spec:
   selector:
     matchLabels:
@@ -24,7 +24,7 @@ spec:
         app.kubernetes.io/name: nr-k8s-otel-collector
         component: daemonset
       annotations:
-        checksum/config: c27445e2dc1b10bbc4cd8162376cada3f999cf641e20b3748e6db721f978a872
+        checksum/config: 9af9d75c4c0eb9157093827273d254f57ef60eb47e934cc8d253db31ab5160f0
     spec:
       serviceAccountName: example-nr-k8s-otel-collector
       containers:

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.21
+    helm.sh/chart: nr-k8s-otel-collector-0.8.22
 data:
   deployment-config.yaml: |
     receivers:
@@ -481,7 +481,7 @@ data:
             value: 'true'
           - key: "newrelic.chart.version"
             action: upsert
-            value: 0.8.21
+            value: 0.8.22
           - key: service.name
             action: delete
           - key: service_name
@@ -506,7 +506,7 @@ data:
             value: 'true'
           - key: "newrelic.chart.version"
             action: upsert
-            value: 0.8.21
+            value: 0.8.22
 
       transform/events:
         log_statements:

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment-configmap.yaml
@@ -712,6 +712,7 @@ data:
             - groupbyattrs
             - transform/ksm
             - k8sattributes/ksm
+            - cumulativetodelta
             - batch
           exporters:
             - otlphttp/newrelic

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.19
+    helm.sh/chart: nr-k8s-otel-collector-0.8.21
 data:
   deployment-config.yaml: |
     receivers:
@@ -22,7 +22,7 @@ data:
       k8s_events:
       prometheus/ksm:
         config:
-          scrape_configs: 
+          scrape_configs:
             - job_name: kube-state-metrics
               scrape_interval: 1m
               kubernetes_sd_configs:
@@ -31,7 +31,7 @@ data:
                 - action: keep
                   regex: kube-state-metrics
                   source_labels:
-                    - __meta_kubernetes_pod_label_app_kubernetes_io_name
+                  - __meta_kubernetes_pod_label_app_kubernetes_io_name
                 - action: replace
                   target_label: job_label
                   replacement: kube-state-metrics
@@ -53,11 +53,11 @@ data:
               bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
               relabel_configs:
               - action: keep
-                regex: default;kubernetes;https
                 source_labels:
                 - __meta_kubernetes_namespace
                 - __meta_kubernetes_service_name
                 - __meta_kubernetes_endpoint_port_name
+                regex: default;kubernetes;https
               - action: replace
                 source_labels:
                 - __meta_kubernetes_namespace
@@ -69,6 +69,78 @@ data:
               - action: replace
                 target_label: job_label
                 replacement: apiserver
+            # if not running on openshift, this only works if controller-manager port 10257 is exposed in the pod
+            # TODO: we may want to create our own service instead to expose the endpoint and scrape it instead
+            - job_name: controller-manager
+              scrape_interval: 1m
+              metrics_path: /metrics
+              kubernetes_sd_configs:
+                - role: pod
+                  namespaces:
+                    names:
+                      - kube-system
+              scheme: https
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: false
+              bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              relabel_configs:
+              - action: keep
+                source_labels:
+                - __meta_kubernetes_pod_name
+                - __address__
+                regex: .*controller-manager.*;.*:10257$
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_namespace
+                target_label: namespace
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_pod_name
+                target_label: pod
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_service_name
+                target_label: service
+              - action: replace
+                target_label: job_label
+                replacement: controller-manager
+            # if not running on openshift, this only works if scheduler port 10259 is exposed in the pod
+            # we may want to create our own service instead to expose the endpoint and scrape it instead
+            - job_name: scheduler
+              scrape_interval: 1m
+              metrics_path: /metrics
+              kubernetes_sd_configs:
+                - role: pod
+                  namespaces:
+                    names:
+                      - kube-system
+              scheme: https
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: false
+              bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              relabel_configs:
+              - action: keep
+                source_labels:
+                - __meta_kubernetes_pod_name
+                - __address__
+                regex: .*scheduler.*;.*:10259$
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_namespace
+                target_label: namespace
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_pod_name
+                target_label: pod
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_service_name
+                target_label: service
+              - action: replace
+                target_label: job_label
+                replacement: scheduler
 
     processors:
       
@@ -156,18 +228,18 @@ data:
         transforms:
           - include: kubernetes_build_info
             action: update
-            new_name: k8s.cluster.info 
+            new_name: k8s.cluster.info
 
       metricstransform/kube_pod_container_status_phase:
         transforms:
           - include: 'kube_pod_container_status_waiting'
-            match_type: strict 
+            match_type: strict
             action: update
             new_name: 'kube_pod_container_status_phase'
             operations:
             - action: add_label
               new_label: container_phase
-              new_value: waiting 
+              new_value: waiting
           - include: 'kube_pod_container_status_running'
             match_type: strict
             action: update
@@ -175,7 +247,7 @@ data:
             operations:
             - action: add_label
               new_label: container_phase
-              new_value: running 
+              new_value: running
           - include: 'kube_pod_container_status_terminated'
             match_type: strict
             action: update
@@ -183,7 +255,7 @@ data:
             operations:
             - action: add_label
               new_label: container_phase
-              new_value: terminated 
+              new_value: terminated
 
       metricstransform/ldm:
         transforms:
@@ -194,12 +266,12 @@ data:
             - action: add_label
               new_label: low.data.mode
               new_value: 'false'
-      
+
       metricstransform/k8s_cluster_info_ldm:
         transforms:
           - include: k8s.cluster.info
             action: update
-            operations: 
+            operations:
             - action: update_label
               label: low.data.mode
               value_actions:
@@ -325,7 +397,7 @@ data:
                 value_actions:
                   - value: 'false'
                     new_value: 'true'
-      
+
       metricstransform/apiserver:
         transforms:
           - include: apiserver_storage_objects
@@ -355,7 +427,7 @@ data:
               value_actions:
               - value: 'false'
                 new_value: 'true'
-    
+
       filter/exclude_metrics_low_data_mode:
         metrics:
           metric:
@@ -380,6 +452,24 @@ data:
             - metric.name == "kube_pod_status_ready" and value_double < 0.5
             - metric.name == "kube_deployment_status_condition" and value_double < 0.5
 
+      resourcedetection/env:
+        detectors: ["env", "system"]
+        override: false
+        system:
+          hostname_sources: ["os"]
+          resource_attributes:
+            host.id:
+              enabled: true
+
+      resourcedetection/cloudproviders:
+        detectors: [gcp, eks, azure, aks, ec2, ecs]
+        timeout: 2s
+        override: false
+        ec2:
+          resource_attributes:
+            host.name:
+              enabled: false
+
       resource/metrics:
         attributes:
           # We set the cluster name to what the customer specified in the helm chart
@@ -391,12 +481,12 @@ data:
             value: 'true'
           - key: "newrelic.chart.version"
             action: upsert
-            value: 0.8.19
+            value: 0.8.21
           - key: service.name
             action: delete
           - key: service_name
             action: delete
-      
+
       resource/events:
         attributes:
           - key: "event.name"
@@ -416,7 +506,7 @@ data:
             value: 'true'
           - key: "newrelic.chart.version"
             action: upsert
-            value: 0.8.19
+            value: 0.8.21
 
       transform/events:
         log_statements:
@@ -461,7 +551,7 @@ data:
             - k8s.cronjob.name
             - k8s.job.name
         pod_association:
-          - sources: 
+          - sources:
             - from: resource_attribute
               name: k8s.pod.uid
           - sources:
@@ -571,7 +661,7 @@ data:
         verbosity: detailed
         sampling_initial: 5
         sampling_thereafter: 200
-    
+
     connectors:
       
 
@@ -584,6 +674,12 @@ data:
             pipelines: [metrics/nr_ksm]
           - context: datapoint
             condition: attributes["job_label"] == "apiserver"
+            pipelines: [metrics/nr_controlplane]
+          - context: datapoint
+            condition: attributes["job_label"] == "controller-manager"
+            pipelines: [metrics/nr_controlplane]
+          - context: datapoint
+            condition: attributes["job_label"] == "scheduler"
             pipelines: [metrics/nr_controlplane]
 
     service:
@@ -611,6 +707,8 @@ data:
             - transform/low_data_mode_inator
             - resource/low_data_mode_inator
             - resource/metrics
+            - resourcedetection/env
+            - resourcedetection/cloudproviders
             - groupbyattrs
             - transform/ksm
             - k8sattributes/ksm

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/name: nr-k8s-otel-collector
         component: deployment
       annotations:
-        checksum/config: c4121e2929bc2aad90c8b3e1a62cc799be62e872d1d8f966afa235bf5cdfda72
+        checksum/config: ec5752d8fba3ed6a012d57aeb1689a23343e263563806819d12aebdc9b69573e
     spec:
       serviceAccountName: example-nr-k8s-otel-collector
       containers:

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.19
+    helm.sh/chart: nr-k8s-otel-collector-0.8.21
 spec:
   replicas: 1
   minReadySeconds: 5
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/name: nr-k8s-otel-collector
         component: deployment
       annotations:
-        checksum/config: 25973d4f8474f1c10a818d19940c5b389b3ebafaab637c005eed50a181ed072d
+        checksum/config: 67ba79970cac10baa79299c37a4f3ecb8b1ca82e4f6ba23c3c88492a41825dec
     spec:
       serviceAccountName: example-nr-k8s-otel-collector
       containers:

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.21
+    helm.sh/chart: nr-k8s-otel-collector-0.8.22
 spec:
   replicas: 1
   minReadySeconds: 5
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/name: nr-k8s-otel-collector
         component: deployment
       annotations:
-        checksum/config: 67ba79970cac10baa79299c37a4f3ecb8b1ca82e4f6ba23c3c88492a41825dec
+        checksum/config: c4121e2929bc2aad90c8b3e1a62cc799be62e872d1d8f966afa235bf5cdfda72
     spec:
       serviceAccountName: example-nr-k8s-otel-collector
       containers:

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/secret.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/secret.yaml
@@ -10,6 +10,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.21
+    helm.sh/chart: nr-k8s-otel-collector-0.8.22
 data:
   licenseKey: PE5SX2xpY2Vuc2VLZXk+

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/secret.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/secret.yaml
@@ -10,6 +10,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.19
+    helm.sh/chart: nr-k8s-otel-collector-0.8.21
 data:
   licenseKey: PE5SX2xpY2Vuc2VLZXk+

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/service.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/service.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.19
+    helm.sh/chart: nr-k8s-otel-collector-0.8.21
 spec:
   type: ClusterIP
   ports:

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/service.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/service.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.21
+    helm.sh/chart: nr-k8s-otel-collector-0.8.22
 spec:
   type: ClusterIP
   ports:

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/serviceaccount.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/serviceaccount.yaml
@@ -10,5 +10,5 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.19
+    helm.sh/chart: nr-k8s-otel-collector-0.8.21
   annotations:

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/serviceaccount.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/serviceaccount.yaml
@@ -10,5 +10,5 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.21
+    helm.sh/chart: nr-k8s-otel-collector-0.8.22
   annotations:

--- a/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
@@ -542,89 +542,6 @@ data:
           - key: net.host.port
             action: delete
 
-      attributes/self:
-        actions:
-          - key: k8s.node.name
-            action: upsert
-            from_attribute: node
-          - key: k8s.namespace.name
-            action: upsert
-            from_attribute: namespace
-          - key: k8s.pod.name
-            action: upsert
-            from_attribute: pod
-          - key: k8s.container.name
-            action: upsert
-            from_attribute: container
-          - key: k8s.replicaset.name
-            action: upsert
-            from_attribute: replicaset
-          - key: k8s.deployment.name
-            action: upsert
-            from_attribute: deployment
-          - key: k8s.statefulset.name
-            action: upsert
-            from_attribute: statefulset
-          - key: k8s.daemonset.name
-            action: upsert
-            from_attribute: daemonset
-          - key: k8s.job.name
-            action: upsert
-            from_attribute: job_name
-          - key: k8s.cronjob.name
-            action: upsert
-            from_attribute: cronjob
-          - key: k8s.replicationcontroller.name
-            action: upsert
-            from_attribute: replicationcontroller
-          - key: k8s.hpa.name
-            action: upsert
-            from_attribute: horizontalpodautoscaler
-          - key: k8s.resourcequota.name
-            action: upsert
-            from_attribute: resourcequota
-          - key: k8s.volume.name
-            action: upsert
-            from_attribute: volumename
-          - key: k8s.volume.name
-            action: upsert
-            from_attribute: persistentvolume
-          - key: k8s.pvc.name
-            action: upsert
-            from_attribute: persistentvolumeclaim
-          - key: node
-            action: delete
-          - key: namespace
-            action: delete
-          - key: pod
-            action: delete
-          - key: container
-            action: delete
-          - key: replicaset
-            action: delete
-          - key: deployment
-            action: delete
-          - key: statefulset
-            action: delete
-          - key: daemonset
-            action: delete
-          - key: job_name
-            action: delete
-          - key: cronjob
-            action: delete
-          - key: replicationcontroller
-            action: delete
-          - key: horizontalpodautoscaler
-            action: delete
-          - key: resourcequota
-            action: delete
-          - key: volumename
-            action: delete
-          - key: persistentvolume
-            action: delete
-          - key: persistentvolumeclaim
-            action: delete
-
       memory_limiter:
          check_interval: 1s
          limit_percentage: 80
@@ -702,7 +619,7 @@ data:
             pipelines: [metrics/nr]
           - context: metric
             condition: instrumentation_scope.name == "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
-            pipelines: [metrics/nr]
+            pipelines: [metrics/nr_prometheus_cadv_kubelet]
           - context: metric
             condition: instrumentation_scope.name == "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver"
             pipelines: [metrics/nr]
@@ -756,11 +673,37 @@ data:
             - filter/exclude_network
             - attributes/exclude_system_paging
             - resourcedetection/env
-          {{- if include "newrelic.common.openShift" . }}
+            {{- if include "newrelic.common.openShift" . }}
             - resourcedetection/openshift
-           # TODO openshift resource detection already obtains some cloud provider details, revisit, resourcedetection/cloudproviders fails to obtain more attributes
-           # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor/internal/openshift/documentation.md
-           #- resourcedetection/cloudproviders
+            {{- else  }}
+            - resourcedetection/cloudproviders
+            {{- end }}
+            - resource
+            {{- if include "nrKubernetesOtel.lowDataMode" . }}
+            - transform/low_data_mode_inator
+            - resource/low_data_mode_inator
+            {{- end }}
+            - k8sattributes/ksm
+            - cumulativetodelta
+            - batch
+          exporters:
+            - otlphttp/newrelic
+            - debug
+        metrics/nr_prometheus_cadv_kubelet:
+          receivers:
+            - routing/nr_pipelines
+          processors:
+            - memory_limiter
+            {{- if include "nrKubernetesOtel.lowDataMode" . }}
+            - metricstransform/ldm
+            - metricstransform/cadvisor
+            - metricstransform/kubelet
+            - filter/exclude_metrics_low_data_mode
+            {{- end }}
+            - transform/truncate
+            - resourcedetection/env
+            {{- if include "newrelic.common.openShift" . }}
+            - resourcedetection/openshift
             {{- else  }}
             - resourcedetection/cloudproviders
             {{- end }}

--- a/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
@@ -159,6 +159,86 @@ data:
     processors:
       {{- include "nrKubernetesOtel.daemonset.configMap.extraConfig.processors" . | nindent 6 }}
 
+      groupbyattrs:
+        keys:
+          - pod
+          - uid
+          - container
+          - daemonset
+          - replicaset
+          - statefulset
+          - deployment
+          - cronjob
+          - configmap
+          - job
+          - job_name
+          - horizontalpodautoscaler
+          - persistentvolume
+          - persistentvolumeclaim
+          - endpoint
+          - mutatingwebhookconfiguration
+          - validatingwebhookconfiguration
+          - lease
+          - storageclass
+          - secret
+          - service
+          - resourcequota
+          - node
+          - namespace
+
+      transform/ksm:
+        metric_statements:
+          - delete_key(resource.attributes, "k8s.node.name")
+          - delete_key(resource.attributes, "k8s.namespace.name")
+          - delete_key(resource.attributes, "k8s.pod.uid")
+          - delete_key(resource.attributes, "k8s.pod.name")
+          - delete_key(resource.attributes, "k8s.container.name")
+          - delete_key(resource.attributes, "k8s.replicaset.name")
+          - delete_key(resource.attributes, "k8s.deployment.name")
+          - delete_key(resource.attributes, "k8s.statefulset.name")
+          - delete_key(resource.attributes, "k8s.daemonset.name")
+          - delete_key(resource.attributes, "k8s.job.name")
+          - delete_key(resource.attributes, "k8s.cronjob.name")
+          - delete_key(resource.attributes, "k8s.replicationcontroller.name")
+          - delete_key(resource.attributes, "k8s.hpa.name")
+          - delete_key(resource.attributes, "k8s.resourcequota.name")
+          - delete_key(resource.attributes, "k8s.volume.name")
+          - set(resource.attributes["k8s.pod.uid"], resource.attributes["uid"])
+          - set(resource.attributes["k8s.node.name"], resource.attributes["node"])
+          - set(resource.attributes["k8s.namespace.name"], resource.attributes["namespace"])
+          - set(resource.attributes["k8s.pod.name"], resource.attributes["pod"])
+          - set(resource.attributes["k8s.container.name"], resource.attributes["container"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["replicaset"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["deployment"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["statefulset"])
+          - set(resource.attributes["k8s.daemonset.name"], resource.attributes["daemonset"])
+          - set(resource.attributes["k8s.job.name"], resource.attributes["job_name"])
+          - set(resource.attributes["k8s.cronjob.name"], resource.attributes["cronjob"])
+          - set(resource.attributes["k8s.replicationcontroller.name"], resource.attributes["replicationcontroller"])
+          - set(resource.attributes["k8s.hpa.name"], resource.attributes["horizontalpodautoscaler"])
+          - set(resource.attributes["k8s.resourcequota.name"], resource.attributes["resourcequota"])
+          - set(resource.attributes["k8s.volume.name"], resource.attributes["volumename"])
+          - set(resource.attributes["k8s.volume.name"], resource.attributes["persistentvolume"])
+          - set(resource.attributes["k8s.pvc.name"], resource.attributes["persistentvolumeclaim"])
+          - delete_key(resource.attributes, "uid")
+          - delete_key(resource.attributes, "node")
+          - delete_key(resource.attributes, "namespace")
+          - delete_key(resource.attributes, "pod")
+          - delete_key(resource.attributes, "container")
+          - delete_key(resource.attributes, "replicaset")
+          - delete_key(resource.attributes, "deployment")
+          - delete_key(resource.attributes, "statefulset")
+          - delete_key(resource.attributes, "daemonset")
+          - delete_key(resource.attributes, "job_name")
+          - delete_key(resource.attributes, "cronjob")
+          - delete_key(resource.attributes, "replicationcontroller")
+          - delete_key(resource.attributes, "horizontalpodautoscaler")
+          - delete_key(resource.attributes, "resourcequota")
+          - delete_key(resource.attributes, "volumename")
+          - delete_key(resource.attributes, "persistentvolume")
+          - delete_key(resource.attributes, "persistentvolumeclaim")
+
+
       metricstransform/ldm:
         transforms:
           - include: .*
@@ -545,25 +625,6 @@ data:
           - key: persistentvolumeclaim
             action: delete
 
-      k8sattributes:
-        auth_type: "serviceAccount"
-        passthrough: false
-        filter:
-          node_from_env_var: KUBE_NODE_NAME
-        extract:
-          metadata:
-            - k8s.pod.name
-            - k8s.pod.uid
-            - k8s.deployment.name
-            - k8s.daemonset.name
-            - k8s.namespace.name
-            - k8s.node.name
-            - k8s.pod.start_time
-        pod_association:
-          - sources:
-            - from: resource_attribute
-              name: k8s.pod.uid
-
       memory_limiter:
          check_interval: 1s
          limit_percentage: 80
@@ -571,6 +632,33 @@ data:
 
       cumulativetodelta:
 
+      k8sattributes/ksm:
+        # Metadata attached by this processor is reliant on the uid & pod name. This would be sufficient for most types
+        # of metrics but there are cases of metrics where a uid would not be present and thus metadata would
+        # not be attached. To address cases like these, metadata attributes must be annotated in a different manner
+        # such as by preserving some of the attributes presented by KSM.
+        auth_type: "serviceAccount"
+        passthrough: false
+        filter:
+          node_from_env_var: KUBE_NODE_NAME
+        extract:
+          metadata:
+            - k8s.deployment.name
+            - k8s.daemonset.name
+            - k8s.namespace.name
+            - k8s.node.name
+            - k8s.pod.start_time
+            - k8s.replicaset.name
+            - k8s.statefulset.name
+            - k8s.cronjob.name
+            - k8s.job.name
+        pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.name
       batch:
         send_batch_max_size: 1000
         timeout: 30s
@@ -681,8 +769,9 @@ data:
             - transform/low_data_mode_inator
             - resource/low_data_mode_inator
             {{- end }}
-            - attributes/self
-            - k8sattributes
+            - groupbyattrs
+            - transform/ksm
+            - k8sattributes/ksm
             - cumulativetodelta
             - batch
           exporters:
@@ -704,7 +793,7 @@ data:
             - memory_limiter
             - transform/truncate
             - resource
-            - k8sattributes
+            - k8sattributes/ksm
             - batch
           exporters:
             - otlphttp/newrelic

--- a/charts/nr-k8s-otel-collector/templates/deployment-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/deployment-configmap.yaml
@@ -759,6 +759,7 @@ data:
             - groupbyattrs
             - transform/ksm
             - k8sattributes/ksm
+            - cumulativetodelta
             - batch
           exporters:
             - otlphttp/newrelic


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

#### What this PR does / why we need it:
1. Fixes a typo for the openshift inside processors.
2. Removes the attributes/self because it is not needed anymore.
3. Uses k8sattribute processor which is being used inside deployment configmap
4. Factors the prometheus into a new pipeline

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
