### PR TITLE
[pipeline-control-gateway] feat: sidecar to restart the pod without flux

### DIFF
--- a/charts/pipeline-control-gateway/Chart.yaml
+++ b/charts/pipeline-control-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: pipeline-control-gateway
 type: application
-version: 2.0.2
+version: 2.1.0
 dependencies:
   - name: common-library
     version: 1.4.0

--- a/charts/pipeline-control-gateway/templates/deployment.yaml
+++ b/charts/pipeline-control-gateway/templates/deployment.yaml
@@ -135,7 +135,7 @@ spec:
               POD_NAME="${MY_POD_NAME}"
 
               echo "Config watcher started. Monitoring ConfigMap: ${CONFIGMAP_NAME}"
-              echo "Will restart pod: ${POD_NAME} in namespace: ${NAMESPACE}"
+              echo "Will restart pod: ${POD_NAME} in namespace: ${NAMESPACE} when a configuration update is detected"
 
               # Get initial resource version
               LAST_VERSION=$(kubectl get configmap ${CONFIGMAP_NAME} -n ${NAMESPACE} -o jsonpath='{.metadata.resourceVersion}')

--- a/charts/pipeline-control-gateway/templates/deployment.yaml
+++ b/charts/pipeline-control-gateway/templates/deployment.yaml
@@ -120,7 +120,7 @@ spec:
           volumeMounts:
             - name: deployment-config
               mountPath: /config
-        {{- if .Values.deployment.externalConfigMap.enabled }}
+        {{- if .Values.deployment.customConfigMap }}
         - name: config-watcher
           image: bitnami/kubectl:latest
           imagePullPolicy: IfNotPresent
@@ -130,7 +130,7 @@ spec:
             - |
               set -e
 
-              CONFIGMAP_NAME="{{ .Values.deployment.externalConfigMap.name }}"
+              CONFIGMAP_NAME="{{ .Values.deployment.customConfigMap }}"
               NAMESPACE="{{ .Release.Namespace }}"
               POD_NAME="${MY_POD_NAME}"
 
@@ -176,9 +176,9 @@ spec:
         {{- end }}
       volumes:
         - name: deployment-config
-          {{- if .Values.deployment.externalConfigMap.enabled }}
+          {{- if .Values.deployment.customConfigMap }}
           configMap:
-            name: {{ .Values.deployment.externalConfigMap.name }}
+            name: {{ .Values.deployment.customConfigMap }}
           {{- else }}
           configMap:
             name: {{ include "nrKubernetesOtel.deployment.fullname" . }}-config

--- a/charts/pipeline-control-gateway/templates/deployment.yaml
+++ b/charts/pipeline-control-gateway/templates/deployment.yaml
@@ -120,10 +120,69 @@ spec:
           volumeMounts:
             - name: deployment-config
               mountPath: /config
+        {{- if .Values.deployment.externalConfigMap.enabled }}
+        - name: config-watcher
+          image: bitnami/kubectl:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -e
+
+              CONFIGMAP_NAME="{{ .Values.deployment.externalConfigMap.name }}"
+              NAMESPACE="{{ .Release.Namespace }}"
+              POD_NAME="${MY_POD_NAME}"
+
+              echo "Config watcher started. Monitoring ConfigMap: ${CONFIGMAP_NAME}"
+              echo "Will restart pod: ${POD_NAME} in namespace: ${NAMESPACE}"
+
+              # Get initial resource version
+              LAST_VERSION=$(kubectl get configmap ${CONFIGMAP_NAME} -n ${NAMESPACE} -o jsonpath='{.metadata.resourceVersion}')
+              echo "Initial ConfigMap resourceVersion: ${LAST_VERSION}"
+
+              # Watch for changes - use --watch instead of --watch-only to get immediate events
+              kubectl get configmap ${CONFIGMAP_NAME} -n ${NAMESPACE} --watch -o jsonpath='{.metadata.resourceVersion}{"\n"}' | while read -r CURRENT_VERSION; do
+                if [ -z "$CURRENT_VERSION" ]; then
+                  continue
+                fi
+
+                echo "Event received. ResourceVersion: ${CURRENT_VERSION}"
+
+                if [ "$CURRENT_VERSION" != "$LAST_VERSION" ]; then
+                  echo "ConfigMap change detected! ResourceVersion changed from ${LAST_VERSION} to ${CURRENT_VERSION}"
+                  echo "Deleting pod ${POD_NAME} to trigger restart..."
+
+                  kubectl delete pod ${POD_NAME} -n ${NAMESPACE} --grace-period=30
+
+                  echo "Pod deletion initiated. Kubernetes will recreate the pod with new config."
+                  exit 0
+                fi
+
+                LAST_VERSION=$CURRENT_VERSION
+              done
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+        {{- end }}
       volumes:
         - name: deployment-config
