### PR TITLE
[agent-control-bootstrap] chore: update common-library to 1.4.0 & update tests

### DIFF
--- a/charts/agent-control-bootstrap/Chart.lock
+++ b/charts/agent-control-bootstrap/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: https://helm-charts.newrelic.com
-  version: 1.3.3
-digest: sha256:0ba54a189b03d9104713cb93542f6df09c0fa3546e785fb71fe679c1a6426d8a
-generated: "2025-07-23T11:49:08.825409+02:00"
+  version: 1.4.0
+digest: sha256:5655aeb5921ac47b5413c3873218309e4a5a78bc0d75d6dd7aabe13ad0e63cc7
+generated: "2026-01-13T17:45:43.119605-08:00"

--- a/charts/agent-control-bootstrap/Chart.yaml
+++ b/charts/agent-control-bootstrap/Chart.yaml
@@ -3,7 +3,7 @@ name: agent-control-bootstrap
 description: Bootstraps New Relic' Agent Control
 
 type: application
-version: 1.2.0
+version: 1.2.1
 # agent-control-deployment chart default version.
 appVersion: 1.2.0
 annotations:
@@ -13,7 +13,7 @@ annotations:
 
 dependencies:
   - name: common-library
-    version: 1.3.3
+    version: 1.4.0
     repository: https://helm-charts.newrelic.com
 
 keywords:

--- a/charts/agent-control-bootstrap/tests/agent-control-cd_test.yaml
+++ b/charts/agent-control-bootstrap/tests/agent-control-cd_test.yaml
@@ -9,11 +9,11 @@ tests:
       - template: templates/installation-job.yaml
         equal:
           path: spec.template.spec.containers[0].image
-          value: "test:123"
+          value: "docker.io/test:123"
       - template: templates/uninstallation-job.yaml
         equal:
           path: spec.template.spec.containers[0].image
-          value: "test:123"
+          value: "docker.io/test:123"
   - it: should allow custom repositoryUrl
     set:
       agentControlCd:

--- a/charts/agent-control-deployment/Chart.lock
+++ b/charts/agent-control-deployment/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: https://helm-charts.newrelic.com
-  version: 1.3.3
-digest: sha256:0ba54a189b03d9104713cb93542f6df09c0fa3546e785fb71fe679c1a6426d8a
-generated: "2025-06-26T12:57:00.46884+02:00"
+  version: 1.4.0
+digest: sha256:5655aeb5921ac47b5413c3873218309e4a5a78bc0d75d6dd7aabe13ad0e63cc7
+generated: "2026-01-13T17:46:47.864451-08:00"

--- a/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control-deployment/Chart.yaml
@@ -4,12 +4,12 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 
 type: application
 
-version: 1.2.0
+version: 1.2.1
 appVersion: "1.7.1"
 
 dependencies:
   - name: common-library
-    version: 1.3.3
+    version: 1.4.0
     repository: https://helm-charts.newrelic.com
 
 keywords:


### PR DESCRIPTION
#### What this PR does / why we need it:
Updates common-library chart to 1.4.0 for agent-control-bootstrap & agent-control-deployment, which enforces the use of fully-qualified image names by setting `docker.io` as the explicit default registry when no other registry is provided. Also fixes some tests in agent-control-bootstrap to account for the enforcement.

Broke this out from https://github.com/newrelic/helm-charts/pull/2040 because trying to get all the necessary approvals before I had to rebase from the master branch was driving me nuts.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Tell the world about the latest changes in the chart.
<!--END-RELEASE-NOTES-->
