### PR TITLE
[nr-k8s-otel-collector] Extract Runtime

### DIFF
--- a/charts/nr-k8s-otel-collector/Chart.yaml
+++ b/charts/nr-k8s-otel-collector/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.40
+version: 0.8.41
 
 dependencies:
   - name: common-library

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/clusterrole.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/clusterrole.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.2.0
-    helm.sh/chart: nr-k8s-otel-collector-0.8.40
+    helm.sh/chart: nr-k8s-otel-collector-0.8.41
 rules:
   - apiGroups:
     - ""

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/clusterrolebinding.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/clusterrolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.2.0
-    helm.sh/chart: nr-k8s-otel-collector-0.8.40
+    helm.sh/chart: nr-k8s-otel-collector-0.8.41
 subjects:
   - kind: ServiceAccount
     name: nr-k8s-otel-collector

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/daemonset-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.2.0
-    helm.sh/chart: nr-k8s-otel-collector-0.8.40
+    helm.sh/chart: nr-k8s-otel-collector-0.8.41
 data:
   daemonset-config.yaml: |
     receivers:
@@ -232,6 +232,14 @@ data:
           - delete_key(resource.attributes, "persistentvolume")
           - delete_key(resource.attributes, "persistentvolumeclaim")
 
+      transform/extract_runtime:
+        metric_statements:
+          - context: datapoint
+            conditions:
+              - IsMatch(attributes["container_id"], ".*://.*")
+            statements:
+              - set(attributes["runtime"], Split(attributes["container_id"], "://")[0])
+              - set(attributes["container_id"], Split(attributes["container_id"], "://")[1])
 
       metricstransform/ldm:
         transforms:
@@ -515,7 +523,7 @@ data:
             value: <cluser_name>
           - key: "newrelic.chart.version"
             action: upsert
-            value: 0.8.40
+            value: 0.8.41
           - key: newrelic.entity.type
             action: upsert
             value: "k8s"
@@ -732,6 +740,7 @@ data:
           receivers:
             - routing/metrics_egress
           processors:
+            - transform/extract_runtime
             
             - batch
           exporters:

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/daemonset.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.2.0
-    helm.sh/chart: nr-k8s-otel-collector-0.8.40
+    helm.sh/chart: nr-k8s-otel-collector-0.8.41
 spec:
   selector:
     matchLabels:
@@ -24,7 +24,7 @@ spec:
         app.kubernetes.io/name: nr-k8s-otel-collector
         component: daemonset
       annotations:
-        checksum/config: 2532d84bec81c5993d41c90cd437c64eaa28eff34a4fb7c9e79604cfdb732d5c
+        checksum/config: ddeb9e92de0afbb19e1d75f78e21adc707b8dcbff28a1a86cdf8c8706e787257
     spec:
       serviceAccountName: nr-k8s-otel-collector
       containers:

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.2.0
-    helm.sh/chart: nr-k8s-otel-collector-0.8.40
+    helm.sh/chart: nr-k8s-otel-collector-0.8.41
 data:
   deployment-config.yaml: |
     receivers:
@@ -157,6 +157,15 @@ data:
           - context: metric
             statements:
               - delete_key(instrumentation_scope.attributes, "job_label")
+
+      transform/extract_runtime:
+        metric_statements:
+          - context: datapoint
+            conditions:
+              - IsMatch(attributes["container_id"], ".*://.*")
+            statements:
+              - set(attributes["runtime"], Split(attributes["container_id"], "://")[0])
+              - set(attributes["container_id"], Split(attributes["container_id"], "://")[1])
 
       groupbyattrs:
         keys:
@@ -488,7 +497,7 @@ data:
             value: <cluser_name>
           - key: "newrelic.chart.version"
             action: upsert
-            value: 0.8.40
+            value: 0.8.41
           - key: newrelic.entity.type
             action: upsert
             value: "k8s"
@@ -506,7 +515,7 @@ data:
             value: <cluser_name>
           - key: "newrelic.chart.version"
             action: upsert
-            value: 0.8.40
+            value: 0.8.41
 
       transform/events:
         log_statements:
