### PR TITLE
[agent-control-deployment] improve security

### DIFF
--- a/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 
 type: application
 
-version: 0.0.55
+version: 0.0.56
 appVersion: "0.40.0"
 
 dependencies:

--- a/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml
+++ b/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml
@@ -141,7 +141,7 @@ spec:
               echo "Creating System Identity..."
 
               ORG_ID={{ include "newrelic-agent-control.auth.organizationId" . }}
-              TEMPORAL_FOLDER=gen-folder
+              TEMPORAL_FOLDER=/tmp/gen-folder
               mkdir $TEMPORAL_FOLDER
               CLIENT_ID=""
               DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")

--- a/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml
+++ b/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml
@@ -67,6 +67,8 @@ spec:
         - name: register-system-identity
           image: "{{ (.Values.systemIdentityRegistration.image).repository }}:{{ (.Values.systemIdentityRegistration.image).tag }}"
           imagePullPolicy: {{ .Values.systemIdentityRegistration.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
           resources:
             limits:
               cpu: 100m


### PR DESCRIPTION
#### Is this a new chart

no

#### What this PR does / why we need it:

Improves the security of the container used in the preinstallation job.
Moves the folder where the private key is stored inside `/tmp`. That will relax privileges constraints. We won't need to use `root` user anymore to create the folder.

#### Which issue this PR fixes

  - relates to #NR-424891

#### Special notes for your reviewer:

There's an ongoing effort to split namespaces in AC. We are using branch https://github.com/newrelic/helm-charts/tree/feat/splitNamespace from this repo to test that everything is still working. I created a separated branch on top of it that includes the changes of this PR. You can find it https://github.com/newrelic/helm-charts/tree/poc-temp-folder. This is the one I used to test that everything is still working.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
