### PR TITLE
[nr-k8s-otel] Enable newrelic entity type to spare entity synthesis when service.name is present

### DIFF
--- a/charts/nr-k8s-otel-collector/Chart.yaml
+++ b/charts/nr-k8s-otel-collector/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.35
+version: 0.8.36
 
 dependencies:
   - name: common-library

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/clusterrole.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/clusterrole.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.35
+    helm.sh/chart: nr-k8s-otel-collector-0.8.36
 rules:
   - apiGroups:
     - ""

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/clusterrolebinding.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/clusterrolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.35
+    helm.sh/chart: nr-k8s-otel-collector-0.8.36
 subjects:
   - kind: ServiceAccount
     name: nr-k8s-otel-collector

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/daemonset-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.35
+    helm.sh/chart: nr-k8s-otel-collector-0.8.36
 data:
   daemonset-config.yaml: |
     receivers:
@@ -151,7 +151,11 @@ data:
 
     processors:
       
-      
+      resource/newrelic_set_entity:
+        attributes:
+        - action: upsert
+          key: newrelic.entity.type
+          value: k8s
 
       groupbyattrs:
         keys:
@@ -511,11 +515,7 @@ data:
             value: <cluser_name>
           - key: "newrelic.chart.version"
             action: upsert
-            value: 0.8.35
-          - key: service.name
-            action: delete
-          - key: service_name
-            action: delete
+            value: 0.8.36
 
       transform/low_data_mode_inator:
         metric_statements:
@@ -720,13 +720,14 @@ data:
             - routing/nr_metrics_pipelines
           processors:
             - memory_limiter
+            - cumulativetodelta
           exporters:
             - routing/metrics_egress
         metrics/egress:
           receivers:
             - routing/metrics_egress
           processors:
-            
+            - resource/newrelic_set_entity
             - batch
           exporters:
             - otlphttp/newrelic
@@ -755,7 +756,7 @@ data:
           receivers:
             - routing/logs_egress
           processors:
-            
+            - resource/newrelic_set_entity
             - batch
           exporters:
             - otlphttp/newrelic

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/daemonset-configmap.yaml
@@ -151,11 +151,7 @@ data:
 
     processors:
       
-      resource/newrelic_set_entity:
-        attributes:
-        - action: upsert
-          key: newrelic.entity.type
-          value: k8s
+      
 
       groupbyattrs:
         keys:
@@ -516,6 +512,9 @@ data:
           - key: "newrelic.chart.version"
             action: upsert
             value: 0.8.36
+          - key: newrelic.entity.type
+            action: upsert
+            value: "k8s"
 
       transform/low_data_mode_inator:
         metric_statements:
@@ -720,6 +719,7 @@ data:
             - routing/nr_metrics_pipelines
           processors:
             - memory_limiter
+            - resource/newrelic
             - cumulativetodelta
           exporters:
             - routing/metrics_egress
@@ -727,7 +727,7 @@ data:
           receivers:
             - routing/metrics_egress
           processors:
-            - resource/newrelic_set_entity
+            
             - batch
           exporters:
             - otlphttp/newrelic
@@ -756,7 +756,7 @@ data:
           receivers:
             - routing/logs_egress
           processors:
-            - resource/newrelic_set_entity
+            
             - batch
           exporters:
             - otlphttp/newrelic

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/daemonset.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.35
+    helm.sh/chart: nr-k8s-otel-collector-0.8.36
 spec:
   selector:
     matchLabels:
@@ -24,7 +24,7 @@ spec:
         app.kubernetes.io/name: nr-k8s-otel-collector
         component: daemonset
       annotations:
-        checksum/config: e09f11400ebe17582c432f6042203f51ec25d771bf5a1bf319d0aa5d23f4a283
+        checksum/config: f3191628cce0a5d79b28cdd9539625c84fd0037d0efd758d5f29b238da020357
     spec:
       serviceAccountName: nr-k8s-otel-collector
       containers:

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/daemonset.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/daemonset.yaml
@@ -24,7 +24,7 @@ spec:
         app.kubernetes.io/name: nr-k8s-otel-collector
         component: daemonset
       annotations:
