### PR TITLE
chore: bump pipeline-control-gateway version to 2.0.1

### DIFF
--- a/charts/pipeline-control-gateway/Chart.yaml
+++ b/charts/pipeline-control-gateway/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 name: pipeline-control-gateway
 type: application
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - name: common-library
     version: 1.4.0
     repository: https://helm-charts.newrelic.com
-appVersion: "2.0.0"
+appVersion: "2.0.1"
 maintainers:
   - name: pipeline-control
     url: https://github.com/orgs/newrelic/teams/pcon/members

--- a/charts/pipeline-control-gateway/values.yaml
+++ b/charts/pipeline-control-gateway/values.yaml
@@ -22,7 +22,7 @@ image:
   # -- The pull policy is defaulted to IfNotPresent, which skips pulling an image if it already exists. If pullPolicy is defined without a specific value, it is also set to Always.
   pullPolicy: IfNotPresent
   # --  Overrides the image tag whose default is the chart appVersion.
-  tag: "2.0.0"
+  tag: "2.0.1"
 
 # -- Name of the Kubernetes cluster monitored. Mandatory. Can be configured also with `global.cluster`
 cluster: ""


### PR DESCRIPTION
Update pipeline-control-gateway image version from 2.0.0 to 2.0.1


#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)

# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Tell the world about the latest changes in the chart.
<!--END-RELEASE-NOTES-->
