### PR TITLE
fix(synthetics-job-manager): Add validation for persistence config wh…

### DIFF
--- a/charts/synthetics-job-manager/Chart.yaml
+++ b/charts/synthetics-job-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: synthetics-job-manager
 description: New Relic Synthetics Containerized Job Manager
 type: application
-version: 3.0.51
+version: 3.0.52
 appVersion: release-511
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:

--- a/charts/synthetics-job-manager/templates/_helpers.tpl
+++ b/charts/synthetics-job-manager/templates/_helpers.tpl
@@ -283,6 +283,20 @@ whether they've provided an existing PV name.
 {{- end -}}
 
 {{/*
+Validate that persistence is configured when volume mounting is required.
+This prevents the confusing "PVC not found" error by failing fast with a clear message.
+*/}}
+{{- define "synthetics-job-manager.validatePersistence" -}}
+{{- $needsMount := or (.Values.global.customNodeModules).customNodeModulesPath (.Values.synthetics.userDefinedVariables).userDefinedPath -}}
+{{- $hasExistingClaim := (.Values.global.persistence).existingClaimName -}}
+{{- $hasExistingVolume := (.Values.global.persistence).existingVolumeName -}}
+{{- $hasPersistence := or $hasExistingClaim $hasExistingVolume -}}
+{{- if and $needsMount (not $hasPersistence) -}}
+{{- fail "Error: When using global.customNodeModules.customNodeModulesPath or synthetics.userDefinedVariables.userDefinedPath, you must configure persistence. Please set either global.persistence.existingClaimName (for an existing PVC) or global.persistence.existingVolumeName (to create a PVC for an existing PV)." -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Calculates the terminationGracePeriodSeconds.
 In order to prevent data-loss the grace period should be configured to be > synthetics job timeout, which is 240s by
 default

--- a/charts/synthetics-job-manager/templates/deployment.yaml
+++ b/charts/synthetics-job-manager/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "synthetics-job-manager.validatePersistence" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Added validatePersistence helper that checks if persistence is properly configured when volume mounting is required. If not, it fails with a clear error message:

  Error: When using global.customNodeModules.customNodeModulesPath or
  synthetics.userDefinedVariables.userDefinedPath, you must configure persistence.
  Please set either global.persistence.existingClaimName (for an existing PVC)
  or global.persistence.existingVolumeName (to create a PVC for an existing PV).