### PR TITLE
[agent-control] make cd and deployment release names configurable

### DIFF
--- a/charts/agent-control-deployment/templates/_helpers.tpl
+++ b/charts/agent-control-deployment/templates/_helpers.tpl
@@ -54,7 +54,7 @@ cluster name, licenses, and custom attributes
 {{- $k8s := (dict "cluster_name" (include "newrelic.common.cluster" .) "namespace" .Release.Namespace "namespace_agents" .Values.subAgentsNamespace) -}}
 {{- /* Add ac_remote_update and cd_remote_update to the config */ -}}
 {{- $k8s = mustMerge $k8s (dict "ac_remote_update" .Values.config.acRemoteUpdate "cd_remote_update" .Values.config.cdRemoteUpdate) -}}
-{{- $k8s = mustMerge $k8s (dict "cd_release_name" "agent-control-cd") -}}
+{{- $k8s = mustMerge $k8s (dict "cd_release_name" .Values.config.cdReleaseName) -}}
 {{- $config = mustMerge $config (dict "k8s" $k8s) -}}
 
 {{- with .Values.config.log -}}

--- a/charts/agent-control-deployment/values.yaml
+++ b/charts/agent-control-deployment/values.yaml
@@ -131,6 +131,9 @@ config:
   # -- (bool) enables or disables remote update from Fleet Control for the agent-control-cd chart
   # @default -- "true"
   cdRemoteUpdate: true
+  # -- The name of the release for the CD chart.
+  # @default -- agent-control-cd
+  cdReleaseName: agent-control-cd
 
   # -- List of allowed chart repository URLs. The Agent Control will only allow to deploy agents from these repositories.
   # @default -- `[]`(Only newrelic chart repositories allowed: ["https://helm-charts.newrelic.com","https://newrelic.github.io/<>"])

--- a/charts/agent-control/README.md
+++ b/charts/agent-control/README.md
@@ -85,7 +85,7 @@ agent-control-deployment:
 | agentControlDeployment.chartValues.subAgentsNamespace | string | "newrelic" | Namespace where agents are deployed |
 | agentControlDeployment.chartVersion | string | `.Chart.appVersion` | The version of the Agent Control chart that will be installed by the installation job. |
 | agentControlDeployment.enabled | bool | `true` | Enable the installation of Agent Control. |
-| agentControlDeployment.releaseName | string | agent-control-cd | The name of the release for the CD chart. |
+| agentControlDeployment.releaseName | string | agent-control-deployment | The name of the release for the CD chart. |
 | agentControlDeployment.repositoryCertificateSecretReferenceName | string | `nil` | Optional name of the secret containing TLS certificates for the Helm repository. Ref.: https://fluxcd.io/flux/components/source/helmrepositories/#cert-secret-reference |
 | agentControlDeployment.repositorySecretReferenceName | string | `nil` | Optional name of the secret containing credentials for the Helm repository. Ref.: https://fluxcd.io/flux/components/source/helmrepositories/#secret-reference |
 | fullnameOverride | string | `""` | Override the full name of the release |

--- a/charts/agent-control/README.md
+++ b/charts/agent-control/README.md
@@ -76,6 +76,7 @@ agent-control-deployment:
 | agentControlCd.chartValues | string | See `values.yaml` | Values for the agent-control-deployment chart. Ref.: https://github.com/newrelic/helm-charts/blob/master/charts/agent-control-cd/values.yaml |
 | agentControlCd.chartVersion | string | `.Chart.annotations.agentControlCdVersion` | The version of the CD chart that will be installed by the installation job. |
 | agentControlCd.enabled | bool | `true` | Enable the installation of a Continuous Deployment system that can be managed by Agent Control. |
