### PR TITLE
fix: update eks-cloud paths to match aws updates

### DIFF
--- a/.github/workflows/post-release-nri-bundle.yml
+++ b/.github/workflows/post-release-nri-bundle.yml
@@ -201,8 +201,8 @@ jobs:
             eks-anywhere-vsphere/Addons/Partner/newrelic/namespace.yaml
             eks-hybrid-nodes/Addons/Partner/newrelic/newrelic.yaml
             eks-hybrid-nodes/Addons/Partner/newrelic/namespace.yaml
-            eks-cloud/Partner/newrelic/newrelic.yaml
-            eks-cloud/Partner/newrelic/namespace.yaml
+            eks-cloud/Addons/Partner/newrelic/newrelic.yaml
+            eks-cloud/Addons/Partner/newrelic/namespace.yaml
           sparse-checkout-cone-mode: false
 
       - name: Configure Git
@@ -224,7 +224,7 @@ jobs:
             'eks-anywhere-snow/Addons/Partner/newrelic'
             'eks-anywhere-vsphere/Addons/Partner/newrelic'
             'eks-hybrid-nodes/Addons/Partner/newrelic'
-            'eks-cloud/Partner/newrelic'
+            'eks-cloud/Addons/Partner/newrelic'
           )
           for directory in "${folders[@]}"; do
             file_name="${directory}/newrelic.yaml"


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
NO

#### What this PR does / why we need it:
AWS recently updated some paths in their eks-anywhere repo, which broke our GHA to update eks-anywhere. This fixes the GHA to match.

AWS PR for reference: https://github.com/aws-samples/eks-anywhere-addons/pull/396

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]


# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Tell the world about the latest changes in the chart.
<!--END-RELEASE-NOTES-->
