### PR TITLE
feat(clientIDAuthToken): support managing locally the token creation

### DIFF
--- a/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 
 type: application
 
-version: 0.0.59
+version: 0.0.60
 appVersion: "0.41.0"
 
 dependencies:

--- a/charts/agent-control-deployment/README.md
+++ b/charts/agent-control-deployment/README.md
@@ -46,6 +46,7 @@ Options that can be defined globally include `affinity`, `nodeSelector`, `tolera
 | extraVolumeMounts | list | `[]` | Defines where to mount volumes specified with `extraVolumes` |
 | extraVolumes | list | `[]` | Volumes to mount in the containers |
 | hostNetwork | bool | `false` | Sets pod's hostNetwork. Can be configured also with `global.hostNetwork` |
+| identityClientAuthToken | string | `""` | Identity auth token. This option takes precedence over identityClientSecret and skips authentication. |
 | identityClientId | string | `""` | Identity client_id to use. |
 | identityClientSecret | string | `""` | Identity client_secret to use. |
 | image | object | See `values.yaml` | Image for the New Relic Agent Control |

--- a/charts/agent-control-deployment/templates/_helpers.tpl
+++ b/charts/agent-control-deployment/templates/_helpers.tpl
@@ -231,21 +231,28 @@ value is provided, it defaults to `""` (empty string) so this helper can be used
 {{- end -}}
 {{- end -}}
 
-{{/* check if both L1 ClientID and ClientSecret are provided */}}
-{{- define "newrelic-agent-control.auth.l1Identity" -}}
-{{- if and (include "newrelic-agent-control.auth.identityClientId" .) (include "newrelic-agent-control.auth.identityClientSecret" .) -}}
+{{/* check if both a ClientID and ClientSecret are provided */}}
+{{- define "newrelic-agent-control.auth.parentIdentity" -}}
+{{- if and (include "newrelic-agent-control.auth.identityClientId" .) (or (include "newrelic-agent-control.auth.identityClientSecret" .) (include "newrelic-agent-control.auth.identityClientAuthToken" .)) -}}
     true
 {{- end -}}
 {{- end -}}
 
-{{/* return L1 ClientID */}}
+{{/* return ClientID */}}
 {{- define "newrelic-agent-control.auth.identityClientId" -}}
 {{- if .Values.identityClientId -}}
   {{- .Values.identityClientId -}}
 {{- end -}}
 {{- end -}}
 
-{{/* return L1 ClientSecret */}}
+{{/* return AuthToken */}}
+{{- define "newrelic-agent-control.auth.identityClientAuthToken" -}}
+{{- if .Values.identityClientAuthToken -}}
+  {{- .Values.identityClientAuthToken -}}
+{{- end -}}
+{{- end -}}
+
+{{/* return ClientSecret */}}
 {{- define "newrelic-agent-control.auth.identityClientSecret" -}}
 {{- if .Values.identityClientSecret -}}
   {{- .Values.identityClientSecret -}}

--- a/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml
+++ b/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml
@@ -1,18 +1,10 @@
 {{- if include "newrelic-agent-control.auth.secret.shouldRunJob" . -}}
-{{- /*
-SystemIdentity currently supports L1/L2 identities.
- L1/L2 identities are used only in the step that create the system identity.
-The secret that is created by the common-library does not allow to add annotations so the secret is removed
-once the installation hook is finished, so I have to add it as a hook.
-
-As both ways co-exist, we'll add a check to ensure at least one exits
-*/ -}}
-{{- if and (not (include "newrelic-agent-control.auth.customIdentitySecretName" .)) (not (include "newrelic-agent-control.auth.l1Identity" .)) -}}
-  {{- fail "You must specify a customIdentitySecretName or identityClientId/identityClientSecret" -}}
+{{- if and (not (include "newrelic-agent-control.auth.customIdentitySecretName" .)) (not (include "newrelic-agent-control.auth.parentIdentity" .)) -}}
+  {{- fail "You must specify a customIdentitySecretName or identityClientId identityClientSecret/identityClientAuthToken" -}}
 {{- end -}}
 
-{{/* L1/L2 Client Credentials - We create the secret if the customIdentitySecretName is not specified  */}}
-{{- if and (not (include "newrelic-agent-control.auth.customIdentitySecretName" .)) (include "newrelic-agent-control.auth.l1Identity" .) }}
+{{/* We create the secret if the customIdentitySecretName is not specified  */}}
+{{- if not (include "newrelic-agent-control.auth.customIdentitySecretName" .) }}
 ---
 apiVersion: v1
 kind: Secret
@@ -26,8 +18,9 @@ metadata:
   name: {{ include "newrelic-agent-control.auth.generatedIdentityCredentialsSecretName" . }}
   namespace: {{ .Release.Namespace }}
 data:
-  clientIdKey: {{ include "newrelic-agent-control.auth.identityClientId" . | b64enc }}
-  clientSecretKey: {{ include "newrelic-agent-control.auth.identityClientSecret" . | b64enc }}
+  NEW_RELIC_AUTH_CLIENT_ID: {{ include "newrelic-agent-control.auth.identityClientId" . | b64enc }}
+  NEW_RELIC_AUTH_CLIENT_SECRET: {{ include "newrelic-agent-control.auth.identityClientSecret" . | b64enc }}
+  NEW_RELIC_AUTH_TOKEN: {{ include "newrelic-agent-control.auth.identityClientAuthToken" . | b64enc   }}
 {{- end }}
 ---
 apiVersion: batch/v1
@@ -37,7 +30,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
     helm.sh/hook-weight: "-1005"
-  name: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "system-identity-installer" ) }}
+  name: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "generate-system-identity" ) }}
   namespace: {{ .Release.Namespace }}
 spec:
   ttlSecondsAfterFinished: 120
@@ -59,19 +52,9 @@ spec:
             requests:
               cpu: 50m
               memory: 64Mi
-          env:
-            {{- if or (include "newrelic-agent-control.auth.customIdentitySecretName" .) (include "newrelic-agent-control.auth.l1Identity" .) }}
-            - name: NEW_RELIC_AUTH_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "newrelic-agent-control.auth.identityCredentialsSecretName" . }}
-                  key: clientIdKey
-            - name: NEW_RELIC_AUTH_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "newrelic-agent-control.auth.identityCredentialsSecretName" . }}
-                  key: clientSecretKey
-            {{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ include "newrelic-agent-control.auth.identityCredentialsSecretName" . }}
           command:
             - bash
           args:
@@ -91,27 +74,33 @@ spec:
               echo "Authenticating with New Relic ($REGION)..."
 
               ACCESS_TOKEN=""
-              for RETRY in 1 2 3; do
-                ACCESS_TOKEN=$(newrelic-auth-cli authenticate --client-id "$NEW_RELIC_AUTH_CLIENT_ID" --client-secret "$NEW_RELIC_AUTH_CLIENT_SECRET" --environment "$REGION" --output-token-format Plain)
+              if [ -n "$NEW_RELIC_AUTH_TOKEN" ]; then
+                echo "Access token obtained via config"
+                ACCESS_TOKEN=$NEW_RELIC_AUTH_TOKEN
+              else
+                for RETRY in 1 2 3; do
+                  
+                  ACCESS_TOKEN=$(newrelic-auth-cli authenticate --client-id "$NEW_RELIC_AUTH_CLIENT_ID" --client-secret "$NEW_RELIC_AUTH_CLIENT_SECRET" --environment "$REGION" --output-token-format Plain)
 
-                if [ -n "$ACCESS_TOKEN" ]; then
-                  echo "Access token obtained successfully"
-                  break
+                  if [ -n "$ACCESS_TOKEN" ]; then
+                    echo "Access token obtained successfully via client secret"
+                    break
+                  fi
+
+                  if [ -z $ACCESS_TOKEN ]; then
+                    echo "Network error occurred or no HTTP response was received. Retrying ($RETRY/3)..."
+                    sleep 2
+                    continue
+                  fi
+                done
+
+                if [ -z "$ACCESS_TOKEN" ]; then
+                  echo "Error getting system identity auth token"
+                  exit 99
                 fi
-
-                if [ -z $ACCESS_TOKEN ]; then
-                  echo "Network error occurred or no HTTP response was received. Retrying ($RETRY/3)..."
-                  sleep 2
-                  continue
-                fi
-              done
-
-              if [ -z "$ACCESS_TOKEN" ]; then
-                echo "Error getting system identity auth token"
-                exit 99
+                echo "Authenticated successfully"
               fi
 
-              echo "Authenticated successfully"
               echo "Creating System Identity..."
 
               ORG_ID={{ include "newrelic-agent-control.auth.organizationId" . }}

--- a/charts/agent-control-deployment/tests/preinstall_job_test.yaml
+++ b/charts/agent-control-deployment/tests/preinstall_job_test.yaml
@@ -11,7 +11,7 @@ tests:
   - it: by default it fails with missing values
     asserts:
       - failedTemplate:
-          errorMessage: You must specify a customIdentitySecretName or identityClientId/identityClientSecret
+          errorMessage: You must specify a customIdentitySecretName or identityClientId identityClientSecret/identityClientAuthToken
 
   - it: with fleet disabled, the job should template correctly 0 documents.
     set:
@@ -33,23 +33,50 @@ tests:
     asserts:
       - hasDocuments:
           count: 5 # Secret, job, and 3 RBAC manifests
+      - documentIndex: 0
+        equal:
+          path: data
+          value:
+            NEW_RELIC_AUTH_CLIENT_ID: dGVzdA==
+            NEW_RELIC_AUTH_CLIENT_SECRET: dGVzdA==
+            NEW_RELIC_AUTH_TOKEN: null
       - documentIndex: 1
         isNotNullOrEmpty:
           path: spec.template.spec.containers[0].args
       - documentIndex: 1
         equal:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[0].envFrom
           value:
-            - name: NEW_RELIC_AUTH_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  key: clientIdKey
-                  name: agent-control-preinstall-client-credentials
-            - name: NEW_RELIC_AUTH_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  key: clientSecretKey
-                  name: agent-control-preinstall-client-credentials
+            - secretRef:
+                name: agent-control-preinstall-client-credentials
+
+  - it: with identityClientId/identityClientAuthToken set, the job should template correctly.
+    set:
+      identityClientId: test
+      identityClientAuthToken: test
+      config:
+        fleet_control:
+          auth:
+            organizationId: test
+    asserts:
+      - hasDocuments:
+          count: 5 # Secret, job, and 3 RBAC manifests
+      - documentIndex: 0
+        equal:
+          path: data
+          value:
+            NEW_RELIC_AUTH_CLIENT_ID: dGVzdA==
+            NEW_RELIC_AUTH_CLIENT_SECRET: null
+            NEW_RELIC_AUTH_TOKEN: dGVzdA==
+      - documentIndex: 1
+        isNotNullOrEmpty:
+          path: spec.template.spec.containers[0].args
+      - documentIndex: 1
+        equal:
+          path: spec.template.spec.containers[0].envFrom
+          value:
+            - secretRef:
+                name: agent-control-preinstall-client-credentials
 
   - it: with a custom secret for clientId and clientSecret, the secret should not be created.
     set:
@@ -66,18 +93,10 @@ tests:
           path: spec.template.spec.containers[0].args
       - documentIndex: 0
         equal:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[0].envFrom
           value:
-            - name: NEW_RELIC_AUTH_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  key: clientIdKey
-                  name: test-client-name
-            - name: NEW_RELIC_AUTH_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  key: clientSecretKey
-                  name: test-client-name
+            - secretRef:
+                name: test-client-name
 
   - it: with a custom secret for userKey and clientId and clientSecret, the secret should not be created.
     set:
@@ -94,18 +113,10 @@ tests:
           path: spec.template.spec.containers[0].args
       - documentIndex: 0
         equal:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.containers[0].envFrom
           value:
-            - name: NEW_RELIC_AUTH_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  key: clientIdKey
-                  name: test-client-name
-            - name: NEW_RELIC_AUTH_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  key: clientSecretKey
-                  name: test-client-name
+            - secretRef:
+                name: test-client-name
 
   - it: setting specific image for system identity registration with tag should use the provided tag
     set:

--- a/charts/agent-control-deployment/values.yaml
+++ b/charts/agent-control-deployment/values.yaml
@@ -10,14 +10,6 @@ customSecretName: ""
 # -- In case you don't want to have the license key in you values, this allows you to point to which secret key is the license key located. Can be configured also with `global.customSecretLicenseKey`
 customSecretLicenseKey: ""
 
-# -- Identity client_id to use.
-identityClientId: ""
-# -- Identity client_secret to use.
-identityClientSecret: ""
-# -- In case you don't want to have the client_id and client_secret in your values, this allows you to point to a user created secret to get the key from there.
-customIdentitySecretName: ""
-
-
 # -- Image for the New Relic Agent Control
 # @default -- See `values.yaml`
 image:
@@ -145,7 +137,7 @@ config:
         # will have.
         # @default -- release name suffixed with "-auth"
         name:
-        ## If private_key and client_id values are specified, their creation is disabled and the `preinstall-user-key` job is not executed
+        ## If private_key and client_id values are specified, their creation is disabled and the `generate-system-identity` job is not executed
         private_key:
           # -- In case `.config.auth.secret.create` is true, you can set these keys to set private key directly as base64 if you want to skip its creation.
           # This options is mutually exclusive with `plain_pem`.
@@ -160,6 +152,21 @@ config:
           # -- In case `.config.auth.secret.create` is true, you can set these keys to set client ID directly as plain text if you want to skip its creation.
           # This options is mutually exclusive with `base64`.
           plain:
+
+# These options provides the required info to run the pre-install job that creates the system identity that are used communicating via OpAMP.
+# You can either authenticate via identityClientId/identityClientSecret or pass directly an `identityClientAuthToken` and manage locally the authentication.
+# The authToken can be retrieve via the cli command "newrelic-auth-cli authenticate ...".
+# System identity creation is executed only once. Subsequent upgrades will not attempt to create the identity again.
+# Therefore, `Helm Upgrade` works even though the identityClientSecret or the identityClientAuthToken are expired.
+# You can skip the whole identity creation providing an identity already existing via `config.fleet_control.auth.secret.[private_key|client_id]`
+# -- Identity client_id to use.
+identityClientId: ""
+# -- Identity client_secret to use.
+identityClientSecret: ""
+# -- Identity auth token. This option takes precedence over identityClientSecret and skips authentication.
+identityClientAuthToken: ""
+# -- In case you don't want to have the client_id and client_secret in your values, this allows you to point to a user created secret to get the key from there.
+customIdentitySecretName: ""
 
 # -- Image for the system identity registration process
 # @default -- See `values.yaml`


### PR DESCRIPTION
#### Is this a new chart
no
#### What this PR does / why we need it:
It adds a new way to authenticate `identityClientAuthToken`. It leverage the same clientID and it allows using a local L2 to authenticate and pass just the token

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