+| agentControlCd.releaseName | string | agent-control-cd | The name of the release for the CD chart. |
 | agentControlCd.repositoryCertificateSecretReferenceName | string | `nil` | Optional name of the secret containing TLS certificates for the Helm repository. Ref.: https://fluxcd.io/flux/components/source/helmrepositories/#cert-secret-reference |
 | agentControlCd.repositorySecretReferenceName | string | `nil` | Optional name of the secret containing credentials for the Helm repository. Ref.: https://fluxcd.io/flux/components/source/helmrepositories/#secret-reference |
 | agentControlDeployment.chartName | string | agent-control-deployment | The name of the chart that will be installed by the installation job. |
@@ -84,6 +85,7 @@ agent-control-deployment:
 | agentControlDeployment.chartValues.subAgentsNamespace | string | "newrelic" | Namespace where agents are deployed |
 | agentControlDeployment.chartVersion | string | `.Chart.appVersion` | The version of the Agent Control chart that will be installed by the installation job. |
 | agentControlDeployment.enabled | bool | `true` | Enable the installation of Agent Control. |
+| agentControlDeployment.releaseName | string | agent-control-cd | The name of the release for the CD chart. |
 | agentControlDeployment.repositoryCertificateSecretReferenceName | string | `nil` | Optional name of the secret containing TLS certificates for the Helm repository. Ref.: https://fluxcd.io/flux/components/source/helmrepositories/#cert-secret-reference |
 | agentControlDeployment.repositorySecretReferenceName | string | `nil` | Optional name of the secret containing credentials for the Helm repository. Ref.: https://fluxcd.io/flux/components/source/helmrepositories/#secret-reference |
 | fullnameOverride | string | `""` | Override the full name of the release |

--- a/charts/agent-control/templates/_helpers.tpl
+++ b/charts/agent-control/templates/_helpers.tpl
@@ -13,6 +13,9 @@ overrides:
 
   {{- if not .Values.agentControlCd.enabled -}}
     {{- $_ := set $config "cdRemoteUpdate" false -}}
+  {{- else -}}
+    {{- $newValues := merge $config.config (dict "cdReleaseName" .Values.agentControlCd.releaseName) -}}
+    {{- $_ := set $config "config" $newValues -}}
   {{- end -}}
 
   {{- $config | toYaml | b64enc -}}

--- a/charts/agent-control/templates/install-flux.yaml
+++ b/charts/agent-control/templates/install-flux.yaml
@@ -45,7 +45,7 @@ spec:
           {{- end }}
           args:
             - |
-              HELM_RELEASE_EXISTS=$(kubectl get HelmRelease agent-control-cd -n {{ .Release.Namespace }})
+              HELM_RELEASE_EXISTS=$(kubectl get HelmRelease {{ .Values.agentControlCd.releaseName }} -n {{ .Release.Namespace }})
               if [ -z "$HELM_RELEASE_EXISTS" ]; then
                 echo "Adding agent-control-cd repository..."
                 helm repo add newrelic-agent-control-cd {{ .Values.agentControlCd.chartRepositoryUrl }}
@@ -60,7 +60,7 @@ spec:
                   --password $HELM_REPO_PASSWORD
 {{- end }}
                 echo "Installing agent-control-cd..."
-                helm upgrade --install agent-control-cd newrelic-agent-control-cd/{{ .Values.agentControlCd.chartName }} \
+                helm upgrade --install {{ .Values.agentControlCd.releaseName }} newrelic-agent-control-cd/{{ .Values.agentControlCd.chartName }} \
                   --version {{ .Values.agentControlCd.chartVersion | default .Chart.Annotations.agentControlCdVersion }} \
                   --namespace {{ .Release.Namespace }} \
                   -f /tmp/flux-values/agent-control-flux.yaml

--- a/charts/agent-control/templates/install.yaml
+++ b/charts/agent-control/templates/install.yaml
@@ -45,7 +45,8 @@ spec:
             {{- if .Values.agentControlCd.repositoryCertificateSecretReferenceName }}
                 --repository-certificate-secret-reference-name={{ .Values.agentControlCd.repositoryCertificateSecretReferenceName }} \
             {{- end }}
