### PR TITLE
[agent-control] fix: skip chart uninstall if not exists (NR-490719)

### DIFF
--- a/charts/agent-control-bootstrap/Chart.yaml
+++ b/charts/agent-control-bootstrap/Chart.yaml
@@ -3,7 +3,7 @@ name: agent-control-bootstrap
 description: Bootstraps New Relic' Agent Control
 
 type: application
-version: 1.0.8
+version: 1.0.9
 # agent-control-deployment chart default version.
 appVersion: 1.0.6
 annotations:

--- a/charts/agent-control-bootstrap/templates/uninstallation-job.yaml
+++ b/charts/agent-control-bootstrap/templates/uninstallation-job.yaml
@@ -44,6 +44,8 @@ spec:
                 --log-level "{{ .Values.uninstallation.log.level }}" \
                 --release-name={{ .Values.agentControlCd.releaseName }}
               echo "uninstalling agent-control-cd chart..."
-              helm uninstall {{ .Values.agentControlCd.releaseName }} --namespace {{ .Release.Namespace }}
+              if helm status {{ .Values.agentControlCd.releaseName }} --namespace {{ .Release.Namespace }}; then
+                helm uninstall {{ .Values.agentControlCd.releaseName }} --namespace {{ .Release.Namespace }}
+              fi
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
- Skips chart uninstall if not exist to unblock uninstallation job