### PR TITLE
[agent-control-deployment] use cli to register system identity [NR-537956]

### DIFF
--- a/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 
 type: application
 
-version: 1.6.5
+version: 1.6.6
 
 dependencies:
   - name: common-library

--- a/charts/agent-control-deployment/README.md
+++ b/charts/agent-control-deployment/README.md
@@ -429,6 +429,24 @@ proxy:
 			<td>Sets pod's tolerations to node taints. Can be configured also with `global.tolerations`</td>
 		</tr>
 		<tr>
+			<td>toolkitImage</td>
+			<td>object</td>
+			<td>See <a href="values.yaml">values.yaml</a></td>
+			<td>The image that contains the necessary tools to setup Agent Control</td>
+		</tr>
+		<tr>
+			<td>toolkitImage.pullSecrets</td>
+			<td>list</td>
+			<td>`[]`</td>
+			<td>The secrets that are needed to pull images from a custom registry.</td>
+		</tr>
+		<tr>
+			<td>toolkitImage.tag</td>
+			<td>string</td>
+			<td>`"1.11.0"`</td>
+			<td>Should be aligned with `image.tag`</td>
+		</tr>
+		<tr>
 			<td>verboseLog</td>
 			<td>bool</td>
 			<td>`false`</td>

--- a/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml
+++ b/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml
@@ -38,8 +38,8 @@ spec:
       serviceAccountName: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.serviceAccount.name" .) "suffix" "auth" ) }}
       containers:
         - name: register-system-identity
