### PR TITLE
[synthetics-job-manager] fix: ping runtime service name

### DIFF
--- a/charts/synthetics-job-manager/Chart.yaml
+++ b/charts/synthetics-job-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: synthetics-job-manager
 description: New Relic Synthetics Containerized Job Manager
 type: application
-version: 3.0.41
+version: 3.0.42
 appVersion: release-486
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
@@ -28,7 +28,7 @@ keywords:
   - newrelic
 dependencies:
   - name: ping-runtime
-    version: 1.0.29
+    version: 1.0.30
     condition: ping-runtime.enabled
   - name: node-api-runtime
     version: 1.0.47

--- a/charts/synthetics-job-manager/charts/ping-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/ping-runtime/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ping-runtime
 description: New Relic Synthetics Ping Runtime
 type: application
-version: 1.0.29
+version: 1.0.30
 appVersion: 1.58.0
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:

--- a/charts/synthetics-job-manager/charts/ping-runtime/templates/service.yaml
+++ b/charts/synthetics-job-manager/charts/ping-runtime/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "ping-runtime.hostname" . }}
+  name: {{ include "ping-runtime.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ping-runtime.labels" . | nindent 4 }}


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

Fixes a bug in the ping-runtime subchart where `service.yaml` references a non-existent template function `ping-runtime.hostname`. This prevented the service name from being configurable via `nameOverride`, which blocked deploying multiple isolated ping-runtime instances in the same namespace (as recommended in the [New Relic scaling documentation](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/private-locations/job-manager-configuration/#scaling-out-with-multiple-sjm-deployments)).

**Problem:** When scaling out ping-runtime with different `nameOverride` values, multiple Deployments were created correctly but multiple Services could not be created because the service name was not configurable.

**Solution:** Updated `service.yaml` to use the existing `ping-runtime.name` template function, enabling `nameOverride` to work correctly for both Deployments and Services.

**Testing:** Validated locally with `ct lint` and deployed to a test cluster with multiple ping-runtime instances to confirm each service now has a unique, configurable name.

#### Which issue this PR fixes
  - fixes #2028

#### Special notes for your reviewer:

This PR includes changes to both the `ping-runtime` subchart and its parent `synthetics-job-manager` chart:
- `ping-runtime/templates/service.yaml`: Fixed template function reference (hostname → name)
- `ping-runtime/Chart.yaml`: Version bump 1.0.29 → 1.0.30
- `synthetics-job-manager/Chart.yaml`: Updated dependency version and chart version 3.0.41 → 3.0.42

All local validation tests passed including `ct lint` and deployment testing with multiple instances.

@Philip-R-Beckwith @sshah-nr @vkasanneni-nr @marcusperezNR @mderemer-nr @kaschaefer-nr @sadafarshad @lromer22 @kondracek-nr @sidnaiknewrelic

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Tell the world about the latest changes in the chart.
<!--END-RELEASE-NOTES-->