### PR TITLE
[agent-control-deployment] cleaning unused code and features

### DIFF
--- a/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 
 type: application
 
-version: 0.0.58
+version: 0.0.59
 appVersion: "0.41.0"
 
 dependencies:

--- a/charts/agent-control-deployment/README.md
+++ b/charts/agent-control-deployment/README.md
@@ -28,19 +28,15 @@ Options that can be defined globally include `affinity`, `nodeSelector`, `tolera
 | config.fleet_control.auth.organizationId | string | `""` | Organization ID where fleets will live. |
 | config.fleet_control.auth.secret.client_id.base64 | string | `nil` | In case `.config.auth.secret.create` is true, you can set these keys to set client ID directly as base64 if you want to skip its creation. This options is mutually exclusive with `plain`. |
 | config.fleet_control.auth.secret.client_id.plain | string | `nil` | In case `.config.auth.secret.create` is true, you can set these keys to set client ID directly as plain text if you want to skip its creation. This options is mutually exclusive with `base64`. |
-| config.fleet_control.auth.secret.client_id.secret_key | string | `client_id` | Key inside the secret containing the client ID. |
 | config.fleet_control.auth.secret.create | bool | `true` |  |
 | config.fleet_control.auth.secret.name | string | release name suffixed with "-auth" | Name auth' secret provided by the user. If the creation of this secret is set to `true`, this is the same the secret will have. |
 | config.fleet_control.auth.secret.private_key.base64_pem | string | `nil` | In case `.config.auth.secret.create` is true, you can set these keys to set private key directly as base64 if you want to skip its creation. This options is mutually exclusive with `plain_pem`. |
 | config.fleet_control.auth.secret.private_key.plain_pem | string | `nil` | In case `.config.auth.secret.create` is true, you can set these keys to set private key directly as plain text if you want to skip its creation. This options is mutually exclusive with `base64_pem`. |
-| config.fleet_control.auth.secret.private_key.secret_key | string | `private_key` | Key inside the secret containing the private key. |
 | config.fleet_control.enabled | bool | `true` | Enables or disables the auth against fleet control. It implies to disable any fleet communication and running the agent in stand alone mode where only the agents specified on `.config.subAgents` will be launched. |
 | config.fleet_control.fleet_id | string | `""` | Specify a fleet_id to automatically connect the Agent Control to an existing fleet. |
 | config.status_server.port | int | See `values.yaml` | Set the status server port |
 | config.subAgents | string | `{}` (See `values.yaml`) | List of managed agents that will be deployed. The key represents the name of the agent and the value holds the configuration. |
 | containerSecurityContext | object | `{}` | Sets security context (at container level). Can be configured also with `global.containerSecurityContext` |
-| customIdentityClientIdSecretKey | string | `""` |  |
-| customIdentityClientSecretSecretKey | string | `""` |  |
 | customIdentitySecretName | string | `""` | In case you don't want to have the client_id and client_secret in your values, this allows you to point to a user created secret to get the key from there. |
 | customSecretLicenseKey | string | `""` | In case you don't want to have the license key in you values, this allows you to point to which secret key is the license key located. Can be configured also with `global.customSecretLicenseKey` |
 | customSecretName | string | `""` | In case you don't want to have the license key in you values, this allows you to point to a user created secret to get the key from there. Can be configured also with `global.customSecretName` |

--- a/charts/agent-control-deployment/templates/_helpers.tpl
+++ b/charts/agent-control-deployment/templates/_helpers.tpl
@@ -1,13 +1,4 @@
 {{- /*
-Return the name of the configMap holding the Agent Control's config. Defaults to release's fill name suffiexed with "-config"
-*/ -}}
-{{- define "newrelic-agent-control.config.name" -}}
-{{- include "newrelic.common.naming.truncateToDNSWithSuffix" ( dict "name" "local-data" "suffix" "agentcontrol-config" ) -}}
-{{- end -}}
-
-
-
-{{- /*
 Test that the value of `.Values.config.subAgents` exists and its valid. If empty, returns the default.
 */ -}}
 {{- define "newrelic-agent-control.config.agents.yaml" -}}
@@ -64,30 +55,6 @@ Return to which endpoint should the agent control ask to renew its token
   {{- fail "Unknown/unsupported region set for this chart" -}}
 {{- end -}}
 {{- end -}}
-
-
-
-{{- /*
-Return to which endpoint should the agent control register its system identity
-*/ -}}
-{{- define "newrelic-agent-control.config.endpoints.systemIdentityRegistration" -}}
-{{- $region := include "newrelic.common.region" . -}}
-
-{{- if eq $region "Staging" -}}
-  https://staging-api.newrelic.com/graphql
-{{- else if eq $region "EU" -}}
-  https://api.eu.newrelic.com/graphql
-{{- else if eq $region "US" -}}
-  https://api.newrelic.com/graphql
-{{- else if eq $region "Local" -}}
-  {{- /* Accessing the value directly without protection. A developer should now how to read the error. */ -}}
-  {{ .Values.development.backend.systemIdentityRegistration }}
-{{- else -}}
-  {{- fail "Unknown/unsupported region set for this chart" -}}
-{{- end -}}
-{{- end -}}
-
-
 
 {{- /*
 Builds the configuration from config on the values and add more config options like
@@ -228,22 +195,6 @@ Helper to toggle the creation of the secret that has the system identity as valu
 {{- end -}}
 
 
-
-{{- /*
-Check if .Values.config.auth.secret.private_key.secret_key exists and use it for the key in the secret containing the private
-key needed for the system identity. Fallbacks to `private_key`.
-*/ -}}
-{{- define "newrelic-agent-control.auth.secret.privateKey.key" -}}
-{{- $key := ((((((.Values.config).fleet_control).auth).secret).private_key).secret_key) -}}
-{{- if $key -}}
-  {{- $key -}}
-{{- else -}}
-  private_key
-{{- end -}}
-{{- end -}}
-
-
-
 {{- /*
 Check if .Values.config.auth.secret.private_key.(plain_pem or base64_pem) exists and use it for as the private certificate for
 auth. If no ceritifcate is provided, it defaults to `""` (empty string) so this helper can be used directly as a test.
@@ -261,23 +212,6 @@ auth. If no ceritifcate is provided, it defaults to `""` (empty string) so this 
   {{- /* Empty string */ -}}
 {{- end -}}
 {{- end -}}
-
-
-
-{{- /*
-Check if .Values.config.auth.secret.client_id.secret_key exists and use it for the key in the secret containing the client id
-needed for the system identity. Fallbacks to `client_id`.
-*/ -}}
-{{- define "newrelic-agent-control.auth.secret.clientId.key" -}}
-{{- $key := ((((((.Values.config).fleet_control).auth).secret).client_id).secret_key) -}}
-{{- if $key -}}
-  {{- $key -}}
-{{- else -}}
-  CLIENT_ID
-{{- end -}}
-{{- end -}}
-
-
 
 {{- /*
 Check if .Values.config.auth.secret.client_id.(plain or base64) exists and use it for as the client id for auth. If no
@@ -318,40 +252,6 @@ value is provided, it defaults to `""` (empty string) so this helper can be used
 {{- end -}}
 {{- end -}}
 
-{{- /*
-Return to which endpoint should the agent control register its system identity
-*/ -}}
-{{- define "newrelic-agent-control.config.endpoints.systemIdentityCreation" -}}
-{{- $region := include "newrelic.common.region" . -}}
-
-{{- if eq $region "Staging" -}}
-  https://staging-api.newrelic.com/graphql
-{{- else if eq $region "EU" -}}
-  https://api.eu.newrelic.com/graphql
-{{- else if eq $region "US" -}}
-  https://api.newrelic.com/graphql
-{{- else if eq $region "Local" -}}
-  {{- /* Accessing the value directly without protection. A developer should now how to read the error. */ -}}
-  {{ .Values.development.backend.systemIdentityCreation }}
-{{- else -}}
-  {{- fail "Unknown/unsupported region set for this chart" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return the name key for the ClientId Key inside the secret.
-*/}}
-{{- define "newrelic-agent-control.auth.l1IdentityCredentialsKey.clientIdKeyName" -}}
-{{- include "newrelic-agent-control.auth.identityCredentialsL1._customClientIdKey" . | default "clientIdKey" -}}
-{{- end -}}
-
-{{/*
-Return the name key for the ClientSecret Key inside the secret.
-*/}}
-{{- define "newrelic-agent-control.auth.l1IdentityCredentialsKey.clientSecretKeyName" -}}
-{{- include "newrelic-agent-control.auth.identityCredentialsL1._customClientSecretKey" . | default "clientSecretKey" -}}
-{{- end -}}
-
 {{/*
 Return the name of the secret holding the clientdId and ClientSecret
 */}}
@@ -361,28 +261,6 @@ Return the name of the secret holding the clientdId and ClientSecret
 {{- end -}}
 {{- end -}}
 
-{{/*
-Return the name key for the ClientID inside the secret.
-*/}}
-{{- define "newrelic-agent-control.auth.identityCredentialsL1._customClientIdKey" -}}
-{{- if .Values.customIdentityClientIdSecretKey -}}
-  {{- .Values.customIdentityClientIdSecretKey -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return the name key for the ClientSecret inside the secret.
-*/}}
-{{- define "newrelic-agent-control.auth.identityCredentialsL1._customClientSecretKey" -}}
-{{- if .Values.customIdentityClientSecretSecretKey -}}
-  {{- .Values.customIdentityClientSecretSecretKey -}}
-{{- end -}}
-{{- end -}}
-
-{{/* Return the generated secret name for the CliendId and ClientSecret*/}}
-{{- define "newrelic.common.userKey.generatedSecretName" -}}
-{{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "preinstall-user-key" ) }}
-{{- end -}}
 
 {{/* Return the custom secret name for the CliendId and ClientSecret with fallback to the generated one */}}
 {{- define "newrelic-agent-control.auth.identityCredentialsSecretName" -}}

--- a/charts/agent-control-deployment/templates/deployment-agentcontrol.yaml
+++ b/charts/agent-control-deployment/templates/deployment-agentcontrol.yaml
@@ -69,7 +69,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "newrelic-agent-control.auth.secret.name" . }}
-                  key: {{ include "newrelic-agent-control.auth.secret.clientId.key" . }}
+                  key: CLIENT_ID
           {{- end }}
           {{- if include "newrelic.common.verboseLog" . }}
             - name: NR_AC_LOG__LEVEL
@@ -150,7 +150,7 @@ spec:
           secret:
             secretName: {{ include "newrelic-agent-control.auth.secret.name" . }}
             items:
-              - key: {{ include "newrelic-agent-control.auth.secret.privateKey.key" . }}
+              - key: private_key
                 path: from-secret.key
         {{- end }}
         {{- with .Values.extraVolumes }}

--- a/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml
+++ b/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml
@@ -1,34 +1,17 @@
 {{- if include "newrelic-agent-control.auth.secret.shouldRunJob" . -}}
 {{- /*
-SystemIdentity currently supports userKey and L1/L2 identities. (userKey to be deprecated)
-Both user key secret or L1/L2 identities are used only in the step that create the system identity.
+SystemIdentity currently supports L1/L2 identities.
+ L1/L2 identities are used only in the step that create the system identity.
 The secret that is created by the common-library does not allow to add annotations so the secret is removed
 once the installation hook is finished, so I have to add it as a hook.
 
 As both ways co-exist, we'll add a check to ensure at least one exits
 */ -}}
-{{- if and (not (include "newrelic.common.userKey._customSecretName" .)) (not (include "newrelic.common.userKey._userKey" .)) (not (include "newrelic-agent-control.auth.customIdentitySecretName" .)) (not (include "newrelic-agent-control.auth.l1Identity" .)) -}}
-  {{- fail "You must specify a userKey/customUserKeySecretName or l1Identity/customIdentitySecretName" -}}
+{{- if and (not (include "newrelic-agent-control.auth.customIdentitySecretName" .)) (not (include "newrelic-agent-control.auth.l1Identity" .)) -}}
+  {{- fail "You must specify a customIdentitySecretName or identityClientId/identityClientSecret" -}}
 {{- end -}}
 
-{{- if and (not (include "newrelic.common.userKey._customSecretName" .)) (include "newrelic.common.userKey._userKey" .) }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
-    helm.sh/hook-weight: "-1010"
-  labels:
-    {{- include "newrelic.common.labels" . | nindent 4 }}
-  name: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "preinstall-user-key" ) }}
-  namespace: {{ .Release.Namespace }}
-data:
-  {{ include "newrelic.common.userKey.secretKeyName" . }}: {{ include "newrelic.common.userKey._userKey" . | b64enc }}
-{{- end }}
-
-{{/* L1/L2 Client Credentials */}}
+{{/* L1/L2 Client Credentials - We create the secret if the customIdentitySecretName is not specified  */}}
 {{- if and (not (include "newrelic-agent-control.auth.customIdentitySecretName" .)) (include "newrelic-agent-control.auth.l1Identity" .) }}
 ---
 apiVersion: v1
@@ -43,8 +26,8 @@ metadata:
   name: {{ include "newrelic-agent-control.auth.generatedIdentityCredentialsSecretName" . }}
   namespace: {{ .Release.Namespace }}
 data:
-  {{ include "newrelic-agent-control.auth.l1IdentityCredentialsKey.clientIdKeyName" . }}: {{ include "newrelic-agent-control.auth.identityClientId" . | b64enc }}
-  {{ include "newrelic-agent-control.auth.l1IdentityCredentialsKey.clientSecretKeyName" . }}: {{ include "newrelic-agent-control.auth.identityClientSecret" . | b64enc }}
+  clientIdKey: {{ include "newrelic-agent-control.auth.identityClientId" . | b64enc }}
+  clientSecretKey: {{ include "newrelic-agent-control.auth.identityClientSecret" . | b64enc }}
 {{- end }}
 ---
 apiVersion: batch/v1
@@ -77,28 +60,17 @@ spec:
               cpu: 50m
               memory: 64Mi
           env:
-            {{- if or  (include "newrelic.common.userKey._customSecretName" .) (include "newrelic.common.userKey._userKey" .) }}
-            - name: USER_KEY
-              valueFrom:
-                secretKeyRef:
-                  {{- if include "newrelic.common.userKey._customSecretName" . }}
-                  name: {{ include "newrelic.common.userKey.secretName" . }}
-                  {{- else }}
-                  name: {{ include "newrelic.common.userKey.generatedSecretName" . }}
-                  {{- end }}
-                  key: {{ include "newrelic.common.userKey.secretKeyName" . }}
-            {{- end }}
             {{- if or (include "newrelic-agent-control.auth.customIdentitySecretName" .) (include "newrelic-agent-control.auth.l1Identity" .) }}
             - name: NEW_RELIC_AUTH_CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ include "newrelic-agent-control.auth.identityCredentialsSecretName" . }}
-                  key: {{ include "newrelic-agent-control.auth.l1IdentityCredentialsKey.clientIdKeyName" . }}
+                  key: clientIdKey
             - name: NEW_RELIC_AUTH_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ include "newrelic-agent-control.auth.identityCredentialsSecretName" . }}
-                  key: {{ include "newrelic-agent-control.auth.l1IdentityCredentialsKey.clientSecretKeyName" . }}
+                  key: clientSecretKey
             {{- end }}
           command:
             - bash

--- a/charts/agent-control-deployment/templates/secret-sa-auth.yaml
+++ b/charts/agent-control-deployment/templates/secret-sa-auth.yaml
@@ -8,6 +8,6 @@ metadata:
     {{- include "newrelic.common.labels" . | nindent 4 }}
 apiVersion: v1
 data:
-  {{ include "newrelic-agent-control.auth.secret.privateKey.key" . }}: {{ include "newrelic-agent-control.auth.secret.privateKey.data" . }}
-  {{ include "newrelic-agent-control.auth.secret.clientId.key" . }}: {{ include "newrelic-agent-control.auth.secret.clientId.data" . }}
+  private_key: {{ include "newrelic-agent-control.auth.secret.privateKey.data" . }}
+  CLIENT_ID: {{ include "newrelic-agent-control.auth.secret.clientId.data" . }}
 {{- end }}

--- a/charts/agent-control-deployment/tests/preinstall_job_test.yaml
+++ b/charts/agent-control-deployment/tests/preinstall_job_test.yaml
@@ -11,74 +11,18 @@ tests:
   - it: by default it fails with missing values
     asserts:
       - failedTemplate:
-          errorMessage: You must specify a userKey/customUserKeySecretName or l1Identity/customIdentitySecretName
+          errorMessage: You must specify a customIdentitySecretName or identityClientId/identityClientSecret
 
-  - it: if userKey is set, it should fail with missing organization id
+  - it: with fleet disabled, the job should template correctly 0 documents.
     set:
-      userKey: test
-    asserts:
-      - failedTemplate:
-          errorMessage: .config.fleet_control.auth.organizationId is required
-
-  - it: if identityCredentialsL1 is set but any fields empty, it should fail
-    set:
-      identityCredentialsL1: {}
-    asserts:
-      - failedTemplate:
-          errorMessage: You must specify a userKey/customUserKeySecretName or l1Identity/customIdentitySecretName
-
-  - it: if identityCredentialsL1 is set but any fields empty, it should fail
-    set:
-      identityCredentialsL1:
-        clientId: test
-        clientSecret: ""
-    asserts:
-      - failedTemplate:
-          errorMessage: You must specify a userKey/customUserKeySecretName or l1Identity/customIdentitySecretName
-
-  - it: if identityCredentialsL1 is set but any fields empty, it should fail
-    set:
-      identityCredentialsL1:
-        clientId: ""
-        clientSecret: "test"
-    asserts:
-      - failedTemplate:
-          errorMessage: You must specify a userKey/customUserKeySecretName or l1Identity/customIdentitySecretName
-
-  - it: if organizationId is set, it should fail with missing userKey
-    set:
-      config:
+      config:   
         fleet_control:
-          auth:
-            organizationId: test
-    asserts:
-      - failedTemplate:
-          errorMessage: You must specify a userKey/customUserKeySecretName or l1Identity/customIdentitySecretName
-
-  - it: with legacy userKey set, the job should template correctly.
-    set:
-      userKey: test
-      config:
-        fleet_control:
-          auth:
-            organizationId: test
+          enabled: false
     asserts:
       - hasDocuments:
-          count: 5 # Secret, job, and 3 RBAC manifests
-      - documentIndex: 1
-        isNotNullOrEmpty:
-          path: spec.template.spec.containers[0].args
-      - documentIndex: 1
-        equal:
-          path: spec.template.spec.containers[0].env
-          value:
-            - name: USER_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: userKey
-                  name: agent-control-preinstall-user-key
+          count: 0
 
-  - it: with identityCredentialsL1 set, the job should template correctly.
+  - it: with identityClientId/identityClientSecret set, the job should template correctly.
     set:
       identityClientId: test
       identityClientSecret: test
@@ -107,35 +51,9 @@ tests:
                   key: clientSecretKey
                   name: agent-control-preinstall-client-credentials
 
-  - it: with a custom secret for userKey, the secret should not be created.
-    set:
-      customUserKeySecretName: test-secret
-      customUserKeySecretKey: test-key
-      config:
-        fleet_control:
-          auth:
-            organizationId: test
-    asserts:
-      - hasDocuments:
-          count: 4 # With everything rendered it should be 5
-      - documentIndex: 0
-        isNotNullOrEmpty:
-          path: spec.template.spec.containers[0].args
-      - documentIndex: 0
-        contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: USER_KEY
-            valueFrom:
-              secretKeyRef:
-                name: test-secret
-                key: test-key
-
   - it: with a custom secret for clientId and clientSecret, the secret should not be created.
     set:
       customIdentitySecretName: test-client-name
-      customIdentityClientIdSecretKey: test-client-id-key
-      customIdentityClientSecretSecretKey: test-client-secret-key
       config:
         fleet_control:
           auth:
@@ -153,21 +71,17 @@ tests:
             - name: NEW_RELIC_AUTH_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  key: test-client-id-key
+                  key: clientIdKey
                   name: test-client-name
             - name: NEW_RELIC_AUTH_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  key: test-client-secret-key
+                  key: clientSecretKey
                   name: test-client-name
 
   - it: with a custom secret for userKey and clientId and clientSecret, the secret should not be created.
     set:
-      customUserKeySecretName: test-secret
-      customUserKeySecretKey: test-key
       customIdentitySecretName: test-client-name
-      customIdentityClientIdSecretKey: test-client-id-key
-      customIdentityClientSecretSecretKey: test-client-secret-key
       config:
         fleet_control:
           auth:
@@ -182,26 +96,20 @@ tests:
         equal:
           path: spec.template.spec.containers[0].env
           value:
-            - name: USER_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: test-secret
-                  key: test-key
             - name: NEW_RELIC_AUTH_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  key: test-client-id-key
+                  key: clientIdKey
                   name: test-client-name
             - name: NEW_RELIC_AUTH_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  key: test-client-secret-key
+                  key: clientSecretKey
                   name: test-client-name
 
   - it: setting specific image for system identity registration with tag should use the provided tag
     set:
-      customUserKeySecretName: test-secret
-      customUserKeySecretKey: test-key
+      customIdentitySecretName: test-secret
       config:
         fleet_control:
           auth:
@@ -217,8 +125,7 @@ tests:
 
   - it: setting specific image for system identity registration with tag should use the provided data
     set:
-      customUserKeySecretName: test-secret
-      customUserKeySecretKey: test-key
+      customIdentitySecretName: test-secret
       config:
         fleet_control:
           auth:
@@ -235,8 +142,7 @@ tests:
 
   - it: setting specific pullPolicy for system identity registration image should use the provided data
     set:
-      customUserKeySecretName: test-secret
-      customUserKeySecretKey: test-key
+      customIdentitySecretName: test-secret
       config:
         fleet_control:
           auth:

--- a/charts/agent-control-deployment/values.yaml
+++ b/charts/agent-control-deployment/values.yaml
@@ -16,8 +16,7 @@ identityClientId: ""
 identityClientSecret: ""
 # -- In case you don't want to have the client_id and client_secret in your values, this allows you to point to a user created secret to get the key from there.
 customIdentitySecretName: ""
-customIdentityClientIdSecretKey: ""
-customIdentityClientSecretSecretKey: ""
+
 
 # -- Image for the New Relic Agent Control
 # @default -- See `values.yaml`
@@ -148,9 +147,6 @@ config:
         name:
         ## If private_key and client_id values are specified, their creation is disabled and the `preinstall-user-key` job is not executed
         private_key:
-          # -- Key inside the secret containing the private key.
-          # @default -- `private_key`
-          secret_key:
           # -- In case `.config.auth.secret.create` is true, you can set these keys to set private key directly as base64 if you want to skip its creation.
           # This options is mutually exclusive with `plain_pem`.
           base64_pem:
@@ -158,9 +154,6 @@ config:
           # This options is mutually exclusive with `base64_pem`.
           plain_pem:
         client_id:
-          # -- Key inside the secret containing the client ID.
-          # @default -- `client_id`
-          secret_key:
           # -- In case `.config.auth.secret.create` is true, you can set these keys to set client ID directly as base64 if you want to skip its creation.
           # This options is mutually exclusive with `plain`.
           base64:


### PR DESCRIPTION
#### Is this a new chart
no
#### What this PR does / why we need it:
It removes:
 - the possibility to configure the key of the secret where some config are fetched from. 
    This feature it adds complexity without a real benefit.
 - it is no longer templating the secret for userKey and mounting it as an environment variables
 -  related code functions and tests

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
