### PR TITLE
[nr-k8s-otel-collector] feat: upgrade ksm chart to 6.1.5 for app v2.16.0

### DIFF
--- a/charts/nr-k8s-otel-collector/Chart.lock
+++ b/charts/nr-k8s-otel-collector/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.3.3
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 5.30.1
-digest: sha256:90847b1de19450692c73cbe5380256963951f6da810efb3dccbfac2bb558bb96
-generated: "2025-09-11T17:17:21.000479+01:00"
+  version: 6.1.5
+digest: sha256:bcbc251699517904509735ccfe24ab625764d0480ef2c58262cf6968bded7d30
+generated: "2025-10-24T15:53:09.813036-07:00"

--- a/charts/nr-k8s-otel-collector/Chart.yaml
+++ b/charts/nr-k8s-otel-collector/Chart.yaml
@@ -17,14 +17,14 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.52
+version: 0.8.53
 
 dependencies:
   - name: common-library
     version: 1.3.3
     repository: "https://helm-charts.newrelic.com"
   - name: kube-state-metrics
-    version: 5.30.1
+    version: 6.1.5
     condition: kube-state-metrics.enabled
     repository: https://prometheus-community.github.io/helm-charts
 

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/clusterrole.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/clusterrole.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.2.0
-    helm.sh/chart: nr-k8s-otel-collector-0.8.52
+    helm.sh/chart: nr-k8s-otel-collector-0.8.53
 rules:
   - apiGroups:
     - ""

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/clusterrolebinding.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/clusterrolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.2.0
-    helm.sh/chart: nr-k8s-otel-collector-0.8.52
+    helm.sh/chart: nr-k8s-otel-collector-0.8.53
 subjects:
   - kind: ServiceAccount
     name: nr-k8s-otel-collector

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/daemonset-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.2.0
-    helm.sh/chart: nr-k8s-otel-collector-0.8.52
+    helm.sh/chart: nr-k8s-otel-collector-0.8.53
 data:
   daemonset-config.yaml: |
     receivers:
@@ -558,7 +558,7 @@ data:
             value: <cluser_name>
           - key: "newrelic.chart.version"
             action: upsert
-            value: 0.8.52
+            value: 0.8.53
           - key: newrelic.entity.type
             action: upsert
             value: "k8s"

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/daemonset.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.2.0
-    helm.sh/chart: nr-k8s-otel-collector-0.8.52
+    helm.sh/chart: nr-k8s-otel-collector-0.8.53
 spec:
   selector:
     matchLabels:
@@ -24,7 +24,7 @@ spec:
         app.kubernetes.io/name: nr-k8s-otel-collector
         component: daemonset
       annotations:
-        checksum/config: ab4fecb38ba638aedcd5707a3705e627c70ada0681dad70d1dc6d1d80657f70e
+        checksum/config: a444e133ac4fd97b347ba0c416223259bdbf9140c3555f5fe4f6e66080e5870a
     spec:
       serviceAccountName: nr-k8s-otel-collector
       containers:

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.2.0
-    helm.sh/chart: nr-k8s-otel-collector-0.8.52
+    helm.sh/chart: nr-k8s-otel-collector-0.8.53
 data:
   deployment-config.yaml: |
     receivers:
@@ -507,7 +507,7 @@ data:
             value: <cluser_name>
           - key: "newrelic.chart.version"
             action: upsert
-            value: 0.8.52
+            value: 0.8.53
           - key: newrelic.entity.type
             action: upsert
             value: "k8s"
@@ -525,7 +525,7 @@ data:
             value: <cluser_name>
           - key: "newrelic.chart.version"
             action: upsert
-            value: 0.8.52
+            value: 0.8.53
 
       transform/events:
         log_statements:

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.2.0
-    helm.sh/chart: nr-k8s-otel-collector-0.8.52
+    helm.sh/chart: nr-k8s-otel-collector-0.8.53
 spec:
   replicas: 1
   minReadySeconds: 5
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/name: nr-k8s-otel-collector
         component: deployment
       annotations:
-        checksum/config: 154d8d67e68b767a358527bec4cae823c5a814746233f4d5967cf6eb39a32207
+        checksum/config: 7a9dbdfddfd9879768e44c1d4114ab6923974aca951457f1ecd4e9afb88ac232
     spec:
       serviceAccountName: nr-k8s-otel-collector
       containers:

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/kube-state-metrics/clusterrolebinding.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/kube-state-metrics/clusterrolebinding.yaml
@@ -4,13 +4,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.30.1
+    helm.sh/chart: kube-state-metrics-6.1.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: nr-k8s-otel-collector
-    app.kubernetes.io/version: "2.15.0"
+    app.kubernetes.io/version: "2.16.0"
   name: nr-k8s-otel-collector-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/kube-state-metrics/deployment.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/kube-state-metrics/deployment.yaml
