### PR TITLE
feat(nr-ebpf-agent): support global.images registry, pullSecrets, and pullPolicy

### DIFF
--- a/charts/nr-ebpf-agent/templates/_helpers.tpl
+++ b/charts/nr-ebpf-agent/templates/_helpers.tpl
@@ -59,64 +59,28 @@ Return the cluster name
 Create otel collector receiver endpoint
 */}}
 {{- define "nr-otel-collector-receiver.endpoint" -}}
-{{- printf "dns:///%s.%s.svc.%s:%v" (include "otel-collector.service.name" .) .Release.Namespace .Values.kubernetesClusterDomain .Values.otelCollector.receiverPort }}
+{{- printf "dns:///%s.%s.svc.%s:4317" (include "otel-collector.service.name" .) .Release.Namespace .Values.kubernetesClusterDomain }}
 {{- end }}
 
 {{/*
 Validates that user-provided tags don't contain "agent-" prefix for chart version >= 0.4.0
-Also validates agent version compatibility for chart version >= 1.0.0
 */}}
 {{- define "nr-ebpf-agent.imageTag" -}}
-{{- $imageTag := "" -}}
 {{- if .Values.ebpfAgent.image.tag -}}
   {{- if semverCompare ">=0.4.0" .Chart.Version -}}
     {{- if hasPrefix "agent-" .Values.ebpfAgent.image.tag -}}
       {{- fail (printf "Error: For chart version %s (>=0.4.0), the ebpfAgent.image.tag should not contain 'agent-' prefix. Please use image tags that do not contain the prefix." .Chart.Version) -}}
     {{- end -}}
-    {{- $imageTag = .Values.ebpfAgent.image.tag -}}
+    {{- .Values.ebpfAgent.image.tag -}}
   {{- else -}}
-    {{- $imageTag = .Values.ebpfAgent.image.tag -}}
+    {{- .Values.ebpfAgent.image.tag -}}
   {{- end -}}
 {{- else -}}
   {{- if semverCompare ">=0.4.0" .Chart.Version -}}
-    {{- $imageTag = .Chart.AppVersion -}}
+    {{- .Chart.AppVersion -}}
   {{- else -}}
-    {{- $imageTag = printf "agent-%s" .Chart.AppVersion -}}
+    {{- printf "agent-%s" .Chart.AppVersion -}}
   {{- end -}}
-{{- end -}}
-{{- if and (semverCompare ">=1.0.0" .Chart.Version) (not .Values.skipVersionValidation) -}}
-  {{- include "nr-ebpf-agent.validateVersion" (dict "tag" $imageTag "chartVersion" .Chart.Version "appVersion" .Chart.AppVersion) -}}
-{{- end -}}
-{{- $imageTag -}}
-{{- end -}}
-
-{{/*
-Validate agent version compatibility at template rendering time
-For chart version >= 1.0.0, ensure agent version >= 1.0.0
-Extracts version from image tag and compares using semver
-*/}}
-{{- define "nr-ebpf-agent.validateVersion" -}}
-{{- $tag := .tag -}}
-{{- $chartVersion := .chartVersion -}}
-{{- $appVersion := .appVersion -}}
-{{- $minVersion := "1.0.0" -}}
-{{- $agentVersion := "" -}}
-
-{{- /* Try to extract semantic version from tag */ -}}
-{{- if regexMatch "^v?[0-9]+\\.[0-9]+\\.[0-9]+" $tag -}}
-  {{- /* Extract X.Y.Z from patterns like "0.5.0", "v0.5.0", "0.5.0-beta", etc */ -}}
-  {{- $agentVersion = regexFind "^v?([0-9]+\\.[0-9]+\\.[0-9]+)" $tag | trimPrefix "v" -}}
-{{- else if eq $tag $appVersion -}}
-  {{- /* If tag equals appVersion, use appVersion directly */ -}}
-  {{- $agentVersion = $appVersion -}}
-{{- else -}}
-  {{- /* Cannot parse version from custom tag - fail with helpful message */ -}}
-  {{- fail (printf "\nError: Chart version %s requires agent version >= %s.\n\nCannot determine agent version from image tag '%s'.\n\nRESOLUTION:\n  1. Use a semantic version tag (e.g., '1.0.0', '0.7.0')\n  2. Remove the image tag to use Chart.AppVersion (%s)\n\nFor more information:\n  https://github.com/newrelic/helm-charts/tree/master/charts/nr-ebpf-agent\n" $chartVersion $minVersion $tag $appVersion) -}}
-{{- end -}}
-
-{{- /* Validate extracted version is >= minimum required version */ -}}
-{{- if not (semverCompare (printf ">=%s" $minVersion) $agentVersion) -}}
-  {{- fail (printf "\n================================================================================\nERROR: INCOMPATIBLE AGENT VERSION\n================================================================================\n\nChart Version:    %s\nAgent Version:    %s (from tag: %s)\nRequired Version: >= %s\n\nChart version %s removed OpenTelemetry collector support and requires\nagent version >= %s.\n\nRESOLUTION:\n  1. Update ebpfAgent.image.tag to version >= %s\n     OR\n  2. Remove custom image tag to use Chart.AppVersion (%s)\n\nFor more information:\n  https://github.com/newrelic/helm-charts/tree/master/charts/nr-ebpf-agent\n\n================================================================================\n" $chartVersion $agentVersion $tag $minVersion $chartVersion $minVersion $minVersion $appVersion) -}}
 {{- end -}}
 {{- end -}}
 