-          image: "{{ (.Values.systemIdentity.image).repository }}:{{ (.Values.systemIdentity.image).tag }}"
-          imagePullPolicy: {{ .Values.systemIdentity.image.pullPolicy }}
+          image: {{ include "newrelic.common.images.image" ( dict "imageRoot" .Values.toolkitImage "context" .) }}
+          imagePullPolicy: {{ .Values.toolkitImage.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
           resources:
@@ -57,81 +57,18 @@ spec:
           args:
             - -c
             - |
-              set -euo pipefail
-
-              echo Checking if the secret '{{ include "newrelic-agent-control.auth.secret.name" . }}' is already present in the cluster
-              if kubectl get secret {{ include "newrelic-agent-control.auth.secret.name" . }}; then
-                echo System identity already exists. Exiting gracefully...
-                exit 0
-              fi
-
-              echo "Secret not present, creating a new System Identity..."
-
-              REGION={{ include "newrelic.common.region" . }}
-              echo "Authenticating with New Relic ($REGION)..."
-
-              ACCESS_TOKEN=""
-              if [ -n "$NEW_RELIC_AUTH_TOKEN" ]; then
-                echo "Access token obtained via config"
-                ACCESS_TOKEN=$NEW_RELIC_AUTH_TOKEN
-              else
-                for RETRY in 1 2 3; do
-                  
-                  ACCESS_TOKEN=$(newrelic-auth-cli {{ with .Values.proxy }} {{ with .url }} --proxy-url "{{.}}" {{ end }} {{ with .ca_bundle_dir }} --proxy-ca-dir "{{.}}" {{ end }} {{ with .ca_bundle_file }}  --proxy-ca-file "{{.}}" {{ end }} {{ end }} authenticate --client-id "$NEW_RELIC_AUTH_CLIENT_ID" --client-secret "$NEW_RELIC_AUTH_CLIENT_SECRET" --environment "$REGION" --output-token-format Plain)
-
-                  if [ -n "$ACCESS_TOKEN" ]; then
-                    echo "Access token obtained successfully via client secret"
-                    break
-                  fi
-
-                  if [ -z $ACCESS_TOKEN ]; then
-                    echo "Network error occurred or no HTTP response was received. Retrying ($RETRY/3)..."
-                    sleep 2
-                    continue
-                  fi
-                done
-
-                if [ -z "$ACCESS_TOKEN" ]; then
-                  echo "Error getting system identity auth token"
-                  exit 99
-                fi
-                echo "Authenticated successfully"
-              fi
-
-              echo "Creating System Identity..."
-
-              ORG_ID={{ (.Values.systemIdentity).organizationId }}
-              TEMPORAL_FOLDER=/tmp/gen-folder
-              mkdir $TEMPORAL_FOLDER
-              CLIENT_ID=""
-              DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-              NAME="System Identity for $(hostname) - $DATE"
-              for RETRY in 1 2 3; do
-                OUTPUT=$(newrelic-auth-cli {{ with .Values.proxy }} {{ with .url }} --proxy-url "{{.}}" {{ end }} {{ with .ca_bundle_dir }} --proxy-ca-dir "{{.}}" {{ end }} {{ with .ca_bundle_file }}  --proxy-ca-file "{{.}}" {{ end }} {{ end }} create-identity key --name "$NAME" --organization-id "$ORG_ID" --client-id "$NEW_RELIC_AUTH_CLIENT_ID" --environment "$REGION" --bearer-access-token "$ACCESS_TOKEN" --output-platform "local-file" --output-local-filepath "$TEMPORAL_FOLDER/key")
-                CLIENT_ID=$(echo "$OUTPUT" | jq -r '.client_id // empty')
-
-                if [ -n "$CLIENT_ID" ]; then
-                  echo "System identity created successfully"
-                  break
-                fi
-                if [ -z "$CLIENT_ID" ]; then
-                  echo "Network error occurred or no HTTP response was received. Retrying ($RETRY/3)..."
-                  sleep 2
-                  continue
-                fi
-              done
-              if [ -z "$CLIENT_ID" ]; then
-                echo "Error creating system identity"
-                exit 99
-              fi
-
-              echo Creating the secret '{{ include "newrelic-agent-control.auth.secret.name" . }}'...
-              kubectl create secret generic --dry-run=client -o json \
-                {{ include "newrelic-agent-control.auth.secret.name" . }} \
-                --from-literal=CLIENT_ID=$CLIENT_ID \
-                --from-file="private_key=$TEMPORAL_FOLDER/key" | \
-              jq '.metadata.labels += ({{ include "newrelic.common.labels" . | fromYaml | toJson }} + {"app.kubernetes.io/managed-by": "newrelic-agent-control"} + {"newrelic.io/agent-id": "agent-control"} )' | \
-              kubectl apply -n "{{ .Release.Namespace }}" -f -
+              set -eo pipefail
+              # Auth env vars (CLIENT_ID, CLIENT_SECRET, AUTH_TOKEN) are conditionally populated
+              # depending on the auth method configured (clientSecret vs authToken vs fromSecret).
+              # Unset variables are intentionally allowed; the CLI handles empty values.
+              newrelic-agent-control-cli register-system-identity --namespace "{{ .Release.Namespace }}" \
+                  --secret-name "{{ include "newrelic-agent-control.auth.secret.name" . }}" \
+                  --region "{{ include "newrelic.common.region" . }}" \
+                  --auth-parent-client-id "$NEW_RELIC_AUTH_CLIENT_ID" \
+                  --auth-parent-client-secret "$NEW_RELIC_AUTH_CLIENT_SECRET" \
+                  --auth-parent-token "$NEW_RELIC_AUTH_TOKEN" \
+                  --organization-id "{{ .Values.systemIdentity.organizationId }}" \
+                  --log-level "debug" {{ with .Values.proxy }} {{ with .url }} --proxy-url "{{.}}" {{ end }} {{ with .ca_bundle_dir }} --proxy-ca-dir "{{.}}" {{ end }} {{ with .ca_bundle_file }}  --proxy-ca-file "{{.}}" {{ end }} {{ end }}
           volumeMounts:
             {{- with .Values.systemIdentity.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -161,6 +98,8 @@ rules:
       - patch
       - update
       - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/agent-control-deployment/tests/preinstall_job_test.yaml
+++ b/charts/agent-control-deployment/tests/preinstall_job_test.yaml
@@ -132,34 +132,35 @@ tests:
             - secretRef:
                 name: test-client-name
 
-  - it: setting specific image for system identity registration with tag should use the provided tag
+  - it: setting specific image for CLI with tag should use the provided tag
     set:
       systemIdentity:
         parentIdentity:
           fromSecret: test-client-name
         organizationId: test  
-        image:
-          tag: 1.0.0
+      toolkitImage:
+        tag: 0.0.100
     asserts:
       - documentIndex: 0
         equal:
           path: spec.template.spec.containers[0].image
-          value: newrelic/agent-control-system-identity-registration:1.0.0
+          value: docker.io/newrelic/newrelic-agent-control-cli:0.0.100
 
-  - it: setting specific image for system identity registration with tag should use the provided data
+  - it: setting specific image for CLI should be honored
     set:
       systemIdentity:
         parentIdentity:
           fromSecret: test-client-name
         organizationId: test  
-        image:
-          repository: some_namespace/test-image
-          tag: 1.0.0
+      toolkitImage:
+        registry: some-registry
+        repository: some_namespace/test-image
+        tag: 0.0.100
     asserts:
       - documentIndex: 0
         equal:
           path: spec.template.spec.containers[0].image
-          value: some_namespace/test-image:1.0.0
+          value: some-registry/some_namespace/test-image:0.0.100
 
   - it: setting specific pullPolicy for system identity registration image should use the provided data
     set:
@@ -167,8 +168,8 @@ tests:
         parentIdentity:
           fromSecret: test-client-name
         organizationId: test  
-        image:
-          pullPolicy: Always
+      toolkitImage:
+        pullPolicy: Always
     asserts:
       - documentIndex: 0
         equal:

--- a/charts/agent-control-deployment/values.yaml
+++ b/charts/agent-control-deployment/values.yaml
@@ -26,11 +26,11 @@ image:
   # - name: regsecret
 
 # -- The image that contains the necessary tools to setup Agent Control
+# The tag should be aligned with  `image.tag`.
 # @default -- See <a href="values.yaml">values.yaml</a>
 toolkitImage:
   registry:
   repository: newrelic/newrelic-agent-control-cli
-  # -- Should be aligned with `image.tag`
   tag: "1.12.0"
   pullPolicy: IfNotPresent
   # -- The secrets that are needed to pull images from a custom registry.

--- a/charts/agent-control-deployment/values.yaml
+++ b/charts/agent-control-deployment/values.yaml
@@ -25,6 +25,18 @@ image:
   pullSecrets: []
   # - name: regsecret
 
+# -- The image that contains the necessary tools to setup Agent Control
+# @default -- See <a href="values.yaml">values.yaml</a>
+toolkitImage:
+  registry:
+  repository: newrelic/newrelic-agent-control-cli
+  # -- Should be aligned with `image.tag`
+  tag: "1.12.0"
+  pullPolicy: IfNotPresent
+  # -- The secrets that are needed to pull images from a custom registry.
+  pullSecrets: []
+  # - name: regsecret
+
 # -- Add user environment variables to the agent
 extraEnv: []
 # -- Add user environment from configMaps or secrets as variables to the agent
@@ -261,11 +273,6 @@ systemIdentity:
 
   # -- Organization ID used to create the system identity.
   organizationId: ""
-
-  image:
-    repository: newrelic/agent-control-system-identity-registration
-    tag: "0.4.0"
-    pullPolicy: IfNotPresent
 
   # -- Configuration for the parent identity
   # You can either authenticate via ClientId/ClientSecret or pass directly an `AuthToken` and manage locally the authentication.


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This PR simplifies the job to provide the system identity by making use the corresponding CLI tool.

#### Special notes for your reviewer:

A new field in `values.yaml` is set to setup the CLI image.

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Tell the world about the latest changes in the chart.
<!--END-RELEASE-NOTES-->
