### PR TITLE
[agent-control-deployment] chore: bump AC release 0.44.0

### DIFF
--- a/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control-deployment/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 
 type: application
 
-version: 0.0.63
-appVersion: "0.43.0"
+version: 0.0.64
+appVersion: "0.44.0"
 
 dependencies:
   - name: common-library

--- a/charts/agent-control-deployment/values.yaml
+++ b/charts/agent-control-deployment/values.yaml
@@ -176,5 +176,5 @@ customIdentitySecretName: ""
 systemIdentityRegistration:
   image:
     repository: newrelic/agent-control-system-identity-registration
-    tag: "0.0.9"
+    tag: "0.0.10"
     pullPolicy: IfNotPresent


### PR DESCRIPTION
Bumps AC to 0.44.0 and https://github.com/newrelic/helm-charts/pull/1790/files