### PR TITLE
feat(nr-k8s-otel-collector): add initContainer to fix ATP storage per…

### DIFF
--- a/charts/nr-k8s-otel-collector/templates/daemonset.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset.yaml
@@ -94,6 +94,39 @@ spec:
               mountPath: /temp-config
             - name: final-daemonset-config
               mountPath: /final-config
+        {{- if .Values.enable_atp }}
+        # Fix permissions for ATP persistent storage
+        # ATP needs to write adaptiveprocess.db to /var/lib/nrdot-collector
+        # hostPath volumes are created as root:root, but main container runs as user 1001
+        - name: fix-atp-storage-permissions
+          image: {{ include "newrelic.common.images.image" ( dict "imageRoot" .Values.images.kubectl "context" .) }}
+          imagePullPolicy: {{ .Values.images.kubectl.pullPolicy }}
+          securityContext:
+            runAsUser: 0  # Must run as root to chown directories
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - CHOWN  # Only capability needed
+                - DAC_OVERRIDE  # Needed to override file permissions
+          command:
+            - sh
+            - -c
+            - |
+              echo "Fixing permissions for ATP storage directory..."
+              # Ensure directory exists (idempotent)
+              mkdir -p /var/lib/nrdot-collector
+              # Change ownership to user 1001 (main container user)
+              chown -R 1001:1001 /var/lib/nrdot-collector
+              # Set appropriate permissions (owner can read/write/execute)
+              chmod -R 755 /var/lib/nrdot-collector
+              echo "Permissions fixed successfully"
+              ls -la /var/lib/ | grep nrdot-collector
+          volumeMounts:
+            - name: nrdot-data-storage
+              mountPath: /var/lib/nrdot-collector
+        {{- end }}
       containers:
         - name: otel-collector-daemonset
           {{- with include "nrKubernetesOtel.daemonset.securityContext.container" . }}


### PR DESCRIPTION
## Problem                                                                                                       
                                                                                                                   
  When ATP (Adaptive Telemetry Processor) is enabled, the collector fails to persist state with the following      
  error:                                                                                                           
                                                                                                                   
  Error: open /var/lib/nrdot-collector/adaptiveprocess.db: permission denied                                       

  **Root Cause:** The `hostPath` volume at `/var/lib/nrdot-collector` is created by Kubernetes with `root:root`
  ownership, but the main container runs as user `1001` (non-root), preventing ATP from writing the persistence
  database.

  ## Solution

  Added a new `fix-atp-storage-permissions` initContainer that:
  - Runs only when `enable_atp: true` (conditional rendering)
  - Changes ownership of `/var/lib/nrdot-collector` to `1001:1001` before the main container starts
  - Reuses the existing `bitnami/kubectl` image (no new dependencies)


  ## Security

  The initContainer runs with minimal privileges:
  - `runAsUser: 0` (required for `chown`)
  - `allowPrivilegeEscalation: false` (prevents privilege escalation attacks)
  - `capabilities: drop: [ALL], add: [CHOWN, DAC_OVERRIDE]` (only necessary capabilities)

  ## Backward Compatibility

  **No impact on existing installations:**
  - Wrapped in `{{- if .Values.enable_atp }}` conditional
  - Only adds initContainer when ATP is explicitly enabled
  - Uses existing image (no new dependencies)
  - All existing unit tests pass (213/213)

 