### PR TITLE
fix: create flux helm release before installing agent control

### DIFF
--- a/charts/agent-control/Chart.yaml
+++ b/charts/agent-control/Chart.yaml
@@ -3,9 +3,9 @@ name: agent-control
 description: Bootstraps New Relic' Agent Control
 
 type: application
-version: 0.0.86
+version: 0.0.87
 # agent-control-deployment chart default version.
-appVersion: 0.0.69
+appVersion: 0.0.70
 annotations:
   # agent-control-cd chart default version.
   agentControlCdVersion: 0.0.2

--- a/charts/agent-control/templates/install.yaml
+++ b/charts/agent-control/templates/install.yaml
@@ -31,21 +31,6 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |-
-              echo "Creating agent-control-deployment resources..."
-              newrelic-agent-control-cli install-agent-control \
-                --chart-version={{ .Values.agentControlDeployment.chartVersion | default .Chart.AppVersion }} \
-                --secrets={{ $secretName }}=agent-control-deployment.yaml,{{ $secretName }}=global.yaml \
-                --namespace={{ .Release.Namespace }} \
-                --repository-url={{ .Values.agentControlDeployment.chartRepositoryUrl }} \
-                --log-level={{ .Values.installation.log.level }} \
-            {{- if .Values.agentControlDeployment.repositorySecretReferenceName }}
-                --repository-secret-reference-name={{ .Values.agentControlDeployment.repositorySecretReferenceName }} \
-            {{- end }}
-            {{- if .Values.agentControlDeployment.repositoryCertificateSecretReferenceName }}
-                --repository-certificate-secret-reference-name={{ .Values.agentControlDeployment.repositoryCertificateSecretReferenceName }} \
-            {{- end }}
-                --chart-name={{ .Values.agentControlDeployment.chartName }}
-
             {{- if .Values.agentControlCd.enabled }}
               echo "Creating Flux's CD resources..."
               newrelic-agent-control-cli create-cd-resources \
@@ -62,4 +47,19 @@ spec:
             {{- end }}
                 --chart-name={{ .Values.agentControlCd.chartName }}
             {{- end }}
+
+              echo "Creating agent-control-deployment resources..."
+              newrelic-agent-control-cli install-agent-control \
+                --chart-version={{ .Values.agentControlDeployment.chartVersion | default .Chart.AppVersion }} \
+                --secrets={{ $secretName }}=agent-control-deployment.yaml,{{ $secretName }}=global.yaml \
+                --namespace={{ .Release.Namespace }} \
+                --repository-url={{ .Values.agentControlDeployment.chartRepositoryUrl }} \
+                --log-level={{ .Values.installation.log.level }} \
+            {{- if .Values.agentControlDeployment.repositorySecretReferenceName }}
+                --repository-secret-reference-name={{ .Values.agentControlDeployment.repositorySecretReferenceName }} \
+            {{- end }}
+            {{- if .Values.agentControlDeployment.repositoryCertificateSecretReferenceName }}
+                --repository-certificate-secret-reference-name={{ .Values.agentControlDeployment.repositoryCertificateSecretReferenceName }} \
+            {{- end }}
+                --chart-name={{ .Values.agentControlDeployment.chartName }}
 {{- end -}}

--- a/charts/agent-control/tests/install_test.yaml
+++ b/charts/agent-control/tests/install_test.yaml
@@ -9,14 +9,6 @@ tests:
           path: spec.template.spec.containers[0].args
           value:
             - |-
-              echo "Creating agent-control-deployment resources..."
-              newrelic-agent-control-cli install-agent-control \
-                --chart-version=0.0.0 \
-                --secrets=RELEASE-NAME-deployment=agent-control-deployment.yaml,RELEASE-NAME-deployment=global.yaml \
-                --namespace=NAMESPACE \
-                --repository-url=https://helm-charts.newrelic.com \
-                --log-level=debug \
-                --chart-name=agent-control-deployment
               echo "Creating Flux's CD resources..."
               newrelic-agent-control-cli create-cd-resources \
                 --chart-version=0.0.2 \
@@ -25,6 +17,15 @@ tests:
                 --repository-url=https://helm-charts.newrelic.com \
                 --log-level=debug \
                 --chart-name=agent-control-cd
+
+              echo "Creating agent-control-deployment resources..."
+              newrelic-agent-control-cli install-agent-control \
+                --chart-version=0.0.0 \
+                --secrets=RELEASE-NAME-deployment=agent-control-deployment.yaml,RELEASE-NAME-deployment=global.yaml \
+                --namespace=NAMESPACE \
+                --repository-url=https://helm-charts.newrelic.com \
+                --log-level=debug \
+                --chart-name=agent-control-deployment
 
   - it: should configure arguments correctly
     set:
@@ -51,6 +52,15 @@ tests:
           path: spec.template.spec.containers[0].args
           value:
             - |-
+              echo "Creating Flux's CD resources..."
+              newrelic-agent-control-cli create-cd-resources \
+                --chart-version=3.2.1 \
+                --secrets=RELEASE-NAME-deployment-flux=agent-control-flux.yaml \
+                --namespace=NAMESPACE \
+                --repository-url=https://newrelic.com/other/url \
+                --log-level=trace \
+                --chart-name=custom-flux
+
               echo "Creating agent-control-deployment resources..."
               newrelic-agent-control-cli install-agent-control \
                 --chart-version=1.2.3 \
@@ -61,14 +71,6 @@ tests:
                 --repository-secret-reference-name=secret-ref \
                 --repository-certificate-secret-reference-name=cert-secret-ref \
                 --chart-name=custom-deployment
-              echo "Creating Flux's CD resources..."
-              newrelic-agent-control-cli create-cd-resources \
-                --chart-version=3.2.1 \
-                --secrets=RELEASE-NAME-deployment-flux=agent-control-flux.yaml \
-                --namespace=NAMESPACE \
-                --repository-url=https://newrelic.com/other/url \
-                --log-level=trace \
-                --chart-name=custom-flux
 
   - it: should leverage correct image tag
     set:


### PR DESCRIPTION
#### Is this a new chart

no

#### What this PR does / why we need it:

Creates flux helm release before installing ac. Otherwise, AC will log an error when the cd remote update is enabled at installation time.