### PR TITLE
[agent-control-cd] chore: bump flux dependency

### DIFF
--- a/.github/workflows/lint_test_charts.yaml
+++ b/.github/workflows/lint_test_charts.yaml
@@ -82,7 +82,7 @@ jobs:
         uses: manusa/actions-setup-minikube@v2.14.0
         with:
           minikube version: v1.36.0
-          kubernetes version: v1.30.0
+          kubernetes version: v1.31.12
           github token: ${{ secrets.GITHUB_TOKEN }}
           driver: docker
           start args: "--container-runtime=containerd"

--- a/charts/agent-control-cd/Chart.lock
+++ b/charts/agent-control-cd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: flux2
   repository: https://fluxcd-community.github.io/helm-charts
-  version: 2.15.0
-digest: sha256:342040f7a5839657d32cf0be208b08f7ed9c5a791e1b134745040c1d9db3751a
-generated: "2025-07-23T16:48:31.70457+02:00"
+  version: 2.16.4
+digest: sha256:ce8683ce063b49f0faf1a8c9f9ec9e0cfbc7e9e30f8caa67e69ef70c4cd058c1
+generated: "2025-08-13T12:09:29.486165+02:00"

--- a/charts/agent-control-cd/Chart.yaml
+++ b/charts/agent-control-cd/Chart.yaml
@@ -4,12 +4,12 @@ description: A Helm chart to install New Relic Agent Control CD (Flux) on Kubern
 
 type: application
 
-version: 0.0.2
+version: 0.0.3
 
 dependencies:
   - name: flux2
     repository: https://fluxcd-community.github.io/helm-charts
-    version: 2.15.0
+    version: 2.16.4
     condition: flux2.enabled
 
 keywords:


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:

Bumps the flux2 chart dependency to the latest upstream.

It also bumps the version for the chart installation testing because we were using an EOL version that is not supported by the latest version of flux.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