+          {{- if .Values.deployment.externalConfigMap.enabled }}
           configMap:
-            name: {{ include "nrKubernetesOtel.deployment.configMap.fullname" . }}
+            name: {{ .Values.deployment.externalConfigMap.name }}
+          {{- else }}
+          configMap:
+            name: {{ include "nrKubernetesOtel.deployment.fullname" . }}-config
+          {{- end }}
       {{- with include "nrKubernetesOtel.deployment.nodeSelector" . }}
       nodeSelector:
         {{- . | nindent 8 }}

--- a/charts/pipeline-control-gateway/templates/deployment.yaml
+++ b/charts/pipeline-control-gateway/templates/deployment.yaml
@@ -120,10 +120,10 @@ spec:
           volumeMounts:
             - name: deployment-config
               mountPath: /config
-        {{- if .Values.deployment.customConfigMap }}
+        {{- if and .Values.deployment.customConfigMap .Values.deployment.configWatcher.enabled }}
         - name: config-watcher
-          image: bitnami/kubectl:latest
-          imagePullPolicy: IfNotPresent
+          image: {{ .Values.deployment.configWatcher.image }}
+          imagePullPolicy: {{ .Values.deployment.configWatcher.imagePullPolicy }}
           command:
             - /bin/bash
             - -c

--- a/charts/pipeline-control-gateway/templates/deployment.yaml
+++ b/charts/pipeline-control-gateway/templates/deployment.yaml
@@ -153,7 +153,7 @@ spec:
                   echo "ConfigMap change detected! ResourceVersion changed from ${LAST_VERSION} to ${CURRENT_VERSION}"
                   echo "Deleting pod ${POD_NAME} to trigger restart..."
 
-                  kubectl delete pod ${POD_NAME} -n ${NAMESPACE} --grace-period=30
+                  kubectl delete pod ${POD_NAME} -n ${NAMESPACE} --grace-period={{ .Values.deployment.configWatcher.gracePeriod }}
 
                   echo "Pod deletion initiated. Kubernetes will recreate the pod with new config."
                   exit 0
@@ -167,12 +167,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
           resources:
-            limits:
-              cpu: 100m
-              memory: 128Mi
-            requests:
-              cpu: 10m
-              memory: 64Mi
+            {{- toYaml .Values.deployment.configWatcher.resources | nindent 12 }}
         {{- end }}
       volumes:
         - name: deployment-config

--- a/charts/pipeline-control-gateway/templates/role.yaml
+++ b/charts/pipeline-control-gateway/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if and (include "newrelic.common.serviceAccount.create" .) .Values.deployment.customConfigMap }}
+{{- if and (include "newrelic.common.serviceAccount.create" .) .Values.deployment.customConfigMap .Values.deployment.configWatcher.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/pipeline-control-gateway/templates/role.yaml
+++ b/charts/pipeline-control-gateway/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if and (include "newrelic.common.serviceAccount.create" .) .Values.deployment.externalConfigMap.enabled }}
+{{- if and (include "newrelic.common.serviceAccount.create" .) .Values.deployment.customConfigMap }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -10,7 +10,7 @@ rules:
   # Allow watching and getting the ConfigMap
   - apiGroups: [""]
     resources: ["configmaps"]
-    resourceNames: ["{{ .Values.deployment.externalConfigMap.name }}"]
+    resourceNames: ["{{ .Values.deployment.customConfigMap }}"]
     verbs: ["get", "watch"]
   # Allow deleting the pod to trigger restart
   - apiGroups: [""]

--- a/charts/pipeline-control-gateway/templates/role.yaml
+++ b/charts/pipeline-control-gateway/templates/role.yaml
@@ -1,0 +1,19 @@
+{{- if and (include "newrelic.common.serviceAccount.create" .) .Values.deployment.externalConfigMap.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "nrKubernetesOtel.deployment.fullname" . }}-config-watcher
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "newrelic.common.labels" . | nindent 4 }}
+rules:
+  # Allow watching and getting the ConfigMap
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["{{ .Values.deployment.externalConfigMap.name }}"]
+    verbs: ["get", "watch"]
+  # Allow deleting the pod to trigger restart
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["delete"]
+{{- end -}}

