### PR TITLE
[agent-control] Improve release automation [NR-475694]

### DIFF
--- a/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control-deployment/Chart.yaml
@@ -5,7 +5,6 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 type: application
 
 version: 1.6.1
-appVersion: "1.11.0"
 
 dependencies:
   - name: common-library

--- a/charts/agent-control-deployment/values.yaml
+++ b/charts/agent-control-deployment/values.yaml
@@ -19,8 +19,7 @@ subAgentsNamespace: "newrelic"
 image:
   registry:
   repository: newrelic/newrelic-agent-control
-  # @default It defaults to `appVersion` in `Chart.yaml`.
-  tag: ""
+  tag: "1.11.0"
   pullPolicy: IfNotPresent
   # -- The secrets that are needed to pull images from a custom registry.
   pullSecrets: []


### PR DESCRIPTION
This PR goal is to reduce friction on agent control char releases and allow both charts to be released at the same time.

- Moves the AC tag version from appVersion to the values so it get's automatically bumped by renovate
- ~Disable the ct test for the bootstrap, to remove the chart dependency lock. Testing is already performed with the e2e running in the same pr exclusive for agent-control. Current test fails on the upgrade scenario is expected~
- ~Once #2173  a single PR will be open by renovate ( we will still need to bump the bootstrap chart versions) but the rest of versions should be bumped automatically~
- ~A new version of both charts are being released witht this PR.~
