### PR TITLE
[agent-control] feat: support custom chart installation job

### DIFF
--- a/charts/agent-control/Chart.yaml
+++ b/charts/agent-control/Chart.yaml
@@ -3,7 +3,7 @@ name: agent-control
 description: Bootstraps New Relic' Agent Control
 
 type: application
-version: 0.0.78
+version: 0.0.79
 # This is the agent-control-deployment chart version.
 appVersion: 0.0.64
 

--- a/charts/agent-control/templates/install.yaml
+++ b/charts/agent-control/templates/install.yaml
@@ -27,17 +27,18 @@ spec:
             requests:
               cpu: 50m
               memory: 64Mi
-          command:
-            - newrelic-agent-control-cli
+          args:
             - install-agent-control
-            - --chart-version
-            - "{{ .Chart.AppVersion }}"
-            - --secrets
-            - "{{ $secretName }}=agent-control-deployment.yaml,{{ $secretName }}=global.yaml"
-            - --namespace
-            - "{{ .Release.Namespace }}"
-            - --repository-url
-            - "{{ .Values.installationJob.chartRepositoryUrl }}"
-            - --log-level
-            - "{{ .Values.installationJob.logLevel }}"
+            - --chart-version={{ .Values.installationJob.chartVersion | default .Chart.AppVersion }}
+            - --secrets={{ $secretName }}=agent-control-deployment.yaml,{{ $secretName }}=global.yaml
+            - --namespace={{ .Release.Namespace }}
+            - --repository-url={{ .Values.installationJob.chartRepositoryUrl }}
+            - --log-level={{ .Values.installationJob.logLevel }}
+            - --chart-name={{ .Values.installationJob.chartName }}
+            {{- if .Values.installationJob.repositorySecretReferenceName }}
+            - --repository-secret-reference-name={{ .Values.installationJob.repositorySecretReferenceName }}
+            {{- end }}
+            {{- if .Values.installationJob.repositoryCertificateSecretReferenceName }}
+            - --repository-certificate-secret-reference-name={{ .Values.installationJob.repositoryCertificateSecretReferenceName }}
+            {{- end }}
 {{- end -}}

--- a/charts/agent-control/tests/install_test.yaml
+++ b/charts/agent-control/tests/install_test.yaml
@@ -1,5 +1,45 @@
 suite: Validate AC Installation
+chart:
+  appVersion: 0.0.0
 tests:
+  - it: should have defaults args correctly set
+    asserts:
+      - template: templates/install.yaml
+        equal:
+          path: spec.template.spec.containers[0].args
+          value: 
+            - install-agent-control
+            - --chart-version=0.0.0
+            - --secrets=RELEASE-NAME-deployment=agent-control-deployment.yaml,RELEASE-NAME-deployment=global.yaml
+            - --namespace=NAMESPACE
+            - --repository-url=https://helm-charts.newrelic.com
+            - --log-level=info
+            - --chart-name=agent-control-deployment
+
+  - it: should configure arguments correctly
+    set:
+      installationJob:
+        chartRepositoryUrl: "https://newrelic.com/some/url"
+        logLevel: custom-log-level
+        chartName: custom-chart-name
+        chartVersion: custom-version
+        repositorySecretReferenceName: secret-ref
+        repositoryCertificateSecretReferenceName: cert-secret-ref 
+    asserts:
+      - template: templates/install.yaml
+        equal:
+          path: spec.template.spec.containers[0].args
+          value: 
+            - install-agent-control
+            - --chart-version=custom-version
+            - --secrets=RELEASE-NAME-deployment=agent-control-deployment.yaml,RELEASE-NAME-deployment=global.yaml
+            - --namespace=NAMESPACE
+            - --repository-url=https://newrelic.com/some/url
+            - --log-level=custom-log-level
+            - --chart-name=custom-chart-name
+            - --repository-secret-reference-name=secret-ref
+            - --repository-certificate-secret-reference-name=cert-secret-ref
+
   - it: should leverage correct image tag
     set:
       toolkitImage:
@@ -14,46 +54,3 @@ tests:
         equal:
           path: spec.template.spec.containers[0].image
           value: "test:123"
-  - it: should allow custom repositoryUrl
-    set:
-      installationJob:
-        chartRepositoryUrl: "https://example.com/some/url"
-      agent-control-deployment:
-        cluster: cluster
-        licenseKey: some_license_key
-        identityClientId: some_client_id
-        identityClientSecret: some_client_secret
-        config:
-          fleet_control:
-            auth:
-              organizationId: some_org_id
-    asserts:
-      - template: templates/install.yaml
-        lengthEqual:
-          path: spec.template.spec.containers[0].command
-          count: 12
-      - template: templates/install.yaml
-        equal:
-          path: spec.template.spec.containers[0].command[8]
-          value: "--repository-url"
-      - template: templates/install.yaml
-        equal:
-          path: spec.template.spec.containers[0].command[9]
-          value: "https://example.com/some/url"
-
-  - it: should accept no repositoryUrl
-    set:
-      agent-control-deployment:
-        cluster: cluster
-        licenseKey: some_license_key
-        identityClientId: some_client_id
-        identityClientSecret: some_client_secret
-        config:
-          fleet_control:
-            auth:
-              organizationId: some_org_id
-    asserts:
-      - template: templates/install.yaml
-        lengthEqual:
-          path: spec.template.spec.containers[0].command
-          count: 12

--- a/charts/agent-control/values.yaml
+++ b/charts/agent-control/values.yaml
@@ -13,11 +13,28 @@ toolkitImage:
   pullSecrets: []
 
 installationJob:
-  # -- The repository URL from where the `agent-control-deployment` chart will be installed.
-  chartRepositoryUrl: https://helm-charts.newrelic.com
   # -- Log level for the installation job.
   # @default -- info
   logLevel: "info"
+
+  # -- The repository URL from where the `agent-control-deployment` chart will be installed.
+  chartRepositoryUrl: https://helm-charts.newrelic.com
+
+  # -- The name of the chart that will be installed by the installation job.
+  # @default -- agent-control-deployment
+  chartName: agent-control-deployment
+
+  # -- The version of the Agent Control chart that will be installed by the installation job.
+  # @default -- The Chart.appVersion
+  chartVersion:
+
+  # -- Optional name of the secret containing credentials for the Helm repository.
+  # Ref.: https://fluxcd.io/flux/components/source/helmrepositories/#secret-reference
+  repositorySecretReferenceName:
+
+  # -- Optional name of the secret containing TLS certificates for the Helm repository.
+  # Ref.: https://fluxcd.io/flux/components/source/helmrepositories/#cert-secret-reference
+  repositoryCertificateSecretReferenceName:
 
 uninstallationJob:
   # -- Log level for the uninstallation job.


### PR DESCRIPTION
Adds support for custom chart installation job.

Note: This PR needs the released AC version before it get's merged