### PR TITLE
[agent-control] chore: bump version

### DIFF
--- a/charts/agent-control/Chart.yaml
+++ b/charts/agent-control/Chart.yaml
@@ -3,9 +3,9 @@ name: agent-control
 description: Bootstraps New Relic' Agent Control
 
 type: application
-version: 0.0.90
+version: 0.0.91
 # agent-control-deployment chart default version.
-appVersion: 0.0.73
+appVersion: 0.0.74
 annotations:
   # agent-control-cd chart default version.
   agentControlCdVersion: 0.0.2

--- a/charts/agent-control/README.md
+++ b/charts/agent-control/README.md
@@ -94,7 +94,7 @@ agent-control-deployment:
 | installation.extraVolumes | list | `[]` | Volumes to mount in the containers |
 | installation.log.level | string | debug | Log level for installation. |
 | nameOverride | string | `""` | Override the name of the chart |
-| toolkitImage | object | `{"pullPolicy":"IfNotPresent","pullSecrets":[],"registry":null,"repository":"newrelic/newrelic-agent-control-cli","tag":"0.47.0"}` | The image that contains the necessary tools to install and uninstall the Agent Control components. |
+| toolkitImage | object | `{"pullPolicy":"IfNotPresent","pullSecrets":[],"registry":null,"repository":"newrelic/newrelic-agent-control-cli","tag":"0.48.0"}` | The image that contains the necessary tools to install and uninstall the Agent Control components. |
 | toolkitImage.pullSecrets | list | `[]` | The secrets that are needed to pull images from a custom registry. |
 | uninstallation.log.level | string | debug | Log level for installation. |
 

--- a/charts/agent-control/values.yaml
+++ b/charts/agent-control/values.yaml
@@ -7,7 +7,7 @@ fullnameOverride: ""
 toolkitImage:
   registry:
   repository: newrelic/newrelic-agent-control-cli
-  tag: "0.47.0"
+  tag: "0.48.0"
   pullPolicy: IfNotPresent
   # -- The secrets that are needed to pull images from a custom registry.
   pullSecrets: []


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No
#### What this PR does / why we need it:

Bump AC chart version due to bump in agent-control-deployment chart version

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Tell the world about the latest changes in the chart.
<!--END-RELEASE-NOTES-->