-        checksum/config: f3191628cce0a5d79b28cdd9539625c84fd0037d0efd758d5f29b238da020357
+        checksum/config: 4020611195906d0c9389aa9d89803f382335e37889d0ed7bbd500cfdeffe16d1
     spec:
       serviceAccountName: nr-k8s-otel-collector
       containers:

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.35
+    helm.sh/chart: nr-k8s-otel-collector-0.8.36
 data:
   deployment-config.yaml: |
     receivers:
@@ -144,7 +144,11 @@ data:
 
     processors:
       
-      
+      resource/newrelic_set_entity:
+        attributes:
+        - action: upsert
+          key: newrelic.entity.type
+          value: k8s
 
       groupbyattrs:
         keys:
@@ -468,7 +472,7 @@ data:
             - metric.name == "kube_job_status_active" and value_double < 0.5
             - metric.name == "kube_job_status_succeeded" and value_double < 0.5
 
-      resource/metrics:
+      resource/newrelic:
         attributes:
           # We set the cluster name to what the customer specified in the helm chart
           - key: k8s.cluster.name
@@ -476,11 +480,7 @@ data:
             value: <cluser_name>
           - key: "newrelic.chart.version"
             action: upsert
-            value: 0.8.35
-          - key: service.name
-            action: delete
-          - key: service_name
-            action: delete
+            value: 0.8.36
 
       resource/events:
         attributes:
@@ -495,7 +495,7 @@ data:
             value: <cluser_name>
           - key: "newrelic.chart.version"
             action: upsert
-            value: 0.8.35
+            value: 0.8.36
 
       transform/events:
         log_statements:
@@ -722,7 +722,7 @@ data:
             - filter/nr_exclude_zero_value_kube_jobs
             - transform/low_data_mode_inator
             - resource/low_data_mode_inator
-            - resource/metrics
+            - resource/newrelic
             - groupbyattrs
             - transform/ksm
             - transform/ksm_datapoints
@@ -742,7 +742,7 @@ data:
             - filter/exclude_metrics_low_data_mode
             - transform/low_data_mode_inator
             - resource/low_data_mode_inator
-            - resource/metrics
+            - resource/newrelic
             - attributes/self
             - cumulativetodelta
           exporters:
@@ -752,13 +752,14 @@ data:
             - routing/nr_metrics_pipelines
           processors:
             - memory_limiter
+            - cumulativetodelta
           exporters:
             - routing/metrics_egress
         metrics/egress:
           receivers:
             - routing/metrics_egress
           processors:
-            
+            - resource/newrelic_set_entity
             - batch
           exporters:
             - otlphttp/newrelic
@@ -778,13 +779,14 @@ data:
             - memory_limiter
             - transform/events
             - resource/events
+            - resource/newrelic
           exporters:
             - routing/logs_egress
         logs/egress:
           receivers:
             - routing/logs_egress
           processors:
-            
+            - resource/newrelic_set_entity
             - batch
           exporters:
             - otlphttp/newrelic

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment-configmap.yaml
@@ -144,11 +144,7 @@ data:
 
     processors:
       
-      resource/newrelic_set_entity:
-        attributes:
-        - action: upsert
-          key: newrelic.entity.type
-          value: k8s
+      
 
       groupbyattrs:
         keys:
@@ -481,6 +477,9 @@ data:
           - key: "newrelic.chart.version"
             action: upsert
             value: 0.8.36
+          - key: newrelic.entity.type
+            action: upsert
+            value: "k8s"
 
       resource/events:
         attributes:
@@ -752,6 +751,7 @@ data:
             - routing/nr_metrics_pipelines
           processors:
             - memory_limiter
+            - resource/newrelic
             - cumulativetodelta
           exporters:
             - routing/metrics_egress
@@ -759,7 +759,7 @@ data:
           receivers:
             - routing/metrics_egress
           processors:
-            - resource/newrelic_set_entity
+            
             - batch
           exporters:
             - otlphttp/newrelic
@@ -786,7 +786,7 @@ data:
           receivers:
             - routing/logs_egress
           processors:
-            - resource/newrelic_set_entity
+            
             - batch
           exporters:
             - otlphttp/newrelic

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/name: nr-k8s-otel-collector
         component: deployment
       annotations:
