### PR TITLE
[newrelic-logging] chore: update common-library to 1.4.0 & fix tests

### DIFF
--- a/charts/newrelic-logging/Chart.lock
+++ b/charts/newrelic-logging/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: https://helm-charts.newrelic.com
-  version: 1.3.3
-digest: sha256:0ba54a189b03d9104713cb93542f6df09c0fa3546e785fb71fe679c1a6426d8a
-generated: "2025-07-16T17:55:23.165414+05:30"
+  version: 1.4.0
+digest: sha256:5655aeb5921ac47b5413c3873218309e4a5a78bc0d75d6dd7aabe13ad0e63cc7
+generated: "2026-01-13T18:06:37.592341-08:00"

--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.33.0
+version: 1.33.1
 appVersion: 3.2.1
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
@@ -15,5 +15,5 @@ keywords:
   - newrelic
 dependencies:
   - name: common-library
-    version: 1.3.3
+    version: 1.4.0
     repository: "https://helm-charts.newrelic.com"

--- a/charts/newrelic-logging/tests/images_test.yaml
+++ b/charts/newrelic-logging/tests/images_test.yaml
@@ -17,16 +17,16 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: newrelic/newrelic-fluentbit-output:3.2.1
+          value: docker.io/newrelic/newrelic-fluentbit-output:3.2.1
         template: templates/daemonset.yaml
       - equal:
           path: spec.template.spec.containers[0].image
-          value: newrelic/newrelic-fluentbit-output:3.2.1-windows-ltsc-2019
+          value: docker.io/newrelic/newrelic-fluentbit-output:3.2.1-windows-ltsc-2019
         template: templates/daemonset-windows.yaml
         documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].image
-          value: newrelic/newrelic-fluentbit-output:3.2.1-windows-ltsc-2022
+          value: docker.io/newrelic/newrelic-fluentbit-output:3.2.1-windows-ltsc-2022
         template: templates/daemonset-windows.yaml
         documentIndex: 1
   - it: global registry is used if set


### PR DESCRIPTION
#### What this PR does / why we need it:
Updates common-library chart to 1.4.0 for newrelic-logging, which enforces the use of fully-qualified image names by setting docker.io as the explicit default registry when no other registry is provided. Also fixes some tests to account for the enforcement.

Broke this out from https://github.com/newrelic/helm-charts/pull/2040 because trying to get all the necessary approvals before I had to rebase from the master branch was driving me nuts.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Tell the world about the latest changes in the chart.
<!--END-RELEASE-NOTES-->
