### PR TITLE
[pipeline-control-gateway] chore: update common-library

### DIFF
--- a/charts/pipeline-control-gateway/Chart.lock
+++ b/charts/pipeline-control-gateway/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: https://helm-charts.newrelic.com
-  version: 1.3.3
-digest: sha256:0ba54a189b03d9104713cb93542f6df09c0fa3546e785fb71fe679c1a6426d8a
-generated: "2025-07-12T01:04:53.431238+05:30"
+  version: 1.4.0
+digest: sha256:5655aeb5921ac47b5413c3873218309e4a5a78bc0d75d6dd7aabe13ad0e63cc7
+generated: "2026-01-13T18:24:48.329105-08:00"

--- a/charts/pipeline-control-gateway/Chart.yaml
+++ b/charts/pipeline-control-gateway/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 name: pipeline-control-gateway
 type: application
-version: 1.2.0
+version: 1.2.1
 dependencies:
   - name: common-library
-    version: 1.3.3
+    version: 1.4.0
     repository: https://helm-charts.newrelic.com
 appVersion: "1.2.0"
 maintainers:


### PR DESCRIPTION
#### What this PR does / why we need it:
Updates common-library chart to 1.4.0 for pipeline-control-gateway, which enforces the use of fully-qualified image names by setting docker.io as the explicit default registry when no other registry is provided.

Broke this out from https://github.com/newrelic/helm-charts/pull/2040 because trying to get all the necessary approvals before I had to rebase from the master branch was driving me nuts.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Tell the world about the latest changes in the chart.
<!--END-RELEASE-NOTES-->