-        checksum/config: 7c4a4a8c2b75f5937b75037ecc1bdc1b9165ab75df1362159e9bfd1cfc2a5067
+        checksum/config: cd7e8d85a390c81320a6ee947e2e32fe0bb947d6f8bb43fd3a32fe9e8098e896
     spec:
       serviceAccountName: nr-k8s-otel-collector
       containers:

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.35
+    helm.sh/chart: nr-k8s-otel-collector-0.8.36
 spec:
   replicas: 1
   minReadySeconds: 5
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/name: nr-k8s-otel-collector
         component: deployment
       annotations:
-        checksum/config: 0a617e03e4394c92d3a5b2a5a1474486b7661375103485e8d5bf4742138e1027
+        checksum/config: 7c4a4a8c2b75f5937b75037ecc1bdc1b9165ab75df1362159e9bfd1cfc2a5067
     spec:
       serviceAccountName: nr-k8s-otel-collector
       containers:

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/secret.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/secret.yaml
@@ -10,6 +10,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.35
+    helm.sh/chart: nr-k8s-otel-collector-0.8.36
 data:
   licenseKey: PE5SX2xpY2Vuc2VLZXk+

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/service.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/service.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.35
+    helm.sh/chart: nr-k8s-otel-collector-0.8.36
 spec:
   type: ClusterIP
   ports:

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/serviceaccount.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/serviceaccount.yaml
@@ -10,5 +10,5 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.0.3
-    helm.sh/chart: nr-k8s-otel-collector-0.8.35
+    helm.sh/chart: nr-k8s-otel-collector-0.8.36
   annotations:

--- a/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
@@ -525,10 +525,6 @@ data:
           - key: "newrelic.chart.version"
             action: upsert
             value: {{ .Chart.Version }}
-          - key: service.name
-            action: delete
-          - key: service_name
-            action: delete
 
       transform/low_data_mode_inator:
         metric_statements:
@@ -763,6 +759,7 @@ data:
             - routing/nr_metrics_pipelines
           processors:
             - memory_limiter
+            - cumulativetodelta
           exporters:
             - routing/metrics_egress
         metrics/egress:

--- a/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
@@ -525,6 +525,9 @@ data:
           - key: "newrelic.chart.version"
             action: upsert
             value: {{ .Chart.Version }}
+          - key: newrelic.entity.type
+            action: upsert
+            value: "k8s"
 
       transform/low_data_mode_inator:
         metric_statements:
@@ -759,6 +762,7 @@ data:
             - routing/nr_metrics_pipelines
           processors:
             - memory_limiter
+            - resource/newrelic
             - cumulativetodelta
           exporters:
             - routing/metrics_egress

--- a/charts/nr-k8s-otel-collector/templates/deployment-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/deployment-configmap.yaml
@@ -503,6 +503,9 @@ data:
           - key: "newrelic.chart.version"
             action: upsert
             value: {{ .Chart.Version }}
+          - key: newrelic.entity.type
+            action: upsert
+            value: "k8s"
 
       resource/events:
         attributes:
@@ -791,6 +794,7 @@ data:
             - routing/nr_metrics_pipelines
           processors:
             - memory_limiter
+            - resource/newrelic
             - cumulativetodelta
           exporters:
             - routing/metrics_egress

--- a/charts/nr-k8s-otel-collector/templates/deployment-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/deployment-configmap.yaml
@@ -494,7 +494,7 @@ data:
         override: true
     {{- end }}
 
-      resource/metrics:
+      resource/newrelic:
         attributes:
           # We set the cluster name to what the customer specified in the helm chart
           - key: k8s.cluster.name
@@ -503,10 +503,6 @@ data:
           - key: "newrelic.chart.version"
             action: upsert
             value: {{ .Chart.Version }}
-          - key: service.name
-            action: delete
-          - key: service_name
-            action: delete
 
       resource/events:
         attributes:
@@ -757,7 +753,7 @@ data:
             - transform/low_data_mode_inator
             - resource/low_data_mode_inator
             {{- end }}
-            - resource/metrics
+            - resource/newrelic
             {{- if include "newrelic.common.openShift" . }}
             - resourcedetection/openshift
             # TODO openshift resource detection already obtains some cloud provider details, revisit, resourcedetection/cloudproviders fails to obtain more attributes
@@ -784,7 +780,7 @@ data:
             - transform/low_data_mode_inator
             - resource/low_data_mode_inator
             {{- end }}