@@ -777,6 +786,7 @@ data:
             - routing/metrics_egress
           processors:
             - transform/remove_routing_metadata
+            - transform/extract_runtime
             
             - batch
           exporters:

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.2.0
-    helm.sh/chart: nr-k8s-otel-collector-0.8.40
+    helm.sh/chart: nr-k8s-otel-collector-0.8.41
 spec:
   replicas: 1
   minReadySeconds: 5
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/name: nr-k8s-otel-collector
         component: deployment
       annotations:
-        checksum/config: 84bdeb361e704fa315e9e51c13e262246a6be3b07580696a773c2e0574d53f09
+        checksum/config: 095f35b31cba9b30438738497267dada45dd0d00def6fdacbef0e9d3d9a9312c
     spec:
       serviceAccountName: nr-k8s-otel-collector
       containers:

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/secret.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/secret.yaml
@@ -10,6 +10,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.2.0
-    helm.sh/chart: nr-k8s-otel-collector-0.8.40
+    helm.sh/chart: nr-k8s-otel-collector-0.8.41
 data:
   licenseKey: PE5SX2xpY2Vuc2VLZXk+

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/service.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/service.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.2.0
-    helm.sh/chart: nr-k8s-otel-collector-0.8.40
+    helm.sh/chart: nr-k8s-otel-collector-0.8.41
 spec:
   type: ClusterIP
   ports:

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/serviceaccount.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/serviceaccount.yaml
@@ -10,5 +10,5 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.2.0
-    helm.sh/chart: nr-k8s-otel-collector-0.8.40
+    helm.sh/chart: nr-k8s-otel-collector-0.8.41
   annotations:

--- a/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
@@ -249,6 +249,14 @@ data:
           - delete_key(resource.attributes, "persistentvolume")
           - delete_key(resource.attributes, "persistentvolumeclaim")
 
+      transform/extract_runtime:
+        metric_statements:
+          - context: datapoint
+            conditions:
+              - IsMatch(attributes["container_id"], ".*://.*")
+            statements:
+              - set(attributes["runtime"], Split(attributes["container_id"], "://")[0])
+              - set(attributes["container_id"], Split(attributes["container_id"], "://")[1])
 
       metricstransform/ldm:
         transforms:
@@ -794,6 +802,7 @@ data:
           receivers:
             - routing/metrics_egress
           processors:
+            - transform/extract_runtime
             {{- include "nrKubernetesOtel.metricsPipeline.collectorEgress.processors" . | nindent 12 }}
             - batch
           exporters:

--- a/charts/nr-k8s-otel-collector/templates/deployment-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/deployment-configmap.yaml
@@ -192,6 +192,15 @@ data:
             statements:
               - delete_key(instrumentation_scope.attributes, "job_label")
 
+      transform/extract_runtime:
+        metric_statements:
+          - context: datapoint
+            conditions:
+              - IsMatch(attributes["container_id"], ".*://.*")
+            statements:
+              - set(attributes["runtime"], Split(attributes["container_id"], "://")[0])
+              - set(attributes["container_id"], Split(attributes["container_id"], "://")[1])
+
       groupbyattrs:
         keys:
           - pod
@@ -846,6 +855,7 @@ data:
             - routing/metrics_egress
           processors:
             - transform/remove_routing_metadata
+            - transform/extract_runtime
             {{- include "nrKubernetesOtel.metricsPipeline.collectorEgress.processors" . | nindent 12 }}
             - batch
           exporters:


### PR DESCRIPTION
#### Is this a new chart
NO.

#### What this PR does / why we need it:
* Extracts the runtime from container_id into an attribute called 'runtime'.
* Removes the runtime + from the container_id 

This allows for backwards compatibility as NR does not expect container_ID to be prefixed with <runtime>:// 
This allow allows for the runtime information to be queried from NRDB. 

#### Which issue this PR fixes
N/A (Internal ticket)

#### Special notes for your reviewer:
N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)

# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Tell the world about the latest changes in the chart.
<!--END-RELEASE-NOTES-->
