### PR TITLE
[agent-control-deployment] hardcode cd release name

### DIFF
--- a/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 
 type: application
 
-version: 0.0.69
+version: 0.0.70
 appVersion: "0.46.0"
 
 dependencies:

--- a/charts/agent-control-deployment/templates/_helpers.tpl
+++ b/charts/agent-control-deployment/templates/_helpers.tpl
@@ -54,6 +54,7 @@ cluster name, licenses, and custom attributes
 {{- $k8s := (dict "cluster_name" (include "newrelic.common.cluster" .) "namespace" .Release.Namespace "namespace_agents" .Values.subAgentsNamespace) -}}
 {{- /* Add ac_remote_update and cd_remote_update to the config */ -}}
 {{- $k8s = mustMerge $k8s (dict "ac_remote_update" .Values.config.acRemoteUpdate "cd_remote_update" .Values.config.cdRemoteUpdate) -}}
+{{- $k8s = mustMerge $k8s (dict "cd_release_name" "agent-control-cd") -}}
 {{- $config = mustMerge $config (dict "k8s" $k8s) -}}
 
 {{- with .Values.config.log -}}

--- a/charts/agent-control-deployment/tests/configmap_agentcontrol_config_test.yaml
+++ b/charts/agent-control-deployment/tests/configmap_agentcontrol_config_test.yaml
@@ -20,6 +20,7 @@ tests:
             agents: {}
             k8s:
               ac_remote_update: true
+              cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster
               namespace: my-namespace
@@ -44,6 +45,7 @@ tests:
             agents: {}
             k8s:
               ac_remote_update: true
+              cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster
               namespace: my-namespace
@@ -73,6 +75,7 @@ tests:
               fleet_id: abcefg
             k8s:
               ac_remote_update: true
+              cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster
               namespace: my-namespace
@@ -96,6 +99,7 @@ tests:
             agents: {}
             k8s:
               ac_remote_update: true
+              cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster
               namespace: my-namespace
@@ -119,6 +123,7 @@ tests:
             agents: {}
             k8s:
               ac_remote_update: true
+              cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster
               namespace: my-namespace
@@ -146,6 +151,7 @@ tests:
               endpoint: https://opamp.service.newrelic.com/v1/opamp
             k8s:
               ac_remote_update: true
+              cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster
               namespace: my-namespace
@@ -175,6 +181,7 @@ tests:
               endpoint: https://opamp.service.newrelic.com/v1/opamp
             k8s:
               ac_remote_update: true
+              cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster
               namespace: my-namespace
@@ -209,6 +216,7 @@ tests:
               endpoint: https://opamp.service.newrelic.com/v1/opamp
             k8s:
               ac_remote_update: true
+              cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: config-cluster
               namespace: config-namespace
@@ -237,6 +245,7 @@ tests:
               endpoint: https://opamp.service.eu.newrelic.com/v1/opamp
             k8s:
               ac_remote_update: true
+              cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster
               namespace: my-namespace
@@ -261,6 +270,7 @@ tests:
             agents: {}
             k8s:
               ac_remote_update: false
+              cd_release_name: agent-control-cd
               cd_remote_update: false
               cluster_name: my-cluster
               namespace: my-namespace
@@ -354,6 +364,7 @@ tests:
             agents: {}
             k8s:
               ac_remote_update: true
+              cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster
               namespace: my-namespace
@@ -380,6 +391,7 @@ tests:
             agents: {}
             k8s:
               ac_remote_update: true
+              cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster
               namespace: my-namespace
@@ -407,6 +419,7 @@ tests:
             agents: {}
             k8s:
               ac_remote_update: true
+              cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster
               namespace: my-namespace
@@ -439,6 +452,7 @@ tests:
               endpoint: https://opamp.service.newrelic.com/v1/opamp
             k8s:
               ac_remote_update: true
+              cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster
               namespace: my-namespace


### PR DESCRIPTION
#### Is this a new chart

no

#### What this PR does / why we need it:

Hardcodes the "cd" release name. Otherwise, agent control will receive an empty string.