### PR TITLE
chore: bump ac chart version

### DIFF
--- a/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 
 type: application
 
-version: 1.6.3
+version: 1.6.4
 
 dependencies:
   - name: common-library


### PR DESCRIPTION
1.6.3 release [failed](https://github.com/newrelic/helm-charts/actions/runs/24505658165) due to nri-bundle chart issues. This PR bumps the version so it gets released