### PR TITLE
[agent-control] fix: do not render namespace manifest if target is release namespace

### DIFF
--- a/charts/agent-control/Chart.yaml
+++ b/charts/agent-control/Chart.yaml
@@ -3,9 +3,9 @@ name: agent-control
 description: Bootstraps New Relic' Agent Control
 
 type: application
-version: 0.0.71
+version: 0.0.72
 # This is the agent-control-deployment chart version.
-appVersion: 0.0.57
+appVersion: 0.0.58
 
 dependencies:
   - name: flux2

--- a/charts/agent-control/templates/namespace-agents.yaml
+++ b/charts/agent-control/templates/namespace-agents.yaml
@@ -1,7 +1,10 @@
-{{- if not (lookup "v1" "Namespace" "" (index .Values "agent-control-deployment" "subAgentsNamespace")) -}}
 {{- /* 
-
+    We check both that the namespace does not exist and that it is not the same as the release namespace.
+    This is due to how we instruct the users to install the chart, using the options `-n <NAMESPACE> --create-namespace`,
+    that will make Helm create the release namespace if it does not exist, so we prevent the rendering to take place.
+    Otherwise, the namespace manifest would be rendered and later applied, which would fail as the namespace was created by Helm.
 */ -}}
+{{- if not (lookup "v1" "Namespace" "" (index .Values "agent-control-deployment" "subAgentsNamespace")) -}}
 {{- if not (eq .Release.Namespace (index .Values "agent-control-deployment" "subAgentsNamespace")) -}}
 apiVersion: v1
 kind: Namespace
@@ -9,5 +12,4 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   name: {{ index .Values "agent-control-deployment" "subAgentsNamespace" }}
-{{- end -}}
 {{- end -}}

--- a/charts/agent-control/templates/namespace-agents.yaml
+++ b/charts/agent-control/templates/namespace-agents.yaml
@@ -13,3 +13,4 @@ metadata:
     "helm.sh/resource-policy": keep
   name: {{ index .Values "agent-control-deployment" "subAgentsNamespace" }}
 {{- end -}}
+{{- end -}}

--- a/charts/agent-control/templates/namespace-agents.yaml
+++ b/charts/agent-control/templates/namespace-agents.yaml
@@ -1,8 +1,13 @@
 {{- if not (lookup "v1" "Namespace" "" (index .Values "agent-control-deployment" "subAgentsNamespace")) -}}
+{{- /* 
+
+*/ -}}
+{{- if not (eq .Release.Namespace (index .Values "agent-control-deployment" "subAgentsNamespace")) -}}
 apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
     "helm.sh/resource-policy": keep
   name: {{ index .Values "agent-control-deployment" "subAgentsNamespace" }}
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
Addresses an issue where, if the AC namespace and the sub-agents namespace were the same, the chart wasn't able to be installed.

This would happen due to Helm rendering the sub-agents namespace manifest and then --create-namespace for a namespace with the same name taking into effect, so Helm would later attempt to apply the rendered namespace manifest to create a namespace that already exists.

The fix introduces an additional check that disables the render of the namespace manifest if the namespace it will attempt to create is the same as the release manifest. This way Helm can be passed the --create-namespace as expected for the AC installation command.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
