### PR TITLE
[nr-k8s-otel-collector] make collector observability resource attributes configurable

### DIFF
--- a/charts/nr-k8s-otel-collector/Chart.yaml
+++ b/charts/nr-k8s-otel-collector/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.8
+version: 0.10.9
 
 
 dependencies:

--- a/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
@@ -827,6 +827,11 @@ data:
                     endpoint: {{ include "nrKubernetesOtel.endpoint" . }}
                     headers:
                       api-key: ${env:NR_LICENSE_KEY}
+        resource:
+          k8s.cluster.name: {{ include "newrelic.common.cluster" . }}
+          {{- range $k, $v := .Values.collectorObservability.resource }}
+          {{ $k }}: {{ $v }}
+          {{- end }}
             {{- end }}
       pipelines:
         {{- include "nrKubernetesOtel.daemonset.configMap.extraConfig.pipelines" . | nindent 8 }}

--- a/charts/nr-k8s-otel-collector/templates/deployment-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/deployment-configmap.yaml
@@ -804,6 +804,11 @@ data:
                     endpoint: {{ include "nrKubernetesOtel.endpoint" . }}
                     headers:
                       api-key: ${env:NR_LICENSE_KEY}
+        resource:
+          k8s.cluster.name: {{ include "newrelic.common.cluster" . }}
+          {{- range $k, $v := .Values.collectorObservability.resource }}
+          {{ $k }}: {{ $v }}
+          {{- end }}
             {{- end }}
       pipelines:
         {{- include "nrKubernetesOtel.deployment.configMap.extraConfig.pipelines" . | nindent 8 }}

--- a/charts/nr-k8s-otel-collector/values.yaml
+++ b/charts/nr-k8s-otel-collector/values.yaml
@@ -335,6 +335,15 @@ collectorObservability:
   # -- Specifies the interval at which the collector reports its metrics (in seconds)
   # @default -- `60`
   scrapeIntervalSeconds: 60
+  # -- Additional resource attributes to attach to its internal metrics.
+  # k8s.cluster.name is automatically populated from the cluster value.
+  # Useful for adding attributes such as env to distinguish between environments
+  # in multi-cluster deployments.
+  # Example:
+  # resource:
+  #   env: production
+  # @default -- `{}`
+  resource: {}
 
 # -- (bool) Send only the [metrics required](https://github.com/newrelic/helm-charts/tree/master/charts/nr-k8s-otel-collector/docs/metrics-lowDataMode.md) to light up the NR kubernetes UI
 # @default -- `true`

--- a/charts/nr-k8s-otel-collector/values.yaml
+++ b/charts/nr-k8s-otel-collector/values.yaml
@@ -332,9 +332,9 @@ collectorObservability:
   # -- (bool) Specifies whether the collector reports its own metrics
   # @default -- `false`
   enabled: false
-  # -- Specifies the interval at which the collector reports its metrics (in milliseconds)
-  # @default -- `60000`
-  scrapeIntervalMs: 60000
+  # -- Specifies the interval at which the collector reports its metrics (in seconds)
+  # @default -- `60`
+  scrapeIntervalSeconds: 60
 
 # -- (bool) Send only the [metrics required](https://github.com/newrelic/helm-charts/tree/master/charts/nr-k8s-otel-collector/docs/metrics-lowDataMode.md) to light up the NR kubernetes UI
 # @default -- `true`


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Exposes `service::telemetry::resource` as a configurable Helm value under `collectorObservability.resource`, allowing users to enrich internal `otelcol_*` metrics with custom resource attributes.

Without this, internal collector metrics arrive in New Relic with no cluster or environment context, making it impossible to distinguish which cluster or environment a collector's internal metrics originate from in multi-cluster deployments. The `resource/newrelic` processor correctly enriches pipeline metrics with `k8s.cluster.name`, but `service::telemetry` exports directly via OTLP and bypasses all pipeline processors, so it never receives that enrichment.

This PR adds a `resource` block under `service::telemetry` in both the daemonset and deployment configmaps. `k8s.cluster.name` is automatically populated from the existing `newrelic.common.cluster` helper, following the same pattern already used in the `resource/newrelic` processor. Additional arbitrary attributes can be passed via `collectorObservability.resource` for things like `env`.

This also fixes a minor inconsistency where `values.yaml` documented the scrape interval field as `scrapeIntervalMs` but the configmap template referenced it as `scrapeIntervalSeconds`.
#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
- The `resource` block is placed at `service::telemetry::resource` per the [OTel collector internal telemetry docs](https://opentelemetry.io/docs/collector/internal-telemetry/#configure-resource-attributes), which applies resource attributes across all internal telemetry signals (metrics, logs, and traces)
- The `resource` block is only rendered when `collectorObservability.enabled` is `true`, so there is no impact to users who have not enabled collector observability
- `k8s.cluster.name` is always set automatically and does not need to be specified by the user
- The change is identical in both `daemonset-configmap.yaml` and `deployment-configmap.yaml`
- The `scrapeIntervalMs` → `scrapeIntervalSeconds` rename in `values.yaml` is a documentation fix only — the configmap template already used `scrapeIntervalSeconds` so behavior is unchanged

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Added `collectorObservability.resource` to allow users to enrich internal collector metrics with custom resource attributes. `k8s.cluster.name` is automatically populated from the chart's cluster value, enabling multi-cluster observability out of the box. Additional attributes such as `env` can be passed via `collectorObservability.resource`.
* Fixed a documentation inconsistency where the scrape interval field was referenced as `scrapeIntervalMs` in `values.yaml` but `scrapeIntervalSeconds` in the configmap template.
<!--END-RELEASE-NOTES-->
