### PR TITLE
chore: bump pipeline-control-gateway version to 2.0.1

### DIFF
--- a/charts/pipeline-control-gateway/Chart.yaml
+++ b/charts/pipeline-control-gateway/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 name: pipeline-control-gateway
 type: application
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - name: common-library
     version: 1.4.0
     repository: https://helm-charts.newrelic.com
-appVersion: "2.0.0"
+appVersion: "2.0.1"
 maintainers:
   - name: pipeline-control
     url: https://github.com/orgs/newrelic/teams/pcon/members

--- a/charts/pipeline-control-gateway/values.yaml
+++ b/charts/pipeline-control-gateway/values.yaml
@@ -22,7 +22,7 @@ image:
   # -- The pull policy is defaulted to IfNotPresent, which skips pulling an image if it already exists. If pullPolicy is defined without a specific value, it is also set to Always.
   pullPolicy: IfNotPresent
   # --  Overrides the image tag whose default is the chart appVersion.
-  tag: "2.0.0"
+  tag: "2.0.1"
 
 # -- Name of the Kubernetes cluster monitored. Mandatory. Can be configured also with `global.cluster`
 cluster: ""


### PR DESCRIPTION
Update pipeline-control-gateway image version from 2.0.0 to 2.0.1

