### PR TITLE
[nr-ebpf-agent] Fix nodeSelector spliced in between volume list

### DIFF
--- a/charts/nr-ebpf-agent/templates/nr-ebpf-agent-daemonset.yaml
+++ b/charts/nr-ebpf-agent/templates/nr-ebpf-agent-daemonset.yaml
@@ -149,10 +149,6 @@ spec:
         hostPath:
           path: /sys
           type: Directory
-      {{- with include "newrelic.common.nodeSelector" . }}
-      nodeSelector:
-        {{- . | nindent 8 -}}
-      {{- end }}
       {{- if (hasKey .Values "tls") }}
       {{- if eq .Values.tls.enabled true }}
       - name: cert
@@ -160,6 +156,10 @@ spec:
           defaultMode: 420
           secretName: {{ include "nr-ebpf-agent-certificates.certificateSecret.name" . }}
       {{- end }}
+      {{- end }}
+      {{- with include "newrelic.common.nodeSelector" . }}
+      nodeSelector:
+        {{- . | nindent 8 -}}
       {{- end }}
       {{- with include "nrEbpfAgent.ebpfAgent.affinity" . }}
       affinity:


### PR DESCRIPTION

#### Is this a new chart
No

#### What this PR does / why we need it:
Setting the `nodeSelector` value field is currently unusable as it breaks the chart; this change fixes it.

#### Which issue this PR fixes
n/a

#### Special notes for your reviewer:
Keep up the good work!

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