@@ -145,16 +109,6 @@ Validate the user inputted value when sampling by error rate.
 {{- end -}}
 
 {{/*
-Validate that receiverPort is not less than 1024 (privileged port range).
-*/}}
-{{- define "validate.receiverPort" -}}
-{{- $port := .Values.otelCollector.receiverPort | int -}}
-{{- if lt $port 1025 -}}
-{{- fail (printf "Error: receiverPort must be > 1024 (got %d). Ports below 1024 are privileged ports and should not be used." $port) -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Pass environment variables to the agent container if tracing a specific protocol is to be disabled.
 */}}
 {{- define "generateTracingEnvVars" -}}
@@ -171,28 +125,118 @@ Pass environment variables to the agent container if tracing a specific protocol
 {{- end -}}
 
 {{/*
-Generate environment variables for protocols configuration including enabled/disabled state and sampling latency.
+Returns the full image reference for kernel header installer, respecting global.images.registry
+*/}}
+{{- define "nr-ebpf-agent.kernelHeaderInstaller.image" -}}
+{{- $globalRegistry := .Values.global.images.registry | default "" -}}
+{{- $repository := .Values.ebpfAgent.kernelHeaderInstaller.repository | default "newrelic/newrelic-ebpf-agent" -}}
+{{- $tag := .Values.ebpfAgent.kernelHeaderInstaller.tag | default "agent-base-image-latest" -}}
+{{- if $globalRegistry -}}
+  {{- printf "%s/%s:%s" $globalRegistry $repository $tag -}}
+{{- else -}}
+  {{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns the pull policy for kernel header installer, respecting global.images.pullPolicy
+*/}}
+{{- define "nr-ebpf-agent.kernelHeaderInstaller.imagePullPolicy" -}}
+{{- $globalPullPolicy := .Values.global.images.pullPolicy | default "" -}}
+{{- $chartPullPolicy := .Values.ebpfAgent.kernelHeaderInstaller.pullPolicy | default "" -}}
+{{- if $globalPullPolicy -}}
+  {{- $globalPullPolicy -}}
+{{- else if $chartPullPolicy -}}
+  {{- $chartPullPolicy -}}
+{{- else -}}
+  IfNotPresent
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns the full image reference for eBPF agent, respecting global.images.registry
+*/}}
+{{- define "nr-ebpf-agent.ebpfAgent.image" -}}
+{{- $globalRegistry := .Values.global.images.registry | default "" -}}
+{{- $repository := .Values.ebpfAgent.image.repository | default "newrelic/newrelic-ebpf-agent" -}}
+{{- $tag := include "nr-ebpf-agent.imageTag" . -}}
+{{- if $globalRegistry -}}
+  {{- printf "%s/%s:%s" $globalRegistry $repository $tag -}}
+{{- else -}}
+  {{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns the pull policy for eBPF agent, respecting global.images.pullPolicy
+*/}}
+{{- define "nr-ebpf-agent.ebpfAgent.imagePullPolicy" -}}
+{{- $globalPullPolicy := .Values.global.images.pullPolicy | default "" -}}
+{{- $chartPullPolicy := .Values.ebpfAgent.image.pullPolicy | default "" -}}
+{{- if $globalPullPolicy -}}
+  {{- $globalPullPolicy -}}
+{{- else if $chartPullPolicy -}}
+  {{- $chartPullPolicy -}}
+{{- else -}}
+  IfNotPresent
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns the full image reference for OTel collector, respecting global.images.registry
+*/}}
+{{- define "nr-ebpf-agent.otelCollector.image" -}}
+{{- $globalRegistry := .Values.global.images.registry | default "" -}}
+{{- $repository := .Values.otelCollector.image.repository | default "newrelic/newrelic-ebpf-agent" -}}
+{{- $tag := .Values.otelCollector.image.tag | default "" -}}
+{{- if $globalRegistry -}}
+  {{- printf "%s/%s:%s" $globalRegistry $repository $tag -}}
+{{- else -}}
+  {{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns the pull policy for OTel collector, respecting global.images.pullPolicy
+*/}}
+{{- define "nr-ebpf-agent.otelCollector.imagePullPolicy" -}}
+{{- $globalPullPolicy := .Values.global.images.pullPolicy | default "" -}}
+{{- $chartPullPolicy := .Values.otelCollector.image.pullPolicy | default "" -}}
+{{- if $globalPullPolicy -}}
+  {{- $globalPullPolicy -}}
+{{- else if $chartPullPolicy -}}
+  {{- $chartPullPolicy -}}
+{{- else -}}
+  IfNotPresent
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate environment variables for disabling protocols and setting sampling latency.
 */}}
 {{- define "generateClientScriptEnvVars" -}}
 {{- if .Values.protocols }}
 {{- range $protocol, $config := .Values.protocols }}