-            - resource/metrics
+            - resource/newrelic
             - attributes/self
             - cumulativetodelta
           exporters:
@@ -795,6 +791,7 @@ data:
             - routing/nr_metrics_pipelines
           processors:
             - memory_limiter
+            - cumulativetodelta
           exporters:
             - routing/metrics_egress
         metrics/egress:
@@ -824,6 +821,7 @@ data:
             - memory_limiter
             - transform/events
             - resource/events
+            - resource/newrelic
           exporters:
             - routing/logs_egress
         logs/egress:

--- a/charts/nr-k8s-otel-collector/values.yaml
+++ b/charts/nr-k8s-otel-collector/values.yaml
@@ -49,6 +49,13 @@ dnsConfig: {}
 
 # -- Define custom processors here. See: https://opentelemetry.io/docs/collector/configuration/#processors
 processors:
+  resource/newrelic_set_entity:
+    attributes:
+        # newrelic.entity.type is needed to make sure we don't synthesize this as a service
+        # when service.name is present in the metric
+        - key: newrelic.entity.type
+          action: upsert
+          value: "k8s"
 
 # -- Define custom exporters here. See: https://opentelemetry.io/docs/collector/configuration/#exporters
 exporters:
@@ -65,6 +72,7 @@ metricsPipeline:
     # -- List of processors to be applied to your Metrics after the NR processors have been applied.
     # This is applied at the end of the pipeline after the default NR processors have been applied to the data.
     processors:
+      - resource/newrelic_set_entity
     # -- List of additional exports to export the processed Metrics.
     exporters:
 
@@ -80,6 +88,7 @@ logsPipeline:
     # -- List of processors to be applied to your Logs after the NR processors have been applied.
     # This is applied at the end of the pipeline after the default NR processors have been applied to the data.
     processors:
+      - resource/newrelic_set_entity
     # -- List of additional exports to export the processed Logs.
     exporters:
 

--- a/charts/nr-k8s-otel-collector/values.yaml
+++ b/charts/nr-k8s-otel-collector/values.yaml
@@ -51,11 +51,11 @@ dnsConfig: {}
 processors:
   resource/newrelic_set_entity:
     attributes:
-        # newrelic.entity.type is needed to make sure we don't synthesize this as a service
-        # when service.name is present in the metric
-        - key: newrelic.entity.type
-          action: upsert
-          value: "k8s"
+      # newrelic.entity.type is needed to make sure we don't synthesize this as a service
+      # when service.name is present in the metric
+      - key: newrelic.entity.type
+        action: upsert
+        value: "k8s"
 
 # -- Define custom exporters here. See: https://opentelemetry.io/docs/collector/configuration/#exporters
 exporters:

--- a/charts/nr-k8s-otel-collector/values.yaml
+++ b/charts/nr-k8s-otel-collector/values.yaml
@@ -49,13 +49,6 @@ dnsConfig: {}
 
 # -- Define custom processors here. See: https://opentelemetry.io/docs/collector/configuration/#processors
 processors:
-  resource/newrelic_set_entity:
-    attributes:
-      # newrelic.entity.type is needed to make sure we don't synthesize this as a service
-      # when service.name is present in the metric
-      - key: newrelic.entity.type
-        action: upsert
-        value: "k8s"
 
 # -- Define custom exporters here. See: https://opentelemetry.io/docs/collector/configuration/#exporters
 exporters:
@@ -72,7 +65,6 @@ metricsPipeline:
     # -- List of processors to be applied to your Metrics after the NR processors have been applied.
     # This is applied at the end of the pipeline after the default NR processors have been applied to the data.
     processors:
-      - resource/newrelic_set_entity
     # -- List of additional exports to export the processed Metrics.
     exporters:
 
@@ -88,7 +80,6 @@ logsPipeline:
     # -- List of processors to be applied to your Logs after the NR processors have been applied.
     # This is applied at the end of the pipeline after the default NR processors have been applied to the data.
     processors:
-      - resource/newrelic_set_entity
     # -- List of additional exports to export the processed Logs.
     exporters:
 


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

#### What this PR does / why we need it:

Adds this block
```
          - key: newrelic.entity.type
            action: upsert
            value: "k8s"
 ```
 
 and removes the service.name and service_name from the metric attributes.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