@@ -6,13 +6,13 @@ metadata:
   name: nr-k8s-otel-collector-kube-state-metrics
   namespace: newrelic
   labels:    
-    helm.sh/chart: kube-state-metrics-5.30.1
+    helm.sh/chart: kube-state-metrics-6.1.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: nr-k8s-otel-collector
-    app.kubernetes.io/version: "2.15.0"
+    app.kubernetes.io/version: "2.16.0"
 spec:
   selector:
     matchLabels:      
@@ -25,13 +25,13 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.30.1
+        helm.sh/chart: kube-state-metrics-6.1.5
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: nr-k8s-otel-collector
-        app.kubernetes.io/version: "2.15.0"
+        app.kubernetes.io/version: "2.16.0"
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -43,13 +43,14 @@ spec:
         runAsUser: 65534
         seccompProfile:
           type: RuntimeDefault
+      dnsPolicy: ClusterFirst
       containers:
       - name: kube-state-metrics
         args:
         - --port=8080
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.16.0
         ports:
         - containerPort: 8080
           name: "http"

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/kube-state-metrics/role.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/kube-state-metrics/role.yaml
@@ -4,13 +4,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.30.1
+    helm.sh/chart: kube-state-metrics-6.1.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: nr-k8s-otel-collector
-    app.kubernetes.io/version: "2.15.0"
+    app.kubernetes.io/version: "2.16.0"
   name: nr-k8s-otel-collector-kube-state-metrics
 rules:
 
@@ -29,12 +29,12 @@ rules:
   - cronjobs
   verbs: ["list", "watch"]
 
-- apiGroups: ["extensions", "apps"]
+- apiGroups: ["apps"]
   resources:
   - daemonsets
   verbs: ["list", "watch"]
 
-- apiGroups: ["extensions", "apps"]
+- apiGroups: ["apps"]
   resources:
   - deployments
   verbs: ["list", "watch"]
@@ -49,7 +49,7 @@ rules:
   - horizontalpodautoscalers
   verbs: ["list", "watch"]
 
-- apiGroups: ["extensions", "networking.k8s.io"]
+- apiGroups: ["networking.k8s.io"]
   resources:
   - ingresses
   verbs: ["list", "watch"]
@@ -109,7 +109,7 @@ rules:
   - pods
   verbs: ["list", "watch"]
 
-- apiGroups: ["extensions", "apps"]
+- apiGroups: ["apps"]
   resources:
   - replicasets
   verbs: ["list", "watch"]

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/kube-state-metrics/service.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/kube-state-metrics/service.yaml
@@ -6,13 +6,13 @@ metadata:
   name: nr-k8s-otel-collector-kube-state-metrics
   namespace: newrelic
   labels:    
-    helm.sh/chart: kube-state-metrics-5.30.1
+    helm.sh/chart: kube-state-metrics-6.1.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: nr-k8s-otel-collector
-    app.kubernetes.io/version: "2.15.0"
+    app.kubernetes.io/version: "2.16.0"
   annotations:
 spec:
   type: "ClusterIP"

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/kube-state-metrics/serviceaccount.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/kube-state-metrics/serviceaccount.yaml
@@ -5,12 +5,12 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.30.1
+    helm.sh/chart: kube-state-metrics-6.1.5
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: nr-k8s-otel-collector
-    app.kubernetes.io/version: "2.15.0"
+    app.kubernetes.io/version: "2.16.0"
   name: nr-k8s-otel-collector-kube-state-metrics
   namespace: newrelic

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/secret.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/secret.yaml
@@ -10,6 +10,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.2.0
-    helm.sh/chart: nr-k8s-otel-collector-0.8.52
+    helm.sh/chart: nr-k8s-otel-collector-0.8.53
 data:
   licenseKey: PE5SX2xpY2Vuc2VLZXk+

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/service.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/service.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.2.0
-    helm.sh/chart: nr-k8s-otel-collector-0.8.52
+    helm.sh/chart: nr-k8s-otel-collector-0.8.53
 spec:
   type: ClusterIP
   ports:

--- a/charts/nr-k8s-otel-collector/examples/k8s/rendered/serviceaccount.yaml
+++ b/charts/nr-k8s-otel-collector/examples/k8s/rendered/serviceaccount.yaml
@@ -10,5 +10,5 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nr-k8s-otel-collector
     app.kubernetes.io/version: 1.2.0
-    helm.sh/chart: nr-k8s-otel-collector-0.8.52
+    helm.sh/chart: nr-k8s-otel-collector-0.8.53
   annotations:


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No
#### What this PR does / why we need it:

#### Which issue this PR fixes
- there were high trivvy vulnerabilities in KSM v2.15.0, 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* update kube-state-metrics chart version to 6.1.5 (the latest version which uses KSM v2.16.0)
<!--END-RELEASE-NOTES-->