-  {{- if ne $protocol "global" }}
   {{- if (hasKey $config "enabled") }}
+    {{- if eq $config.enabled false }}
 - name: PROTOCOLS_{{ upper $protocol }}_ENABLED
-  value: "{{ $config.enabled }}"
-  {{- end }}
-  {{- if (hasKey $config "spans") }}
-    {{- if (hasKey $config.spans "enabled") }}
+  value: "false"
 - name: PROTOCOLS_{{ upper $protocol }}_SPANS_ENABLED
-  value: "{{ $config.spans.enabled }}"
-    {{- end }}
-    {{- if and (eq $config.spans.enabled true) (hasKey $config.spans "samplingLatency") }}
+  value: "false"
+    {{- else if eq $config.enabled true }}
+      {{- if (hasKey $config "spans") }}
+        {{- if (eq $config.spans.enabled false) }}
+- name: PROTOCOLS_{{ upper $protocol }}_SPANS_ENABLED
+  value: "false"
+        {{- end }}  
+      {{- if (eq $config.spans.enabled true) }}
       {{- include "validate.samplingLatency" (dict "protocol" $protocol "latency" $config.spans.samplingLatency) }}
 - name: PROTOCOLS_{{ upper $protocol }}_SPANS_SAMPLING_LATENCY
   value: "{{ $config.spans.samplingLatency | regexMatch "p1|p10|p50|p90|p99" | ternary $config.spans.samplingLatency "" }}"
+      {{- end }}
     {{- end }}
-  {{- end }}
-  {{- end }}
+  {{- end }} 
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/nr-ebpf-agent/templates/nr-ebpf-agent-daemonset.yaml
+++ b/charts/nr-ebpf-agent/templates/nr-ebpf-agent-daemonset.yaml
@@ -1,10 +1,8 @@
 ---