-                --chart-name={{ .Values.agentControlCd.chartName }}
+                --chart-name={{ .Values.agentControlCd.chartName }} \
+                --release-name={{ .Values.agentControlCd.releaseName }}
             {{- end }}
 
               echo "Creating agent-control-deployment resources..."

--- a/charts/agent-control/templates/uninstall-flux.yaml
+++ b/charts/agent-control/templates/uninstall-flux.yaml
@@ -30,5 +30,5 @@ spec:
           args:
             - -c
             - |
-              helm delete agent-control-cd --namespace {{ .Release.Namespace }}
+              helm delete {{ .Values.agentControlCd.releaseName }} --namespace {{ .Release.Namespace }}
 {{- end -}}

--- a/charts/agent-control/templates/uninstall.yaml
+++ b/charts/agent-control/templates/uninstall.yaml
@@ -39,6 +39,7 @@ spec:
               echo "Removing agent-control-cd resources..."
               newrelic-agent-control-cli remove-cd-resources \
                 --namespace "{{ .Release.Namespace }}" \
-                --log-level "{{ .Values.uninstallation.log.level }}"
+                --log-level "{{ .Values.uninstallation.log.level }}" \
+                --release-name={{ .Values.agentControlCd.releaseName }}
             {{- end }}
 {{- end -}}

--- a/charts/agent-control/templates/uninstall.yaml
+++ b/charts/agent-control/templates/uninstall.yaml
@@ -34,7 +34,8 @@ spec:
               newrelic-agent-control-cli uninstall-agent-control \
                 --namespace "{{ .Release.Namespace }}" \
                 --namespace-agents "{{ .Values.agentControlDeployment.chartValues.subAgentsNamespace }}" \
-                --log-level "{{ .Values.uninstallation.log.level }}"
+                --log-level "{{ .Values.uninstallation.log.level }}" \
+                --release-name={{ .Values.agentControlDeployment.releaseName }}
             {{- if .Values.agentControlCd.enabled }}
               echo "Removing agent-control-cd resources..."
               newrelic-agent-control-cli remove-cd-resources \

--- a/charts/agent-control/values.yaml
+++ b/charts/agent-control/values.yaml
@@ -59,7 +59,7 @@ agentControlDeployment:
   chartVersion:
 
   # -- The name of the release for the CD chart.
-  # @default -- agent-control-cd
+  # @default -- agent-control-deployment
   releaseName: agent-control-deployment
 
   # -- Optional name of the secret containing credentials for the Helm repository.

--- a/charts/agent-control/values.yaml
+++ b/charts/agent-control/values.yaml
@@ -58,6 +58,10 @@ agentControlDeployment:
   # @default -- `.Chart.appVersion`
   chartVersion:
 
+  # -- The name of the release for the CD chart.
+  # @default -- agent-control-cd
+  releaseName: agent-control-deployment
+
   # -- Optional name of the secret containing credentials for the Helm repository.
   # Ref.: https://fluxcd.io/flux/components/source/helmrepositories/#secret-reference
   repositorySecretReferenceName:

--- a/charts/agent-control/values.yaml
+++ b/charts/agent-control/values.yaml
@@ -89,6 +89,10 @@ agentControlCd:
   # @default -- `.Chart.annotations.agentControlCdVersion`
   chartVersion:
 
+  # -- The name of the release for the CD chart.
+  # @default -- agent-control-cd
+  releaseName: agent-control-cd
+
   # -- Optional name of the secret containing credentials for the Helm repository.
   # Ref.: https://fluxcd.io/flux/components/source/helmrepositories/#secret-reference
   repositorySecretReferenceName:


### PR DESCRIPTION
#### Is this a new chart

no

#### What this PR does / why we need it:

Makes the release name of the `agent-control-deployment` and `agent-control-cd` configurable.
This helps with testing.

#### Which issue this PR fixes

  - fixes #NR-449397
  - fixes #NR-441446

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)