--- a/charts/pipeline-control-gateway/templates/rolebinding.yaml
+++ b/charts/pipeline-control-gateway/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and (include "newrelic.common.serviceAccount.create" .) .Values.deployment.externalConfigMap.enabled }}
+{{- if and (include "newrelic.common.serviceAccount.create" .) .Values.deployment.customConfigMap }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/pipeline-control-gateway/templates/rolebinding.yaml
+++ b/charts/pipeline-control-gateway/templates/rolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if and (include "newrelic.common.serviceAccount.create" .) .Values.deployment.externalConfigMap.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "nrKubernetesOtel.deployment.fullname" . }}-config-watcher
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "newrelic.common.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "nrKubernetesOtel.deployment.fullname" . }}-config-watcher
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "newrelic.common.serviceAccount.name" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/pipeline-control-gateway/templates/rolebinding.yaml
+++ b/charts/pipeline-control-gateway/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and (include "newrelic.common.serviceAccount.create" .) .Values.deployment.customConfigMap }}
+{{- if and (include "newrelic.common.serviceAccount.create" .) .Values.deployment.customConfigMap .Values.deployment.configWatcher.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/pipeline-control-gateway/values.yaml
+++ b/charts/pipeline-control-gateway/values.yaml
@@ -76,13 +76,9 @@ deployment:
   configMap:
     # -- OpenTelemetry config for the deployment. If set, overrides default config and disables configuration parameters for the deployment.
     config: {}
-  # -- External ConfigMap watcher settings
-  # @default -- See `values.yaml`
-  externalConfigMap:
-    # -- Enable the config watcher sidecar that monitors external ConfigMap changes and restarts the pod
-    enabled: false
-    # -- Name of the external ConfigMap to watch for changes
-    name: "pipeline-control-gateway-config"
+  # -- Custom external ConfigMap name to watch for changes. When set, deploys a config-watcher sidecar that monitors this ConfigMap and restarts the pod on changes. Leave empty to disable.
+  # @default -- `""`
+  customConfigMap: ""
 
 # -- Sets all pods' node selector. Can be configured also with `global.nodeSelector`
 nodeSelector: {}

--- a/charts/pipeline-control-gateway/values.yaml
+++ b/charts/pipeline-control-gateway/values.yaml
@@ -76,9 +76,18 @@ deployment:
   configMap:
     # -- OpenTelemetry config for the deployment. If set, overrides default config and disables configuration parameters for the deployment.
     config: {}
-  # -- Custom external ConfigMap name to watch for changes. When set, deploys a config-watcher sidecar that monitors this ConfigMap and restarts the pod on changes. Leave empty to disable.
+  # -- Custom external ConfigMap name to use instead of the chart-generated one. Leave empty to use the internal ConfigMap.
   # @default -- `""`
   customConfigMap: ""
+  # -- Config watcher sidecar settings. Only applies when customConfigMap is set.
+  # @default -- See `values.yaml`
+  configWatcher:
+    # -- Enable the config-watcher sidecar that monitors the custom ConfigMap and restarts the pod on changes
+    enabled: true
+    # -- Config watcher image repository and tag
+    image: bitnami/kubectl:latest
+    # -- Config watcher image pull policy
+    imagePullPolicy: IfNotPresent
 
 # -- Sets all pods' node selector. Can be configured also with `global.nodeSelector`
 nodeSelector: {}

--- a/charts/pipeline-control-gateway/values.yaml
+++ b/charts/pipeline-control-gateway/values.yaml
@@ -76,6 +76,13 @@ deployment:
   configMap:
     # -- OpenTelemetry config for the deployment. If set, overrides default config and disables configuration parameters for the deployment.
     config: {}
+  # -- External ConfigMap watcher settings
+  # @default -- See `values.yaml`
+  externalConfigMap:
+    # -- Enable the config watcher sidecar that monitors external ConfigMap changes and restarts the pod
+    enabled: false
+    # -- Name of the external ConfigMap to watch for changes
+    name: "pipeline-control-gateway-config"
 
 # -- Sets all pods' node selector. Can be configured also with `global.nodeSelector`
 nodeSelector: {}

--- a/charts/pipeline-control-gateway/values.yaml
+++ b/charts/pipeline-control-gateway/values.yaml
@@ -88,6 +88,16 @@ deployment:
     image: bitnami/kubectl:latest
     # -- Config watcher image pull policy
     imagePullPolicy: IfNotPresent
+    # -- Grace period in seconds for pod deletion when ConfigMap changes
+    gracePeriod: 30
+    # -- Resource limits and requests for the config-watcher sidecar
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 64Mi
 
 # -- Sets all pods' node selector. Can be configured also with `global.nodeSelector`
 nodeSelector: {}


### PR DESCRIPTION
Add optional config-watcher sidecar for external ConfigMap auto-reload                                                                                                        
                  
 - Introduces `deployment.customConfigMap` to use external ConfigMaps with an optional sidecar that monitors `resourceVersion` changes via `kubectl --watch` and triggers        
  graceful pod restarts on updates. 
- Includes `deployment.configWatcher` settings for image configuration and RBAC resources (Role/RoleBinding) for ConfigMap access and pod     
  management.
- Disabled by default to maintain backward compatibility.

<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)

# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Tell the world about the latest changes in the chart.
<!--END-RELEASE-NOTES-->
