### PR TITLE
eBPF: JVM metrics configuration

### DIFF
--- a/charts/nr-ebpf-agent/Chart.yaml
+++ b/charts/nr-ebpf-agent/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.2.1
 
 dependencies:
   - name: common-library
@@ -23,7 +23,7 @@ dependencies:
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.2.0"
+appVersion: "1.2.1"
 home: https://github.com/newrelic/helm-charts
 sources:
   - https://github.com/newrelic/

--- a/charts/nri-bundle/Chart.lock
+++ b/charts/nri-bundle/Chart.lock
@@ -1,25 +1,25 @@
 dependencies:
 - name: newrelic-infrastructure
   repository: https://newrelic.github.io/nri-kubernetes
-  version: 3.58.0
+  version: 3.58.1
 - name: nri-prometheus
   repository: https://newrelic.github.io/nri-prometheus
   version: 2.1.22
 - name: newrelic-prometheus-agent
   repository: https://newrelic.github.io/newrelic-prometheus-configurator
-  version: 2.6.0
+  version: 2.6.1
 - name: nri-metadata-injection
   repository: https://newrelic.github.io/k8s-metadata-injection
-  version: 4.32.0
+  version: 4.33.0
 - name: newrelic-k8s-metrics-adapter
   repository: https://newrelic.github.io/newrelic-k8s-metrics-adapter
-  version: 1.17.6
+  version: 1.17.7
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 6.1.5
 - name: nri-kube-events
   repository: https://newrelic.github.io/nri-kube-events
-  version: 3.18.0
+  version: 3.18.1
 - name: newrelic-logging
   repository: https://newrelic.github.io/helm-charts
   version: 1.33.1
@@ -28,15 +28,15 @@ dependencies:
   version: 2.1.6
 - name: nr-ebpf-agent
   repository: https://newrelic.github.io/helm-charts
-  version: 1.2.0
+  version: 1.2.1
 - name: k8s-agents-operator
   repository: https://newrelic.github.io/k8s-agents-operator
-  version: 0.37.0
+  version: 0.37.1
 - name: pixie-operator-chart
   repository: https://pixie-operator-charts.storage.googleapis.com
   version: 0.1.7
 - name: newrelic-infra-operator
   repository: https://newrelic.github.io/newrelic-infra-operator
-  version: 2.18.4
-digest: sha256:2ef0d2222bcf7de11685887d2412da7f260ef9d13fc4c5e7c8d0310bdab9ea3c
-generated: "2026-01-20T09:59:26.086356002Z"
+  version: 2.18.5
+digest: sha256:eaaa1ca95198688cd14e5aa433fc640cf659618e1769bdb7988a6209644d979b
+generated: "2026-02-02T15:59:54.351873825Z"

--- a/charts/nri-bundle/Chart.yaml
+++ b/charts/nri-bundle/Chart.yaml
@@ -18,13 +18,13 @@ sources:
   - https://github.com/newrelic/newrelic-infra-operator/tree/master/charts/newrelic-infra-operator
   - https://github.com/newrelic/k8s-agents-operator/tree/master/charts/k8s-agents-operator
 
-version: 6.0.35
+version: 6.0.36
 
 dependencies:
   - name: newrelic-infrastructure
     repository: https://newrelic.github.io/nri-kubernetes
     condition: infrastructure.enabled,newrelic-infrastructure.enabled
-    version: 3.58.0
+    version: 3.58.1
 
   - name: nri-prometheus
     repository: https://newrelic.github.io/nri-prometheus
@@ -34,17 +34,17 @@ dependencies:
   - name: newrelic-prometheus-agent
     repository: https://newrelic.github.io/newrelic-prometheus-configurator
     condition: newrelic-prometheus-agent.enabled
-    version: 2.6.0
+    version: 2.6.1
 
   - name: nri-metadata-injection
     repository: https://newrelic.github.io/k8s-metadata-injection
     condition: webhook.enabled,nri-metadata-injection.enabled
-    version: 4.32.0
+    version: 4.33.0
 
   - name: newrelic-k8s-metrics-adapter
     repository: https://newrelic.github.io/newrelic-k8s-metrics-adapter
     condition: metrics-adapter.enabled,newrelic-k8s-metrics-adapter.enabled
-    version: 1.17.6
+    version: 1.17.7
 
   - name: kube-state-metrics
     version: 6.1.5
@@ -54,7 +54,7 @@ dependencies:
   - name: nri-kube-events
     repository: https://newrelic.github.io/nri-kube-events
     condition: kubeEvents.enabled,nri-kube-events.enabled
-    version: 3.18.0
+    version: 3.18.1
 
   - name: newrelic-logging
     repository: https://newrelic.github.io/helm-charts
@@ -67,14 +67,14 @@ dependencies:
     version: 2.1.6
 
   - name: nr-ebpf-agent
-    version: 1.2.0
+    version: 1.2.1
     condition: newrelic-eapm-agent.enabled,nr-ebpf-agent.enabled
     repository: https://newrelic.github.io/helm-charts
 
   - name: k8s-agents-operator
     repository: https://newrelic.github.io/k8s-agents-operator
     condition: k8s-agents-operator.enabled
-    version: 0.37.0
+    version: 0.37.1
 
   # Keep the version of pixie-operator-chart in sync with the CRD versions for
   # olm_crd.yaml and px.dev_viziers.yaml in
@@ -88,7 +88,7 @@ dependencies:
   - name: newrelic-infra-operator
     repository: https://newrelic.github.io/newrelic-infra-operator
     condition: newrelic-infra-operator.enabled
-    version: 2.18.4
+    version: 2.18.5
 
 maintainers:
   - name: Philip-R-Beckwith


### PR DESCRIPTION
#### Is this a new chart
No
#### What this PR does / why we need it:
- Introduced new env - `JVM_METRICS_REPORTING`
- In K8s - `apmDataFilters.jvmMetricsReporting`

#### Special notes for your reviewer:
When this config is enabled, collects JVM metrics (heap usage, GC stats, thread counts, etc.) for the Java applications.


<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Tell the world about the latest changes in the chart.
<!--END-RELEASE-NOTES-->
