### PR TITLE
[nr-k8s-otel-collector] feat: temporarily change state persistence pat…

### DIFF
--- a/charts/nr-k8s-otel-collector/templates/daemonset.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset.yaml
@@ -162,8 +162,7 @@ spec:
             - name: final-daemonset-config
               mountPath: /config
             {{- if .Values.enable_atp }}
-            # ATP requires persistent storage to maintain state across restarts (thresholds, history).
-            # This hostPath volume ensures ATP data survives pod restarts on the same node.
+            # ATP storage for adaptive telemetry state (thresholds, anomaly history, tracked entities).
             - name: nrdot-data-storage
               mountPath: /var/lib/nrdot-collector
             {{- end }}
@@ -185,13 +184,9 @@ spec:
           configMap:
             name: {{ include "nrKubernetesOtel.daemonset.configMap.fullname" . }}
         {{- if .Values.enable_atp }}
-        # ATP storage volume: Uses hostPath to persist adaptive telemetry processor state.
-        # DirectoryOrCreate ensures the directory is created if it doesn't exist.
-        # Data persists across pod restarts but is node-specific (DaemonSet behavior).
+        # ATP storage volume: Uses emptyDir for temporary pod-local storage.
         - name: nrdot-data-storage
-          hostPath:
-            path: /var/lib/nrdot-collector
-            type: DirectoryOrCreate
+          emptyDir: {}
         {{- end }}
         {{- with .Values.daemonset.extraVolumes }}
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION

When ATP (Adaptive Telemetry Processor) is enabled, the collector fails to persist state with the following
error:

Error: open /var/lib/nrdot-collector/adaptiveprocess.db: permission denied


Changed the persistence path to pod storage path