-{{- $region := include "newrelic.common.region" . }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: nr-ebpf-agent
-  namespace: {{ .Release.Namespace }}
   labels:
     app: nr-ebpf-agent
     component: agent
@@ -42,30 +40,48 @@ spec:
       {{- end }}
       initContainers:
       - name: kernel-header-installer
-        image: {{ .Values.ebpfAgent.image.repository }}:agent-base-image-latest
-        imagePullPolicy: {{ .Values.ebpfAgent.image.pullPolicy }}
-        command: ["/scripts/install-headers.sh"]
+        image: {{ include "nr-ebpf-agent.kernelHeaderInstaller.image" . }}
+        imagePullPolicy: {{ include "nr-ebpf-agent.kernelHeaderInstaller.imagePullPolicy" . }}
+        command:
+          - "/bin/bash"
+          - "-c"
+          - |
+            # Detect OS and install kernel headers accordingly
+            if [ -f /host/etc/os-release ]; then
+              . /host/etc/os-release
+              if [[ $ID == 'amzn' || $ID == 'centos' || $ID == 'rhel' ]]; then
+                echo 'Detected EKS/Amazon Linux or CentOS/RHEL. Installing kernel-devel...'
+                chroot /host /bin/bash -c "yum install -y kernel-devel-$(uname -r)" || echo 'kernel-devel install failed, proceeding.'
+              elif [[ $ID == 'debian' || $ID == 'ubuntu' ]]; then
+                echo 'Detected Debian/Ubuntu. Installing linux-headers...'
+                chroot /host /bin/bash -c "apt-get update || true && apt-get install -y linux-headers-$(uname -r)" || echo 'linux-headers install failed, proceeding.'
+              else
+                echo "Unsupported OS: $ID"
+                echo "Proceeding without kernel header install."
+              fi
+            else
+              echo "/host/etc/os-release not found"
+              echo "Proceeding without kernel header install."
+            fi
         securityContext:
           privileged: true
         volumeMounts:
-        - name: installer-script
-          mountPath: /scripts
-          readOnly: true
         - name: host-root-volume
           mountPath: /host
-        - name: kernel-headers-volume
-          mountPath: /kernel-headers
 
       containers:
       - name: nr-ebpf-agent
-        image: {{ .Values.ebpfAgent.image.repository }}:{{ include "nr-ebpf-agent.imageTag" . }}
-        imagePullPolicy: {{ .Values.ebpfAgent.image.pullPolicy }}
+        image: {{ include "nr-ebpf-agent.ebpfAgent.image" . }}
+        imagePullPolicy: {{ include "nr-ebpf-agent.ebpfAgent.imagePullPolicy" . }}
         resources: {{ .Values.ebpfAgent.resources | toYaml | nindent 10 }}
         env:
+          - name: VIZIER_PORT
+            value: "{{ .Values.ebpfAgent.vizierPort | default "12345" }}"
           - name: PL_HOST_PATH
             value: "/host"
           - name: PL_STIRLING_SOURCES
             value: "{{ .Values.stirlingSources | default "socket_tracer,tcp_stats" }}"
+          {{- include "generateTracingEnvVars" . | indent 10 }}
           - name: KUBERNETES_CLUSTER_DOMAIN
             value: "cluster.local"
           - name: NEW_RELIC_LOG_LEVEL
@@ -84,6 +100,18 @@ spec:
                 {{- end }}
           - name: TABLE_STORE_DATA_LIMIT_MB
             value: "{{ .Values.tableStoreDataLimitMB }}"
+          - name: TLS_ENABLED
+          {{- if (hasKey .Values "tls") }}
+          {{- if eq .Values.tls.enabled true }}
+            value: "true"
+          {{- else }}
+            value: "false"
+          {{- end }}
+          {{- if eq .Values.tls.enabled true }}
+          - name: TLS_CERT_PATH
+            value: "{{ .Values.tls.certPath }}/"
+          {{- end }}
+          {{- end }}
 
           {{- if .Values.ebpfAgent.downloadedPackagedHeadersPath }}
           - name: DOWNLOADED_PACKAGED_HEADERS_PATH
@@ -95,26 +123,14 @@ spec:
             value: "{{ .Values.ebpfAgent.distroKernelHeadersPath }}"
           {{- end }}
           - name: DEPLOYMENT_NAME
-            value: {{ if .Values.global }}{{ .Values.global.cluster | default .Values.cluster }}{{ else }}{{ .Values.cluster }}{{ end }}
+            value: {{ .Values.cluster }}
           - name: HOST_IP
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
           - name: OTLP_ENDPOINT
-        {{- if eq $region "Staging" }}
-            value: "staging-otlp.nr-data.net:443"
-        {{- else if eq $region "EU" }}
-            value: "otlp.eu01.nr-data.net:443"
-        {{- else }}
-            value: "otlp.nr-data.net:443"
-        {{- end }}
+            value: {{ include "nr-otel-collector-receiver.endpoint" .}}
           {{- include "generateClientScriptEnvVars" . | nindent 10 }}
-          {{- if .Values.protocols.global }}
-          {{- if (hasKey .Values.protocols.global "max_unlinked_spans") }}
-          - name: PROTOCOLS_SPANS_UNLINKED_MAX
-            value: "{{ .Values.protocols.global.max_unlinked_spans }}"
-          {{- end }}
-          {{- end }}
           {{- if (hasKey .Values.protocols.http "spans") }}
           {{- if .Values.protocols.http.spans.samplingErrorRate}}
           {{- include "validate.samplingErrorRate" (dict "protocol" "http" "errorRate" .Values.protocols.http.spans.samplingErrorRate) }}
@@ -126,66 +142,8 @@ spec:
             value: {{ .Release.Namespace }}
           - name: AGENT_SERVICE_NAME
             value: {{ include "nr-ebpf-agent.service.name" . }}
-          - name: APM_DATA_REPORTING
-            value: "{{ if hasKey .Values "apmDataReporting" }}{{ .Values.apmDataReporting }}{{ else }}true{{ end }}"
-          - name: NETWORK_METRICS_REPORTING
-            value: "{{ if hasKey .Values "networkMetricsReporting" }}{{ .Values.networkMetricsReporting }}{{ else if hasKey .Values "tcpStatsReporting" }}{{ .Values.tcpStatsReporting }}{{ else }}true{{ end }}"  
-          # ALL Data filtering configuration
-          {{- if .Values.allDataFilters }}
-          - name: DROP_ALL_DATA_FOR_NEW_RELIC
-            value: "{{ if hasKey .Values.allDataFilters "dropNewRelicBundle" }}{{ .Values.allDataFilters.dropNewRelicBundle }}{{ else }}true{{ end }}"
-          - name: DROP_ALL_DATA_FOR_NAMESPACES
-            value: "{{ .Values.allDataFilters.dropNamespaces | join "," }}"
-          - name: DROP_ALL_DATA_FOR_SERVICE_NAME_REGEX
-            value: {{ .Values.allDataFilters.dropServiceNameRegex }}
-          - name: KEEP_ALL_DATA_FOR_SERVICE_NAME_REGEX
-            value: {{ .Values.allDataFilters.keepServiceNameRegex }}
-          - name: DROP_ALL_DATA_FOR_APM_AGENT_ENABLED_ENTITY
-            value: "{{ if hasKey .Values.allDataFilters "dropApmAgentEnabledEntity" }}{{ .Values.allDataFilters.dropApmAgentEnabledEntity }}{{ else }}false{{ end }}"
-          {{- end }}
-          
-          # APM data filtering configuration
-          {{- if .Values.apmDataFilters }}
-          - name: DROP_APM_DATA_FOR_APM_AGENT_ENABLED_ENTITY
-            value: "{{ if hasKey .Values.apmDataFilters "dropEapmForApmEnabledEntity" }}{{ .Values.apmDataFilters.dropEapmForApmEnabledEntity }}{{ else if hasKey .Values.apmDataFilters "apmAgentEnabledEntity" }}{{ .Values.apmDataFilters.apmAgentEnabledEntity }}{{ else }}true{{ end }}"
-          {{- if .Values.apmDataFilters.dropPodLabels }}
-          - name: DROP_APM_DATA_FOR_POD_LABELS
-            value: "{{ range $key, $value := .Values.apmDataFilters.dropPodLabels }}{{ $key }}={{ $value }},{{ end }}"
-          {{- end }}
-          - name: DROP_APM_DATA_FOR_ENTITY_NAME
-            value: "{{ .Values.apmDataFilters.dropEntityName | join "," }}"
-          - name: KEEP_APM_DATA_FOR_ENTITY_NAME
-            value: "{{ .Values.apmDataFilters.keepEntityName | join "," }}"
-          {{- end }}
-
-          # Network metrics data filtering configuration
-          {{- if .Values.networkMetricsDataFilter }}
-          {{- if .Values.networkMetricsDataFilter.dropPodLabels }}
-          - name: DROP_NETWORK_METRICS_DATA_FOR_POD_LABELS
-            value: "{{ range $key, $value := .Values.networkMetricsDataFilter.dropPodLabels }}{{ $key }}={{ $value }},{{ end }}"
-          {{- end }}
-          - name: DROP_NETWORK_METRICS_DATA_FOR_ENTITY_NAME
-            value: "{{ .Values.networkMetricsDataFilter.dropEntityName | join "," }}"
-          - name: KEEP_NETWORK_METRICS_DATA_FOR_ENTITY_NAME
-            value: "{{ .Values.networkMetricsDataFilter.keepEntityName | join "," }}"
-          {{- end }}
-
-          # DEPRECATED: The following environment variables are deprecated and kept for backward compatibility.
-          # If you are using an older configuration file with a newer Helm chart version, these settings will still work.
-          # However, please update your configuration to use the new filtering mechanisms.
-          # These variables will be removed in a future release.
-          - name: TCP_STATS_REPORTING
-            value: "{{ if hasKey .Values "networkMetricsReporting" }}{{ .Values.networkMetricsReporting }}{{ else if hasKey .Values "tcpStatsReporting" }}{{ .Values.tcpStatsReporting }}{{ else }}true{{ end }}"
-          - name: DROP_DATA_NEW_RELIC
-            value: "{{ if hasKey .Values "dropDataNewRelic" }}{{ .Values.dropDataNewRelic }}{{ else }}true{{ end }}"
-          - name: DROP_APM_ENABLED_PODS
-            value: "{{ if hasKey .Values "dropAPMEnabledPods" }}{{ .Values.dropAPMEnabledPods }}{{ else }}false{{ end }}"
-          - name: DROP_DATA_FOR_NAMESPACES
-            value: "{{ .Values.dropDataForNamespaces | join "," }}"
-          - name: DROP_SERVICE_NAME_REGEX
-            value: {{ .Values.dropDataServiceNameRegex }}
-          - name: ALLOW_SERVICE_NAME_REGEX
-            value: {{ .Values.allowServiceNameRegex }}
+          - name: IS_INSECURE
+            value: "True"
         securityContext:
           privileged: true
         volumeMounts:
@@ -195,19 +153,18 @@ spec:
           - name: sys-volume
             mountPath: /sys
             readOnly: true
-          - name: kernel-headers-volume
-            mountPath: /kernel-headers
+          {{- if (hasKey .Values "tls") }}
+          {{- if eq .Values.tls.enabled true }}
+          - name: cert
+            mountPath: "{{ .Values.tls.certPath }}/"
             readOnly: true
+          {{- end }}
+          {{- end }}
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: true
       restartPolicy: Always
-      serviceAccountName: {{ include "nr-ebpf-agent.service.name" . }}
       volumes:
-      - name: installer-script
-        configMap:
-          name: {{ include "nr-ebpf-agent.fullname" . }}-installer-script
-          defaultMode: 0755
       - name: host-root-volume
         hostPath:
           path: /
@@ -216,8 +173,14 @@ spec:
         hostPath:
           path: /sys
           type: Directory
-      - name: kernel-headers-volume
-        emptyDir: {}
+      {{- if (hasKey .Values "tls") }}
+      {{- if eq .Values.tls.enabled true }}
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: {{ include "nr-ebpf-agent-certificates.certificateSecret.name" . }}
+      {{- end }}
+      {{- end }}
       {{- with include "newrelic.common.nodeSelector" . }}
       nodeSelector:
         {{- . | nindent 8 -}}

--- a/charts/nr-ebpf-agent/values.yaml
+++ b/charts/nr-ebpf-agent/values.yaml
@@ -9,64 +9,36 @@ customSecretName: ""
 customSecretLicenseKey: ""
 # -- If using a customSecretLicenseKey, you must supply your region "US"/"EU". Otherwise, leave this value as an empty string.
 region: ""
+# -- Configures the agent to send all data through the proxy specified via the otel collector.
+proxy: ""
 # -- To configure the log level in increasing order of verboseness.
 # -- OFF, FATAL, ERROR, WARNING, INFO, DEBUG
 logLevel: "INFO"
 # -- To configure log file path of eBPF Agent. If logging to this path fails, logs will be directed to stdout.
 logFilePath: ""
+# -- Drop data when service names map to an IP address.
+dropDataIpServiceNames: true
+# -- Drop data from the newrelic namespace and newrelic-bundle services.
+dropDataNewRelic: true
+# -- Drop data from pods that are monitored by New Relic APM via auto attach.
+dropAPMEnabledPods: false
+# -- List of Kubernetes namespaces for which all data should be dropped by the agent.
+dropDataForNamespaces: ["kube-system"]
+# -- Define a regex to match service names to drop. Example "kube-dns|otel-collector|\\bblah\\b"
+# see Golang Docs for Regex syntax https://github.com/google/re2/wiki/Syntax
+dropDataServiceNameRegex: ""
+# -- This config acts as a bypass for the dropDataServiceNameRegex config.
+# Service names that match this regex will not have their data dropped by the dropDataServiceNameRegex.
+# If dropDataServiceNameRegex is not defined, this config has no impact on the eBPF agent.
+allowServiceNameRegex: ""
+# -- list entity to ignore the process monitoring based on NEW_RELIC_APP_NAME
+dropDataForEntity: []
 # -- The primary lever to control RAM use of the eBPF agent. Specified in MiB.
 tableStoreDataLimitMB: "250"
-# -- Enable APM data reporting. When enabled, the agent collects and reports application performance monitoring data
-apmDataReporting: true
-# -- Enable network metrics reporting. When enabled, the agent collects and reports network metrics including TCP statistics
-# RENAMED from 'tcpStatsReporting' for clarity. The old name is deprecated but still supported for backward compatibility.
-networkMetricsReporting: true
-
-# -- All data drop filters configuration
-# Configure filters to drop all types of data (Network Metrics and APM data) based on config provided
-allDataFilters:
-  # -- Drop data from the newrelic namespace and newrelic-bundle services.
-  # RENAMED from 'dropDataNewRelic' for clarity. The old name is deprecated but still supported for backward compatibility.
-  dropNewRelicBundle: true
-  # -- List of Kubernetes namespaces for which all data should be dropped by the agent.
-  # RENAMED from 'dropDataForNamespaces' for clarity. The old name is deprecated but still supported for backward compatibility.
-  dropNamespaces: ["kube-system"]
-  # -- Define a regex to match k8s service names to drop. Example "kube-dns|otel-collector|\\bblah\\b"
-  # RENAMED from 'dropServiceNameRegex' for clarity. The old name is deprecated but still supported for backward compatibility.
-  dropServiceNameRegex: ""
-  # -- This config acts as a bypass for the dropServiceNameRegex config.
-  # Service names that match this regex will not have their data dropped by the dropServiceNameRegex.
-  # RENAMED from 'allowServiceNameRegex' for clarity. The old name is deprecated but still supported for backward compatibility.
-  keepServiceNameRegex: ""
-  # -- Drop all data for applications/entities that have NewRelic/OTEL APM agents running
-  dropApmAgentEnabledEntity: false
-
-# -- APM data filters configuration
-# Configure filters to drop ebpf APM data based on config provided
-apmDataFilters:
-  # -- Drop eBPF APM data for applications/entities that have NewRelic APM/OTel agents running
-  dropEapmForApmEnabledEntity: true
-  # -- Pod labels to match for filtering APM data. Empty map means no label-based filtering
-  # Example: dropPodLabels: { "app": "frontend", "env": "production" }
-  dropPodLabels: {}
-  # -- List of entity names to drop ebpf APM data for
-  dropEntityName: []
-  # -- List of entity names to always keep APM data. By default all entities are kept/enabled
-  # -- This config bypasses dropEntityName filter.
-  keepEntityName: []
-
-# -- Network metrics Data filter / TCP stats filters
-# Configure filters to drop/keep Network metrics data based on config provided
-networkMetricsDataFilter:
-  # -- Pod labels to match for filtering Network metrics data. Empty map means no label-based filtering
-  # Example: dropPodLabels: { "app": "frontend", "env": "production" }
-  dropPodLabels: {}
-  # -- List of entity names to drop Network metrics data for
-  dropEntityName: []
-  # -- List of entity names to always keep Network metrics data. By default all entities are kept/enabled
-  # -- This config bypasses dropEntityName filter.
-  keepEntityName: []
-
+# -- The source connectors (and data export scripts) to enable.
+# Note that socket_tracer tracks http, mysql, redis, mongodb, amqp, cassandra, dns, and postgresql
+# while tcp_stats tracks TCP metrics.
+# stirlingSources: "socket_tracer,tcp_stats"
 
 # The protocols to enable for tracing in the socket_tracer. There is an ability to configure span export if it is enabled.
 # Each protocol has the flexibility to selectively enable the type of OTLP data to export.
@@ -74,9 +46,6 @@ networkMetricsDataFilter:
 # samplingLatency represents the sampling latency threshold for the spans to export.
 # Options: p1, p10, p50, p90, p99.
 protocols:
-  global:
-    # Controls maximum unlinked spans reported per protocol. Set to 0 to disable limit
-    max_unlinked_spans: "100"
   http:
     enabled: true
     spans:
@@ -89,62 +58,58 @@ protocols:
     enabled: true
     spans:
       enabled: true
-      samplingLatency: "p50"
+      samplingLatency: ""
   pgsql:
     enabled: true
     spans:
       enabled: true
-      samplingLatency: "p50"
+      samplingLatency: ""
   cass:
     enabled: true
     spans:
       enabled: true
-      samplingLatency: "p50"
+      samplingLatency: ""
   redis:
     enabled: true
     spans:
       enabled: true
-      samplingLatency: "p50"
+      samplingLatency: ""
   mongodb:
     enabled: true
     spans:
       enabled: true
-      samplingLatency: "p50"
+      samplingLatency: ""
   kafka:
     enabled: true
     spans:
       enabled: true
-      samplingLatency: "p50"
+      samplingLatency: ""
   amqp:
     enabled: true
     spans:
       enabled: true
-      samplingLatency: "p50"
+      samplingLatency: ""
   dns:
     enabled: true
     spans:
       enabled: true
-      samplingLatency: "p50"
-  dynamodb:
-    enabled: true
-    spans:
-      enabled: true
-      samplingLatency: "p50"
-  mssql:
-    enabled: true
-    spans:
-      enabled: true
-      samplingLatency: "p50"
+      samplingLatency: ""
+
 
 # Configuration to apply on the eBPF agent daemonset.
 ebpfAgent:
   image:
-    # -- eBPF agent image to be deployed.
-    repository: docker.io/newrelic/newrelic-ebpf-agent
+    # -- eBPF agent image to be deployed. Defaults to newrelic/newrelic-ebpf-agent. If global.images.registry is set, it will be used instead.
+    repository: newrelic/newrelic-ebpf-agent
     # -- The pull policy is defaulted to IfNotPresent, which skips pulling an image if it already exists. If pullPolicy is defined without a specific value, it is also set to Always.
     pullPolicy: IfNotPresent
-    # -- The tag of the eBPF agent image to be deployed. If empty, uses Chart.AppVersion.
+    # -- The tag of the eBPF agent image to be deployed.
     tag: ""
+  # -- Image for the kernel header installer init container. Defaults to newrelic/newrelic-ebpf-agent:agent-base-image-latest. If global.images.registry is set, it will be used instead.
+  kernelHeaderInstaller:
+    repository: newrelic/newrelic-ebpf-agent
+    tag: agent-base-image-latest
+    pullPolicy: IfNotPresent
   resources:
     limits:
       # -- Max memory allocated to the container.
@@ -154,8 +119,6 @@ ebpfAgent:
       cpu: 100m
       # -- Min memory allocated to the container.
       memory: 250Mi
-  serviceAccount:
-    annotations: {}
   # -- Sets ebpfAgent pod tolerations. Overrides `tolerations` and `global.tolerations`
   tolerations: []
   # -- Sets ebpfAgent pod affinities. Overrides `affinity` and `global.affinity`
@@ -166,6 +129,8 @@ ebpfAgent:
   podSecurityContext: {}
   # -- Sets ebpfAgent pod containerSecurityContext. Overrides `containerSecurityContext` and `global.securityContext.container`
   containerSecurityContext: {}
+  # Vizier server port on which agent receives pxl scripts from the client. Default to 12345
+  vizierPort: ""
   # Sets the absolute path of the complete directory where the required linux headers are manually downloaded and placed for the eBPF agent to use.
   # This is useful under restricted environments where agent is not able to download required linux headers. The required headers are identified by the agent based on the kernel version.
   # The absolute path in case of K8s should also be prepended with /host when necessary.
@@ -175,6 +140,41 @@ ebpfAgent:
   # This is useful where required linux headers could not be installed or path could not be determined. The absolute path in case of K8s should also be prepended with /host when necessary.
   # ---- USE ONLY AFTER NEW RELIC SUPPORT RECOMMENDATION. ----
   distroKernelHeadersPath: ""
+
+# Configuration to apply on the OpenTelemetry collector daemonset.
+otelCollector:
+  image:
+    # -- OpenTelemetry collector image to be deployed. Defaults to newrelic/newrelic-ebpf-agent. If global.images.registry is set, it will be used instead.
+    repository: newrelic/newrelic-ebpf-agent
+    # -- The pull policy is defaulted to IfNotPresent, which skips pulling an image if it already exists. If pullPolicy is defined without a specific value, it is set to Always.
+    pullPolicy: IfNotPresent
+    # -- The tag of the OpenTelemetry collector image to be deployed.
+    tag: ""
+  resources:
+    limits:
+      # -- Max CPU allocated to the container.
+      cpu: 200m
+      # -- Max memory allocated to the container.
+      memory: 500Mi
+    requests:
+      # -- Min CPU allocated to the container.
+      cpu: 100m
+      # -- Min memory allocated to the container.
+      memory: 200Mi
+  # -- Sets otelCollector pod tolerations. Overrides `tolerations` and `global.tolerations`
+  tolerations: []
+  # -- Sets otelCollector pod affinities. Overrides `affinity` and `global.affinity`
+  affinity: {}
+  # -- Sets otelCollector pod Annotations. Overrides `podAnnotations` and `global.podAnnotations`
+  podAnnotations: {}
+  # -- Sets otelCollector pod podSecurityContext. Overrides `podSecurityContext` and `global.securityContext.pod`
+  podSecurityContext: {}
+  # -- Sets otelCollector pod containerSecurityContext. Overrides `containerSecurityContext` and `global.securityContext.container`
+  containerSecurityContext: {}
+  collector:
+    serviceAccount:
+      # -- Annotations for the OTel collector service account.
+      annotations: {}
 
 # -- The secrets that are needed to pull images from a custom registry.
 pullSecrets: []
@@ -198,3 +198,33 @@ podSecurityContext: {}
 containerSecurityContext: {}
 # --  Kubernetes cluster domain.
 kubernetesClusterDomain: cluster.local
+# -- (bool) Sets the debug logs to this integration or all integrations if it is set globally. Can be configured also with `global.verboseLog`
+# @default -- `false`
+verboseLog:
+# tls makes sure only requests with correctly formatted rules will get into the operator.
+tls:
+  # -- Enable TLS communication between the eBPF client and agent.
+  enabled: true
+  # TLS Certificate Option 1: Use Helm to automatically generate a self-signed certificate.
+  # autoGenerateCert must be enabled.
+  autoGenerateCert:
+    # -- If true, Helm will automatically create a self-signed cert and secret for you.
+    enabled: true
+    # -- If set to true, a new key/certificate is generated on helm upgrade.
+    recreate: true
+    # -- Cert validity period time in days.
+    certPeriodDays: 365
+    # -- Certificates path.
+  certPath: "/etc/newrelic-ebpf-agent/certs/"
+
+  # TLS Certificate Option 2: Use your own self-signed certificate.
+  # autoGenerateCert must be disabled, and certFile, keyFile, and caFile must be set.
+  # The chart reads the contents of the file paths with the helm. Files.Get function.
+  # Refer to this doc https://helm.sh/docs/chart_template_guide/accessing_files/ to understand
+  # limitations of file paths accessible to the chart.
+  # -- Path to your own PEM-encoded certificate.
+  certFile: ""
+  # -- Path to your own PEM-encoded private key.
+  keyFile: ""
+  # -- Path to the CA cert.
+  caFile: ""


### PR DESCRIPTION
## Summary

Add support for cascading registry, pullSecrets, and pullPolicy from global settings to nr-ebpf-agent.

### Phase 1: Global.Images.Registry Support ✅
- Updated values.yaml with clarifying comments for all 3 images
- Added kernelHeaderInstaller configuration (previously hardcoded)
- Added helpers to _helpers.tpl for all 3 images
- Updated both daemonset templates to use new image helpers

### Phase 2: Global.Images.PullSecrets Support ✅
- Updated both daemonsets (nr-ebpf-agent-daemonset.yaml, otel-collector-daemonset.yaml)
- Both use common library renderPullSecrets helper with concat
- Global and chart-level pullSecrets are concatenated together

### Phase 3: Global.Images.PullPolicy Support ✅ (NEW)
- Added pullPolicy helpers to _helpers.tpl for all 3 images
- Updated both daemonsets to use pullPolicy helpers
- Configuration respects hierarchy: global setting → chart-level setting → default (IfNotPresent)

## Configuration Hierarchy

**For Image Registry:**
1. `global.images.registry` (if set AND repository matches default)
2. Explicit repository configuration (takes precedence)

**For ImagePullSecrets:**
1. `global.images.pullSecrets` (highest priority)
2. Chart-level `pullSecrets`
Both sources are concatenated to support flexible secret management.

**For ImagePullPolicy:**
1. `global.images.pullPolicy` (highest priority)
2. Chart-level image `pullPolicy`
3. Default: `IfNotPresent`

## Implementation Details

**Images covered:**
- Kernel header installer init container
- eBPF agent main container
- OpenTelemetry collector container

- If global.images.registry is set AND repository matches default, uses global registry
- If repository is explicitly set to custom value, that takes precedence
- If global registry is not set, defaults to original docker.io paths
- kernel-header-installer is now configurable (was previously hardcoded)
- PullPolicy hierarchy ensures global settings cascade down when no explicit chart configuration is provided

## Test Plan

**Phase 1 (Registry):**
- ✓ Global registry is used when set: my.private.registry.com/newrelic/newrelic-ebpf-agent
- ✓ Defaults to docker.io when global registry not configured
- ✓ Explicit repository configuration overrides global
- ✓ All 3 images respect the same configuration hierarchy

**Phase 2 (PullSecrets):**
- ✓ No pullSecrets set → No imagePullSecrets section rendered
- ✓ Global pullSecrets only → Uses global across all daemonsets
- ✓ Both global + chart pullSecrets → Uses both (global items first)

**Phase 3 (PullPolicy):**
- ✓ Global pullPolicy is used when set and no chart-level policy exists
- ✓ Defaults to IfNotPresent when neither global nor chart policy is set
- ✓ Explicit chart-level pullPolicy overrides global setting

## Impact

Once merged, users can now configure nr-ebpf-agent with comprehensive global image settings:

\`\`\`yaml
global:
  images:
    registry: "my.private.registry.com"
    pullSecrets:
      - name: my-registry-credentials
    pullPolicy: Always
\`\`\`

**Note:** Rebased from upstream/master. Original PR #2004.