### PR TITLE
[agent-control-deployment] removing ttl from job

### DIFF
--- a/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control-deployment/Chart.yaml
@@ -4,9 +4,8 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 
 type: application
 
-version: 0.0.68
+version: 0.0.69
 appVersion: "0.46.0"
-
 
 dependencies:
   - name: common-library

--- a/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml
+++ b/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml
@@ -31,7 +31,6 @@ metadata:
   name: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "generate-system-identity" ) }}
   namespace: {{ .Release.Namespace }}
 spec:
-  ttlSecondsAfterFinished: 120
   backoffLimit: 3
   template:
     spec:


### PR DESCRIPTION
#### Is this a new chart
no
#### What this PR does / why we need it:
there is already the hook policy to delete the resource, there is no reason to rely on the TTL 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

