### PR TITLE
[agent-control-deployment] setting value through env to avoid race conditions

### DIFF
--- a/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 
 type: application
 
-version: 0.0.50
+version: 0.0.51
 appVersion: "0.39.0"
 
 dependencies:

--- a/charts/agent-control-deployment/templates/_helpers.tpl
+++ b/charts/agent-control-deployment/templates/_helpers.tpl
@@ -101,7 +101,7 @@ cluster name, licenses, and custom attributes
 {{- $config := dict "server" (dict "enabled" true "port" $statusServerPort "host" $statusServerHost) -}}
 
 {{- /* Add to config k8s cluster and namespace config */ -}}
-{{- $k8s := (dict "cluster_name" (include "newrelic.common.cluster" .) "namespace" .Release.Namespace "chart_version" .Chart.Version) -}}
+{{- $k8s := (dict "cluster_name" (include "newrelic.common.cluster" .) "namespace" .Release.Namespace) -}}
 {{- $config = mustMerge $config (dict "k8s" $k8s) -}}
 
 {{- /* Add fleet_control if enabled */ -}}
@@ -137,6 +137,9 @@ cluster name, licenses, and custom attributes
 {{- end -}}
 {{- if ne (printf "%v" $config.server.port) (printf "%v" $statusServerPort) -}}
   {{- fail "Setting up the status server port is `.Values.config.agentControl.content` is not supported because it would conflict with container probes. Use `.Values.config.status_server.port` instead" -}}
+{{- end -}}
+{{- if $config.k8s.chart_version -}}
+  {{- fail "The chart version is set automatically via environment variable and should not be set manually" -}}
 {{- end -}}
 
 {{- $config | toYaml -}}

--- a/charts/agent-control-deployment/templates/deployment-agentcontrol.yaml
+++ b/charts/agent-control-deployment/templates/deployment-agentcontrol.yaml
@@ -76,6 +76,9 @@ spec:
               value: debug
           {{- end }}
 
+            - name: NR_AC_K8S__CHART_VERSION
+              value: {{ .Chart.Version }}
+
           {{- /* ----- Variables used to send data downstream to subagents */}}
             - name: NR_LICENSE_KEY
               valueFrom:

--- a/charts/agent-control-deployment/tests/configmap_agentcontrol_config_test.yaml
+++ b/charts/agent-control-deployment/tests/configmap_agentcontrol_config_test.yaml
@@ -28,7 +28,6 @@ tests:
           value: |
             agents: {}
             k8s:
-              chart_version: 1.2.3-beta
               cluster_name: my-cluster
               namespace: my-namespace
             server:
@@ -50,7 +49,6 @@ tests:
           value: |
             agents: {}
             k8s:
-              chart_version: 1.2.3-beta
               cluster_name: my-cluster
               namespace: my-namespace
             server:
@@ -77,7 +75,6 @@ tests:
               endpoint: https://opamp.service.newrelic.com/v1/opamp
               fleet_id: abcefg
             k8s:
-              chart_version: 1.2.3-beta
               cluster_name: my-cluster
               namespace: my-namespace
             server:
@@ -102,7 +99,6 @@ tests:
                 token_url: https://system-identity-oauth.service.newrelic.com/oauth2/token
               endpoint: https://opamp.service.newrelic.com/v1/opamp
             k8s:
-              chart_version: 1.2.3-beta
               cluster_name: my-cluster
               namespace: my-namespace
             server:
@@ -130,7 +126,6 @@ tests:
                 token_url: https://system-identity-oauth.service.newrelic.com/oauth2/token
               endpoint: https://opamp.service.newrelic.com/v1/opamp
             k8s:
-              chart_version: 1.2.3-beta
               cluster_name: my-cluster
               namespace: my-namespace
             server:
@@ -163,7 +158,6 @@ tests:
                 token_url: https://system-identity-oauth.service.newrelic.com/oauth2/token
               endpoint: https://opamp.service.newrelic.com/v1/opamp
             k8s:
-              chart_version: 1.2.3-beta
               cluster_name: config-cluster
               namespace: config-namespace
             server:
@@ -189,7 +183,6 @@ tests:
                 token_url: https://system-identity-oauth.service.newrelic.com/oauth2/token
               endpoint: https://opamp.service.eu.newrelic.com/v1/opamp
             k8s:
-              chart_version: 1.2.3-beta
               cluster_name: my-cluster
               namespace: my-namespace
             server:
@@ -262,3 +255,17 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "Setting up the status server port is `.Values.config.agentControl.content` is not supported because it would conflict with container probes. Use `.Values.config.status_server.port` instead"
+
+  - it: Fails is expected if chart_version is set manually
+    set:
+      cluster: my-cluster
+      config:
+        agentControl:
+          content:
+            k8s:
+              chart_version: test
+    asserts:
+      - failedTemplate:
+          errorMessage: "The chart version is set automatically via environment variable and should not be set manually"
+
+


### PR DESCRIPTION
#### Is this a new chart
no
#### What this PR does / why we need it:
set chart_version via env_var and not config



#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
