### PR TITLE
fix(nri-bundle): add alias for nr-ebpf-agent configuration routing

### DIFF
--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -67,6 +67,7 @@ dependencies:
     version: 2.1.6
 
   - name: nr-ebpf-agent
+    alias: newrelic-eapm-agent
     version: 1.3.0
     condition: newrelic-eapm-agent.enabled,nr-ebpf-agent.enabled
     repository: https://newrelic.github.io/helm-charts


### PR DESCRIPTION
## Problem Statement

The `nr-ebpf-agent` chart is configured in nri-bundle with a mismatch between its condition name and chart name:
- Condition name: `newrelic-eapm-agent.enabled`
- Chart name: `nr-ebpf-agent`

This forces users to maintain **two separate configuration sections** in their values file:

```yaml
newrelic-eapm-agent:
  enabled: true

nr-ebpf-agent:
  ebpfAgent:
    image: {...}
  otelCollector:
    image: {...}
```

This is **inconsistent with all other nri-bundle charts**, which use a single configuration section.

## Solution

Add `alias: newrelic-eapm-agent` to the nr-ebpf-agent dependency definition in Chart.yaml.

This allows Helm to route both the condition name and chart name to the same chart, enabling users to consolidate configuration under a single section:

```yaml
newrelic-eapm-agent:
  enabled: true
  ebpfAgent:
    image: {...}
  otelCollector:
    image: {...}
```

## Implementation

This approach:
- ✅ Mirrors the existing pattern used for `pixie-operator-chart` alias
- ✅ Maintains full backward compatibility
- ✅ Improves configuration UX consistency across nri-bundle
- ✅ Requires no changes to the nr-ebpf-agent chart itself

## Testing

Verified with `helm template` that configuration under `newrelic-eapm-agent:` is properly routed to the nr-ebpf-agent chart subchart.