### PR TITLE
[agent-control-deployment] fix: do not render namespace manifest if target is release namespace

### DIFF
--- a/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 
 type: application
 
-version: 0.0.57
+version: 0.0.58
 appVersion: "0.41.0"
 
 dependencies:

--- a/charts/agent-control-deployment/templates/namespace-agents.yaml
+++ b/charts/agent-control-deployment/templates/namespace-agents.yaml
@@ -1,8 +1,10 @@
 {{- if not (lookup "v1" "Namespace" "" .Values.subAgentsNamespace) -}}
+{{- if not (eq .Release.Namespace .Values.subAgentsNamespace) -}}
 apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
     "helm.sh/resource-policy": keep
   name: {{ .Values.subAgentsNamespace }}
+{{- end -}}
 {{- end -}}

--- a/charts/agent-control-deployment/templates/namespace-agents.yaml
+++ b/charts/agent-control-deployment/templates/namespace-agents.yaml
@@ -1,3 +1,9 @@
+{{- /* 
+    We check both that the namespace does not exist and that it is not the same as the release namespace.
+    This is due to how we instruct the users to install the chart, using the options `-n <NAMESPACE> --create-namespace`,
+    that will make Helm create the release namespace if it does not exist, so we prevent the rendering to take place.
+    Otherwise, the namespace manifest would be rendered and later applied, which would fail as the namespace was created by Helm.
+*/ -}}
 {{- if not (lookup "v1" "Namespace" "" .Values.subAgentsNamespace) -}}
 {{- if not (eq .Release.Namespace .Values.subAgentsNamespace) -}}
 apiVersion: v1

--- a/charts/agent-control-deployment/tests/configmap_agentcontrol_config_test.yaml
+++ b/charts/agent-control-deployment/tests/configmap_agentcontrol_config_test.yaml
@@ -106,6 +106,27 @@ tests:
               host: 0.0.0.0
               port: 51200
 
+  - it: sub-agents namespace can be the same as AC namespace
+    set:
+      cluster: my-cluster
+      config:
+        fleet_control:
+          enabled: false
+      subAgentsNamespace: my-namespace
+    asserts:
+      - equal:
+          path: data["local_config"]
+          value: |
+            agents: {}
+            k8s:
+              cluster_name: my-cluster
+              namespace: my-namespace
+              namespace_agents: my-namespace
+            server:
+              enabled: true
+              host: 0.0.0.0
+              port: 51200
+
   - it: agent control's config always include cluster_name, namespace and defaults
     set:
       cluster: my-cluster

--- a/charts/agent-control-deployment/tests/namespace_agentcontrol_test.yaml
+++ b/charts/agent-control-deployment/tests/namespace_agentcontrol_test.yaml
@@ -19,6 +19,7 @@ tests:
           count: 1
       - containsDocument:
           kind: Namespace
+          apiVersion: v1
           name: my-subagents-namespace
 
   - it: sub-agents namespace is not rendered if same as AC namespace

--- a/charts/agent-control-deployment/tests/namespace_agentcontrol_test.yaml
+++ b/charts/agent-control-deployment/tests/namespace_agentcontrol_test.yaml
@@ -1,0 +1,33 @@
+suite: agent control's config
+templates:
+  - templates/namespace-agents.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+chart:
+  version: 1.2.3-beta
+tests:
+  - it: sub-agents namespace is rendered if different from AC namespace
+    set:
+      cluster: my-cluster
+      config:
+        fleet_control:
+          enabled: false
+      subAgentsNamespace: my-subagents-namespace
+    asserts:
+      - hasDocuments:
+          count: 1
+      - containsDocument:
+          kind: Namespace
+          name: my-subagents-namespace
+
+  - it: sub-agents namespace is not rendered if same as AC namespace
+    set:
+      cluster: my-cluster
+      config:
+        fleet_control:
+          enabled: false
+      subAgentsNamespace: my-namespace
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No

#### What this PR does / why we need it:

Addresses an issue where, if the AC namespace and the sub-agents namespace were the same, the chart wasn't able to be installed.

This would happen due to Helm rendering the sub-agents namespace manifest and then `--create-namespace` for a namespace with the same name taking into effect, so Helm would later attempt to apply the rendered namespace manifest to create a namespace that already exists.

The fix introduces an additional check that disables the render of the namespace manifest if the namespace it will attempt to create is the same as the release manifest. This way Helm can be passed the `--create-namespace` as expected for the AC installation command.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
