### PR TITLE
[agent-control] imageToolkit is not part of child chart values

### DIFF
--- a/charts/agent-control/Chart.yaml
+++ b/charts/agent-control/Chart.yaml
@@ -3,7 +3,7 @@ name: agent-control
 description: Bootstraps New Relic' Agent Control
 
 type: application
-version: 0.0.68
+version: 0.0.69
 # This is the agent-control-deployment chart version.
 appVersion: 0.0.52
 

--- a/charts/agent-control/README.md
+++ b/charts/agent-control/README.md
@@ -74,8 +74,6 @@ agent-control-deployment:
 | agent-control-deployment | object | See `values.yaml` | Values for the agent-control-deployment chart. Ref.: https://github.com/newrelic/helm-charts/blob/master/charts/agent-control-deployment/values.yaml |
 | agent-control-deployment.chartRepositoryUrl | string | `"https://helm-charts.newrelic.com"` | The repository URL from where the `agent-control-deployment` chart will be installed. |
 | agent-control-deployment.enabled | bool | `true` | Enable the installation of the Agent Control. |
-| agent-control-deployment.toolkitImage | object | `{"pullPolicy":"IfNotPresent","pullSecrets":[],"registry":null,"repository":"newrelic/newrelic-agent-control-cli","tag":"nightly"}` | The image that contains the necessary tools to install and uninstall Agent Control. |
-| agent-control-deployment.toolkitImage.pullSecrets | list | `[]` | The secrets that are needed to pull images from a custom registry. |
 | flux2 | object | See `values.yaml` | Values for the Flux chart. Ref.: https://github.com/fluxcd-community/helm-charts/blob/flux2-2.10.2/charts/flux2/values.yaml |
 | flux2.clusterDomain | string | `"cluster.local"` | This is the domain name of the cluster. |
 | flux2.enabled | bool | `true` | Enable or disable FluxCD installation. New Relic' Agent Control need Flux to work, but the user can use an already existing Flux deployment. With that use case, the use can disable Flux and use this chart to only install the CRs to deploy the Agent Control. |
@@ -86,6 +84,8 @@ agent-control-deployment:
 | flux2.watchAllNamespaces | bool | `false` | As we are using Flux as a tool from the agent control to release new workloads, we do not want Flux to listen to all CRs created on the whole cluster. If the user does not want to use Flux and is only using it because of the agent control, this is the way to go so the cluster has deployed all operators needed by the agent control. But if the user want to use Flux for other purposes besides the agent control, this toggle can be used to allow Flux to work on the whole cluster. |
 | fullnameOverride | string | `""` | Override the full name of the release |
 | nameOverride | string | `""` | Override the name of the chart |
+| toolkitImage | object | `{"pullPolicy":"IfNotPresent","pullSecrets":[],"registry":null,"repository":"newrelic/newrelic-agent-control-cli","tag":"nightly"}` | The image that contains the necessary tools to install and uninstall Agent Control. |
+| toolkitImage.pullSecrets | list | `[]` | The secrets that are needed to pull images from a custom registry. |
 
 ## Maintainers
 

--- a/charts/agent-control/templates/install.yaml
+++ b/charts/agent-control/templates/install.yaml
@@ -18,8 +18,8 @@ spec:
       serviceAccountName: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" .Release.Name "suffix" "install-job") }}
       containers:
         - name: install-agent-control-deployment
-          image: {{ include "newrelic.common.images.image" ( dict "imageRoot" (index .Values "agent-control-deployment").toolkitImage "context" .) }}
-          imagePullPolicy: {{ (index .Values "agent-control-deployment").toolkitImage.pullPolicy }}
+          image: {{ include "newrelic.common.images.image" ( dict "imageRoot" .Values.toolkitImage "context" .) }}
+          imagePullPolicy: {{ .Values.toolkitImage.pullPolicy }}
           resources:
             limits:
               cpu: 100m

--- a/charts/agent-control/templates/uninstall.yaml
+++ b/charts/agent-control/templates/uninstall.yaml
@@ -18,8 +18,8 @@ spec:
       serviceAccountName: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" .Release.Name "suffix" "uninstall-job") }}
       containers:
         - name: uninstall-agent-control-deployment
-          image: {{ include "newrelic.common.images.image" ( dict "imageRoot" (index .Values "agent-control-deployment").toolkitImage "context" .) }}
-          imagePullPolicy: {{ (index .Values "agent-control-deployment").toolkitImage.pullPolicy }}
+          image: {{ include "newrelic.common.images.image" ( dict "imageRoot" .Values.toolkitImage "context" .) }}
+          imagePullPolicy: {{ .Values.toolkitImage.pullPolicy }}
           resources:
             limits:
               cpu: 100m

--- a/charts/agent-control/tests/install_test.yaml
+++ b/charts/agent-control/tests/install_test.yaml
@@ -1,5 +1,19 @@
 suite: Validate AC Installation
 tests:
+  - it: should leverage correct image tag
+    set:
+      toolkitImage:
+        tag: 123
+        repository: test
+    asserts:
+      - template: templates/install.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: "test:123"
+      - template: templates/uninstall.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: "test:123"
   - it: should allow custom repositoryUrl
     set:
       agent-control-deployment:

--- a/charts/agent-control/values.yaml
+++ b/charts/agent-control/values.yaml
@@ -3,6 +3,16 @@ nameOverride: ""
 # -- Override the full name of the release
 fullnameOverride: ""
 
+# -- The image that contains the necessary tools to install and uninstall Agent Control.
+toolkitImage:
+  registry:
+  repository: newrelic/newrelic-agent-control-cli
+  # @default It defaults to `appVersion` in `Chart.yaml`.
+  tag: nightly
+  pullPolicy: IfNotPresent
+  # -- The secrets that are needed to pull images from a custom registry.
+  pullSecrets: []
+
 # -- Values for the agent-control-deployment chart. Ref.: https://github.com/newrelic/helm-charts/blob/master/charts/agent-control-deployment/values.yaml
 # @default -- See `values.yaml`
 agent-control-deployment:
@@ -11,16 +21,6 @@ agent-control-deployment:
 
   # -- The repository URL from where the `agent-control-deployment` chart will be installed.
   chartRepositoryUrl: https://helm-charts.newrelic.com
-
-  # -- The image that contains the necessary tools to install and uninstall Agent Control.
-  toolkitImage:
-    registry:
-    repository: newrelic/newrelic-agent-control-cli
-    # @default It defaults to `appVersion` in `Chart.yaml`.
-    tag: nightly
-    pullPolicy: IfNotPresent
-    # -- The secrets that are needed to pull images from a custom registry.
-    pullSecrets: []
 
 # -- Values for the Flux chart. Ref.: https://github.com/fluxcd-community/helm-charts/blob/flux2-2.10.2/charts/flux2/values.yaml
 # @default -- See `values.yaml`


### PR DESCRIPTION
#### Is this a new chart
no
#### What this PR does / why we need it:
It fixes the values.yaml structure. Image toolkit is used by the parent chart, not the child one


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
