### PR TITLE
[nr-ebpf-agent] Add support for imagePullSecrets in agent and otel pods

### DIFF
--- a/charts/nr-ebpf-agent/Chart.yaml
+++ b/charts/nr-ebpf-agent/Chart.yaml
@@ -17,7 +17,7 @@ version: 0.2.5
 
 dependencies:
   - name: common-library
-    version: 1.3.1
+    version: 1.3.3
     repository: "https://helm-charts.newrelic.com"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nr-ebpf-agent/templates/nr-ebpf-agent-daemonset.yaml
+++ b/charts/nr-ebpf-agent/templates/nr-ebpf-agent-daemonset.yaml
@@ -153,10 +153,6 @@ spec:
         hostPath:
           path: /sys
           type: Directory
-      {{- with include "newrelic.common.nodeSelector" . }}
-      nodeSelector:
-        {{- . | nindent 8 -}}
-      {{- end }}
       {{- if (hasKey .Values "tls") }}
       {{- if eq .Values.tls.enabled true }}
       - name: cert
@@ -164,6 +160,10 @@ spec:
           defaultMode: 420
           secretName: {{ include "nr-ebpf-agent-certificates.certificateSecret.name" . }}
       {{- end }}
+      {{- end }}
+      {{- with include "newrelic.common.nodeSelector" . }}
+      nodeSelector:
+        {{- . | nindent 8 -}}
       {{- end }}
       {{- with include "nrEbpfAgent.ebpfAgent.affinity" . }}
       affinity:

--- a/charts/nr-ebpf-agent/templates/nr-ebpf-agent-daemonset.yaml
+++ b/charts/nr-ebpf-agent/templates/nr-ebpf-agent-daemonset.yaml
@@ -30,6 +30,10 @@ spec:
       {{- with include "newrelic.common.priorityClassName" . }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" (list .Values.pullSecrets) "context" .) }}
+      imagePullSecrets:
+        {{- . | nindent 8 }}
+      {{- end }}
       {{- with include "newrelic.common.dnsConfig" . }}
       dnsConfig:
         {{- . | nindent 8 }}

--- a/charts/nr-ebpf-agent/templates/otel-collector-daemonset.yaml
+++ b/charts/nr-ebpf-agent/templates/otel-collector-daemonset.yaml
@@ -121,10 +121,6 @@ spec:
       - name: data
         configMap:
           name: {{ include "nr-ebpf-agent.otelconfig.name" . }}
-      {{- with include "newrelic.common.nodeSelector" . }}
-      nodeSelector:
-        {{- . | nindent 8 -}}
-      {{- end }}
       {{- if (hasKey .Values "tls") }}
       {{- if eq .Values.tls.enabled true }}
       - name: cert
@@ -132,6 +128,10 @@ spec:
           defaultMode: 420
           secretName: {{ include "nr-ebpf-agent-certificates.certificateSecret.name" . }}
       {{- end }}
+      {{- end }}
+      {{- with include "newrelic.common.nodeSelector" . }}
+      nodeSelector:
+        {{- . | nindent 8 -}}
       {{- end }}
       {{- with include "nrEbpfAgent.otelCollector.affinity" . }}
       affinity:

--- a/charts/nr-ebpf-agent/templates/otel-collector-daemonset.yaml
+++ b/charts/nr-ebpf-agent/templates/otel-collector-daemonset.yaml
@@ -33,6 +33,10 @@ spec:
       {{- with include "newrelic.common.priorityClassName" . }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" (list .Values.pullSecrets) "context" .) }}
+      imagePullSecrets:
+        {{- . | nindent 8 }}
+      {{- end }}
       {{- with include "newrelic.common.dnsConfig" . }}
       dnsConfig:
         {{- . | nindent 8 }}

--- a/charts/nr-ebpf-agent/values.yaml
+++ b/charts/nr-ebpf-agent/values.yaml
@@ -179,6 +179,8 @@ otelCollector:
       # -- Annotations for the OTel collector service account.
       annotations: {}
 
+# -- The secrets that are needed to pull images from a custom registry.
+pullSecrets: []
 # -- Additional labels for chart pods.
 podLabels: {}
 # -- Additional labels for chart objects.


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
This PR contains changes related to adding support for imagePullSecrets, bumping up the version for commons-library and fixing nodeSelector placement in pod YAMLs

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
