### PR TITLE
[Common library] Region updates, added resolve function, region aware endpoint lookup. 

### DIFF
--- a/.github/workflows/lint_test_charts.yaml
+++ b/.github/workflows/lint_test_charts.yaml
@@ -14,7 +14,7 @@ jobs:
           check_filenames: true
           check_hidden: true
           skip: ./.git
-          ignore_words_list: enver,NotIn,aks,commitish
+          ignore_words_list: enver,NotIn,aks,commitish,NPE,DNE,NAN
 
   lint-test:
     name: Lint and test charts

--- a/charts/nri-bundle/templates/NOTES.txt
+++ b/charts/nri-bundle/templates/NOTES.txt
@@ -1,3 +1,3 @@
 {{- if (index .Values "newrelic-eapm-agent") }}
-WARNING: Configs prefixed with 'newrelic-eapm-agent' are deprecated and will be removed May 1st 2026. Please use 'nr-ebpf-agent' instead.
+WARNING: 'newrelic-eapm-agent' prefixed configs are deprecated and will be removed in a future release. For example, 'newrelic-eapm-agent.enabled' has been replaced with 'nr-ebpf-agent.enabled'.
 {{- end }}

--- a/charts/nri-bundle/templates/NOTES.txt
+++ b/charts/nri-bundle/templates/NOTES.txt
@@ -1,3 +1,3 @@
 {{- if (index .Values "newrelic-eapm-agent") }}
-WARNING: 'newrelic-eapm-agent' prefixed configs are deprecated and will be removed in a future release. For example, 'newrelic-eapm-agent.enabled' has been replaced with 'nr-ebpf-agent.enabled'.
+WARNING: Configs prefixed with 'newrelic-eapm-agent' are deprecated and will be removed May 1st 2026. Please use 'nr-ebpf-agent' instead.
 {{- end }}

--- a/library/CHART-TEMPLATE/Chart.lock
+++ b/library/CHART-TEMPLATE/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: file://../common-library
-  version: 1.3.3
-digest: sha256:a6cccdb998711673638d38bed3e2406bc1871245eec5a14a054a594bcdaba3a2
-generated: "2025-06-03T11:13:13.110324-07:00"
+  version: 2.0.0
+digest: sha256:1ea3dd548c85651d52456ac555b6adf8af0f64d8523341a7f2504e24880fae5a
+generated: "2026-04-27T10:59:18.25987-07:00"

--- a/library/CHART-TEMPLATE/Chart.lock
+++ b/library/CHART-TEMPLATE/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: file://../common-library
-  version: 2.0.0
-digest: sha256:1ea3dd548c85651d52456ac555b6adf8af0f64d8523341a7f2504e24880fae5a
-generated: "2026-04-27T10:59:18.25987-07:00"
+  version: 2.0.1
+digest: sha256:103d5453f63465069768f9cfef3c4ff1d89faed969f1dcd3e41690fd02cb0442
+generated: "2026-04-27T20:14:43.744659-07:00"

--- a/library/CHART-TEMPLATE/Chart.lock
+++ b/library/CHART-TEMPLATE/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: file://../common-library
-  version: 2.0.1
-digest: sha256:103d5453f63465069768f9cfef3c4ff1d89faed969f1dcd3e41690fd02cb0442
-generated: "2026-04-27T20:14:43.744659-07:00"
+  version: 2.0.0
+digest: sha256:1ea3dd548c85651d52456ac555b6adf8af0f64d8523341a7f2504e24880fae5a
+generated: "2026-04-27T21:18:30.561623-07:00"

--- a/library/CHART-TEMPLATE/Chart.yaml
+++ b/library/CHART-TEMPLATE/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.3
+version: 2.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,7 +25,7 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: common-library
-    version: 1.3.3
+    version: 2.0.0
     repository: file://../common-library  # We keep this as a file to test things immediately locally/in the pipeline
 
 keywords:

--- a/library/CHART-TEMPLATE/Chart.yaml
+++ b/library/CHART-TEMPLATE/Chart.yaml
@@ -25,7 +25,7 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: common-library
-    version: 2.0.0
+    version: 2.0.1
     repository: file://../common-library  # We keep this as a file to test things immediately locally/in the pipeline
 
 keywords:

--- a/library/CHART-TEMPLATE/Chart.yaml
+++ b/library/CHART-TEMPLATE/Chart.yaml
@@ -25,7 +25,7 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: common-library
-    version: 2.0.1
+    version: 2.0.0
     repository: file://../common-library  # We keep this as a file to test things immediately locally/in the pipeline
 
 keywords:

--- a/library/CHART-TEMPLATE/templates/example-cm-endpoint-lookup.yaml
+++ b/library/CHART-TEMPLATE/templates/example-cm-endpoint-lookup.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "newrelic.common.naming.fullname" . }}-example-cm-endpoint-lookup
+  namespace: {{ .Release.Namespace }}
+data:
+  {{/* Otel has endpoints for US, EU, JP, GOV, and STG  */}}
+  otel: "{{- include "newrelic.common.otlp_endpoint" . -}}"
+
+  {{/* Some usecases require more than a domain, here's an example where we look up the base domain and append a path to it */}}
+  endpoint_with_path: "{{- include "newrelic.common.otlp_endpoint" . -}}/v1/supplementary/path"

--- a/library/CHART-TEMPLATE/templates/example-cm-region.yaml
+++ b/library/CHART-TEMPLATE/templates/example-cm-region.yaml
@@ -5,4 +5,11 @@ metadata:
   name: {{ include "newrelic.common.naming.fullname" . }}-examples-region
   namespace: {{ .Release.Namespace }}
 data:
-  region: {{ include "newrelic.common.region" . }}
+  region: "{{ include "newrelic.common.region" . }}"
+
+  is_us: "{{ if include "newrelic.common.region.is_us" . }}Yes{{ else }}NO{{ end }}"
+  is_eu: "{{ if include "newrelic.common.region.is_eu" . }}Yes{{ else }}NO{{ end }}"
+  is_jp: "{{ if include "newrelic.common.region.is_jp" . }}Yes{{ else }}NO{{ end }}"
+  is_gov: "{{ if include "newrelic.common.region.is_gov" . }}Yes{{ else }}NO{{ end }}"
+  is_stg: "{{ if include "newrelic.common.region.is_stg" . }}Yes{{ else }}NO{{ end }}"
+  is_dev: "{{ if include "newrelic.common.region.is_dev" . }}Yes{{ else }}NO{{ end }}"

--- a/library/CHART-TEMPLATE/templates/example-cm-resolve.yaml
+++ b/library/CHART-TEMPLATE/templates/example-cm-resolve.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   {{/* Using lookup With Default  */}}
-  custom: {{ include "newrelic.common.resolve_or" (dict "ctx" . "key" "custom"  "default" "myDefaultData") -}}
+  custom: {{ include "newrelic.common.resolve" (dict "ctx" . "key" "custom"  "default" "myDefaultData") -}}
 
   {{/* Look up only will return nothing if value not found */}}
   proxy: {{ include "newrelic.common.resolve" (dict "ctx" . "key" "proxy") -}}
@@ -22,7 +22,7 @@ data:
   nested_three_deep: {{ include "newrelic.common.resolve" (dict "ctx" . "key" "nested.secondLevel.value") -}}
 
   {{/* Example of using lookup with default with a nested path */}}
-  nested_two_deep_with_default: {{ include "newrelic.common.resolve_or" (dict "ctx" . "key" "nested.value" "default" "defaultNestedValue") -}}
+  nested_two_deep_with_default: {{ include "newrelic.common.resolve" (dict "ctx" . "key" "nested.value" "default" "defaultNestedValue") -}}
 
   {{/* Example of looking up a nested path that doesn't exist... (Test that this doesn't cause errors) */}}
   nested_value_DNE: {{ include "newrelic.common.resolve" (dict "ctx" . "key" "nested.blah.value.DNE") -}}

--- a/library/CHART-TEMPLATE/templates/example-cm-resolve.yaml
+++ b/library/CHART-TEMPLATE/templates/example-cm-resolve.yaml
@@ -1,0 +1,28 @@
+# This is a dummy CM to test the resolve template
+# and give examples on how to use it
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "newrelic.common.naming.fullname" . }}-examples-cm-resolve
+  namespace: {{ .Release.Namespace }}
+data:
+  {{/* Using lookup With Default  */}}
+  custom: {{ include "newrelic.common.resolve_or" (dict "ctx" . "key" "custom"  "default" "myDefaultData") -}}
+
+  {{/* Look up only will return nothing if value not found */}}
+  proxy: {{ include "newrelic.common.resolve" (dict "ctx" . "key" "proxy") -}}
+
+  {{/* Example of using lookup with custom logic to set default */}}
+  endpoint: {{ include "newrelic.common.resolve" (dict "ctx" . "key" "endpoint") | default "inline-default" -}}
+
+  {{/* Example of using lookup test with a nested two-level path */}}
+  nested_two_deep: {{ include "newrelic.common.resolve" (dict "ctx" . "key" "nested.value") -}}
+
+  {{/* Example of using lookup test with a nested three-level path */}}
+  nested_three_deep: {{ include "newrelic.common.resolve" (dict "ctx" . "key" "nested.secondLevel.value") -}}
+
+  {{/* Example of using lookup with default with a nested path */}}
+  nested_two_deep_with_default: {{ include "newrelic.common.resolve_or" (dict "ctx" . "key" "nested.value" "default" "defaultNestedValue") -}}
+
+  {{/* Example of looking up a nested path that doesn't exist... (Test that this doesn't cause errors) */}}
+  nested_value_DNE: {{ include "newrelic.common.resolve" (dict "ctx" . "key" "nested.blah.value.DNE") -}}

--- a/library/CHART-TEMPLATE/tests/cl-endpoints.yaml
+++ b/library/CHART-TEMPLATE/tests/cl-endpoints.yaml
@@ -1,0 +1,68 @@
+suite: test endpoints tpl
+templates:
+  - templates/example-cm-endpoint-lookup.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+tests:
+  - it: Should return US endpoint by default
+    asserts:
+      - equal:
+          path: data.otel
+          value: https://otlp.nr-data.net
+
+  - it: Should append path to endpoint
+    asserts:
+      - equal:
+          path: data.endpoint_with_path
+          value: https://otlp.nr-data.net/v1/supplementary/path
+
+  - it: Should return EU endpoint
+    set:
+      licenseKey: eu01NotARelLicenceKeyFFFFNRAL
+    asserts:
+      - equal:
+          path: data.otel
+          value: https://otlp.eu01.nr-data.net
+
+  - it: Should return Japan endpoint
+    set:
+      licenseKey: jpx1NotARelLicenceKeyFFFFNRAL
+    asserts:
+      - equal:
+          path: data.otel
+          value: https://otlp.jp.nr-data.net
+
+  - it: Should return Gov endpoint
+    set:
+      fedramp:
+        enabled: true
+    asserts:
+      - equal:
+          path: data.otel
+          value: https://gov-otlp.nr-data.net
+
+  - it: Should return staging endpoint
+    set:
+      nrStaging: true
+    asserts:
+      - equal:
+          path: data.otel
+          value: https://staging-otlp.nr-data.net
+
+  - it: Should should fail if region supplied that doesn't have an endpoint
+    set:
+      region: dev
+    asserts:
+      - failedTemplate:
+          errorMessage: "This chart does not have support for the region provided 'DEV'. Please either supply an override URL via .Values.otlpEndpoint or .Values.global.otlpEndpoint, or set a different region."
+
+
+  - it: Should use override endpoint if provided even if region doesn't have a supported endpoint
+    set:
+      otlpEndpoint: https://my-custom-endpoint.com
+      region: dev
+    asserts:
+      - equal:
+          path: data.otel
+          value: https://my-custom-endpoint.com

--- a/library/CHART-TEMPLATE/tests/cl-images_registry_test.yaml
+++ b/library/CHART-TEMPLATE/tests/cl-images_registry_test.yaml
@@ -10,7 +10,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: nginx:1.16.0
+          value: docker.io/nginx:1.16.0
 
   - it: sets registry if specified in values
     set:
@@ -50,7 +50,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: nginx:1.16.0
+          value: docker.io/nginx:1.16.0
 
   - it: does not break if global.image=null
     set:
@@ -59,4 +59,4 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: nginx:1.16.0
+          value: docker.io/nginx:1.16.0

--- a/library/CHART-TEMPLATE/tests/cl-images_registry_test.yaml
+++ b/library/CHART-TEMPLATE/tests/cl-images_registry_test.yaml
@@ -6,7 +6,7 @@ release:
   name: my-release
   namespace: my-namespace
 tests:
-  - it: does not set registry if not specified
+  - it: Sets docker.io as default registry if no registry set.
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image

--- a/library/CHART-TEMPLATE/tests/cl-region.yaml
+++ b/library/CHART-TEMPLATE/tests/cl-region.yaml
@@ -125,23 +125,15 @@ tests:
         region: US
     asserts:
       - equal:
-          path: data.is_us
-          value: Yes
-      - equal:
-          path: data.is_eu
-          value: NO
-      - equal:
-          path: data.is_jp
-          value: NO
-      - equal:
-          path: data.is_gov
-          value: NO
-      - equal:
-          path: data.is_stg
-          value: NO
-      - equal:
-          path: data.is_dev
-          value: NO
+          path: data
+          value:
+            region: US
+            is_us: Yes
+            is_eu: NO
+            is_jp: NO
+            is_gov: NO
+            is_stg: NO
+            is_dev: NO
 
 
 
@@ -151,23 +143,15 @@ tests:
         region: EU
     asserts:
       - equal:
-          path: data.is_us
-          value: NO
-      - equal:
-          path: data.is_eu
-          value: Yes
-      - equal:
-          path: data.is_jp
-          value: NO
-      - equal:
-          path: data.is_gov
-          value: NO
-      - equal:
-          path: data.is_stg
-          value: NO
-      - equal:
-          path: data.is_dev
-          value: NO
+          path: data
+          value:
+            region: EU
+            is_us: NO
+            is_eu: Yes
+            is_jp: NO
+            is_gov: NO
+            is_stg: NO
+            is_dev: NO
 
   - it: Convenience Functions work for JP
     set:
@@ -175,23 +159,15 @@ tests:
         region: JP
     asserts:
       - equal:
-          path: data.is_us
-          value: NO
-      - equal:
-          path: data.is_eu
-          value: NO
-      - equal:
-          path: data.is_jp
-          value: Yes
-      - equal:
-          path: data.is_gov
-          value: NO
-      - equal:
-          path: data.is_stg
-          value: NO
-      - equal:
-          path: data.is_dev
-          value: NO
+          path: data
+          value:
+            region: JP
+            is_us: NO
+            is_eu: NO
+            is_jp: Yes
+            is_gov: NO
+            is_stg: NO
+            is_dev: NO
 
   - it: Convenience Functions work for Gov
     set:
@@ -199,23 +175,15 @@ tests:
         enabled: true
     asserts:
       - equal:
-          path: data.is_us
-          value: NO
-      - equal:
-          path: data.is_eu
-          value: NO
-      - equal:
-          path: data.is_jp
-          value: NO
-      - equal:
-          path: data.is_gov
-          value: Yes
-      - equal:
-          path: data.is_stg
-          value: NO
-      - equal:
-          path: data.is_dev
-          value: NO
+          path: data
+          value:
+            region: GOV
+            is_us: NO
+            is_eu: NO
+            is_jp: NO
+            is_gov: Yes
+            is_stg: NO
+            is_dev: NO
 
   - it: Convenience Functions work for STG
     set:
@@ -223,43 +191,27 @@ tests:
         nrStaging: true
     asserts:
       - equal:
-          path: data.is_us
-          value: NO
-      - equal:
-          path: data.is_eu
-          value: NO
-      - equal:
-          path: data.is_jp
-          value: NO
-      - equal:
-          path: data.is_gov
-          value: NO
-      - equal:
-          path: data.is_stg
-          value: Yes
-      - equal:
-          path: data.is_dev
-          value: NO
+          path: data
+          value:
+            region: STG
+            is_us: NO
+            is_eu: NO
+            is_jp: NO
+            is_gov: NO
+            is_stg: Yes
+            is_dev: NO
 
   - it: Convenience Functions work for Dev
     set:
       region: dev
     asserts:
       - equal:
-          path: data.is_us
-          value: NO
-      - equal:
-          path: data.is_eu
-          value: NO
-      - equal:
-          path: data.is_jp
-          value: NO
-      - equal:
-          path: data.is_gov
-          value: NO
-      - equal:
-          path: data.is_stg
-          value: NO
-      - equal:
-          path: data.is_dev
-          value: Yes
+          path: data
+          value:
+            region: DEV
+            is_us: NO
+            is_eu: NO
+            is_jp: NO
+            is_gov: NO
+            is_stg: NO
+            is_dev: Yes

--- a/library/CHART-TEMPLATE/tests/cl-region.yaml
+++ b/library/CHART-TEMPLATE/tests/cl-region.yaml
@@ -20,7 +20,7 @@ tests:
           path: data.region
           value: US
 
-  - it: Detects an EU license key
+  - it: Detects EU license key
     set:
       global: null
       region: null
@@ -29,6 +29,16 @@ tests:
       - equal:
           path: data.region
           value: EU
+
+  - it: Detects Japan license key
+    set:
+      global: null
+      region: null
+      licenseKey: jpxNotARelLicenceKeyFFFFNRAL
+    asserts:
+      - equal:
+          path: data.region
+          value: JP
 
   - it: Set region (globally)
     set:
@@ -47,15 +57,32 @@ tests:
           path: data.region
           value: EU
 
+  - it: Set Japan region (globally)
+    set:
+      global:
+        region: JP
+    asserts:
+      - equal:
+          path: data.region
+          value: JP
+
+  - it: Set Japan region (locally)
+    set:
+      region: JP
+    asserts:
+      - equal:
+          path: data.region
+          value: JP
+
   - it: Overrides global region with the local one
     set:
       global:
         region: EU
-      region: local
+      region: DEV
     asserts:
       - equal:
           path: data.region
-          value: Local
+          value: DEV
 
   - it: Honors staging flag
     set:
@@ -63,4 +90,176 @@ tests:
     asserts:
       - equal:
           path: data.region
-          value: Staging
+          value: STG
+
+  - it: Honors global staging flag
+    set:
+      global.nrStaging: true
+    asserts:
+      - equal:
+          path: data.region
+          value: STG
+
+  - it: Honors fedramp flag
+    set:
+      fedramp:
+        enabled: true
+    asserts:
+      - equal:
+          path: data.region
+          value: GOV
+
+  - it: Honors global fedramp flag
+    set:
+      global:
+        fedramp:
+          enabled: true
+    asserts:
+      - equal:
+          path: data.region
+          value: GOV
+
+  - it: Convenience Functions work for US
+    set:
+      global:
+        region: US
+    asserts:
+      - equal:
+          path: data.is_us
+          value: Yes
+      - equal:
+          path: data.is_eu
+          value: NO
+      - equal:
+          path: data.is_jp
+          value: NO
+      - equal:
+          path: data.is_gov
+          value: NO
+      - equal:
+          path: data.is_stg
+          value: NO
+      - equal:
+          path: data.is_dev
+          value: NO
+
+
+
+  - it: Convenience Functions work for EU
+    set:
+      global:
+        region: EU
+    asserts:
+      - equal:
+          path: data.is_us
+          value: NO
+      - equal:
+          path: data.is_eu
+          value: Yes
+      - equal:
+          path: data.is_jp
+          value: NO
+      - equal:
+          path: data.is_gov
+          value: NO
+      - equal:
+          path: data.is_stg
+          value: NO
+      - equal:
+          path: data.is_dev
+          value: NO
+
+  - it: Convenience Functions work for JP
+    set:
+      global:
+        region: JP
+    asserts:
+      - equal:
+          path: data.is_us
+          value: NO
+      - equal:
+          path: data.is_eu
+          value: NO
+      - equal:
+          path: data.is_jp
+          value: Yes
+      - equal:
+          path: data.is_gov
+          value: NO
+      - equal:
+          path: data.is_stg
+          value: NO
+      - equal:
+          path: data.is_dev
+          value: NO
+
+  - it: Convenience Functions work for Gov
+    set:
+      fedramp:
+        enabled: true
+    asserts:
+      - equal:
+          path: data.is_us
+          value: NO
+      - equal:
+          path: data.is_eu
+          value: NO
+      - equal:
+          path: data.is_jp
+          value: NO
+      - equal:
+          path: data.is_gov
+          value: Yes
+      - equal:
+          path: data.is_stg
+          value: NO
+      - equal:
+          path: data.is_dev
+          value: NO
+
+  - it: Convenience Functions work for STG
+    set:
+      global:
+        nrStaging: true
+    asserts:
+      - equal:
+          path: data.is_us
+          value: NO
+      - equal:
+          path: data.is_eu
+          value: NO
+      - equal:
+          path: data.is_jp
+          value: NO
+      - equal:
+          path: data.is_gov
+          value: NO
+      - equal:
+          path: data.is_stg
+          value: Yes
+      - equal:
+          path: data.is_dev
+          value: NO
+
+  - it: Convenience Functions work for Dev
+    set:
+      region: dev
+    asserts:
+      - equal:
+          path: data.is_us
+          value: NO
+      - equal:
+          path: data.is_eu
+          value: NO
+      - equal:
+          path: data.is_jp
+          value: NO
+      - equal:
+          path: data.is_gov
+          value: NO
+      - equal:
+          path: data.is_stg
+          value: NO
+      - equal:
+          path: data.is_dev
+          value: Yes

--- a/library/CHART-TEMPLATE/tests/cl-resolve.yaml
+++ b/library/CHART-TEMPLATE/tests/cl-resolve.yaml
@@ -1,0 +1,138 @@
+suite: test resolve
+templates:
+  - templates/example-cm-resolve.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+tests:
+  - it: Should return local override values
+    set:
+      custom: my_custom_data
+      proxy: my_proxy_name
+      endpoint: my_endpoint
+    asserts:
+        # Lookup with default
+      - equal:
+          path: data.custom
+          value: my_custom_data
+        # Lookup only
+      - equal:
+          path: data.proxy
+          value: my_proxy_name
+        # Lookup with custom default logic
+      - equal:
+          path: data.endpoint
+          value: my_endpoint
+
+  - it: Should return global override values
+    set:
+      global:
+        custom: some_custom_data
+        proxy: some_proxy_name
+        endpoint: some_endpoint
+    asserts:
+      # Lookup with default
+      - equal:
+          path: data.custom
+          value: some_custom_data
+        # Lookup only
+      - equal:
+          path: data.proxy
+          value: some_proxy_name
+        # Lookup with custom default logic
+      - equal:
+          path: data.endpoint
+          value: some_endpoint
+
+  - it: Should return defaults when no values are set
+    asserts:
+      # Lookup with default
+      - equal:
+          path: data.custom
+          value: myDefaultData
+        # Lookup only
+      - equal:
+          path: data.proxy
+          value: null
+        # Lookup with custom default logic
+      - equal:
+          path: data.endpoint
+          value: inline-default
+          
+  - it: Should return local values when both global and local are set
+    set:
+      custom: local_custom_data
+      proxy: local_proxy_name
+      endpoint: local_endpoint
+      global:
+        custom: global_custom_data
+        proxy: global_proxy_name
+        endpoint: global_endpoint
+    asserts:
+      # Lookup with default
+      - equal:
+          path: data.custom
+          value: local_custom_data
+        # Lookup only
+      - equal:
+          path: data.proxy
+          value: local_proxy_name
+        # Lookup with custom default logic
+      - equal:
+          path: data.endpoint
+          value: local_endpoint
+
+  - it: Should return nested values
+    set:
+      nested:
+        value: my_nested_value
+        secondLevel:
+            value: my_second_level_nested_value
+    asserts:
+      - equal:
+          path: data.nested_two_deep
+          value: my_nested_value
+      - equal:
+          path: data.nested_three_deep
+          value: my_second_level_nested_value
+
+  - it: Should return global nested values
+    set:
+      global:
+        nested:
+          value: my_other_nested_value
+          secondLevel:
+            value: my_other_second_level_nested_value
+    asserts:
+      - equal:
+          path: data.nested_two_deep
+          value: my_other_nested_value
+      - equal:
+          path: data.nested_three_deep
+          value: my_other_second_level_nested_value
+
+  - it: lookup with default should return found nested value
+    set:
+      nested:
+        value: not_the_default
+    asserts:
+      - equal:
+          path: data.nested_two_deep_with_default
+          value: not_the_default
+
+  - it: lookup with default should return default when values not set
+    asserts:
+      - equal:
+          path: data.nested_two_deep_with_default
+          value: defaultNestedValue
+
+  # This test exposes the bug where `default $ctx.Values $ctx` always returns
+  # $ctx (the full Helm context) instead of $ctx.Values, causing the function
+  # to index the top-level context map rather than Values — so no value is ever found.
+  - it: BUG should resolve a simple local value (fails if default args are swapped)
+    set:
+      proxy: bug_repro_value
+    asserts:
+      - equal:
+          path: data.proxy
+          value: bug_repro_value

--- a/library/CHART-TEMPLATE/values.yaml
+++ b/library/CHART-TEMPLATE/values.yaml
@@ -43,8 +43,8 @@ global:
   lowDataMode:
 
   nrStaging:
-  fedramp:
-    enabled:
+#  fedramp:
+#    enabled:
 
   verboseLog:
 
@@ -127,8 +127,8 @@ proxy:
 lowDataMode:
 
 nrStaging:
-fedramp:
-  enabled:
+#fedramp:
+#  enabled:
 
 verboseLog:
 

--- a/library/CHART-TEMPLATE/values.yaml
+++ b/library/CHART-TEMPLATE/values.yaml
@@ -43,10 +43,18 @@ global:
   lowDataMode:
 
   nrStaging:
-  fedRamp:
+  fedramp:
     enabled:
 
   verboseLog:
+
+  custom:
+  endpoint:
+
+  nested:
+    value:
+    secondLevel:
+      value:
 
 licenseKey: foobar  # These ease testing as we don't have to set these values in each test
 cluster: barfoo  # These ease testing as we don't have to set these values in each test
@@ -119,7 +127,16 @@ proxy:
 lowDataMode:
 
 nrStaging:
-fedRamp:
+fedramp:
   enabled:
 
 verboseLog:
+
+custom:
+endpoint:
+
+nested:
+  value:
+  secondLevel:
+    value:
+

--- a/library/CHART-TEMPLATE/values.yaml
+++ b/library/CHART-TEMPLATE/values.yaml
@@ -139,4 +139,3 @@ nested:
   value:
   secondLevel:
     value:
-

--- a/library/CHART-TEMPLATE/values.yaml
+++ b/library/CHART-TEMPLATE/values.yaml
@@ -43,8 +43,8 @@ global:
   lowDataMode:
 
   nrStaging:
-#  fedramp:
-#    enabled:
+  fedramp:
+    enabled:
 
   verboseLog:
 
@@ -127,8 +127,8 @@ proxy:
 lowDataMode:
 
 nrStaging:
-#fedramp:
-#  enabled:
+fedramp:
+  enabled:
 
 verboseLog:
 

--- a/library/common-library/Chart.yaml
+++ b/library/common-library/Chart.yaml
@@ -3,7 +3,7 @@ name: common-library
 description: Provides helpers to provide consistency on all the charts
 
 type: library
-version: 1.4.0
+version: 2.0.0
 
 keywords:
   - newrelic

--- a/library/common-library/Chart.yaml
+++ b/library/common-library/Chart.yaml
@@ -3,7 +3,7 @@ name: common-library
 description: Provides helpers to provide consistency on all the charts
 
 type: library
-version: 2.0.0
+version: 2.0.1
 
 keywords:
   - newrelic

--- a/library/common-library/Chart.yaml
+++ b/library/common-library/Chart.yaml
@@ -3,7 +3,7 @@ name: common-library
 description: Provides helpers to provide consistency on all the charts
 
 type: library
-version: 2.0.1
+version: 2.0.0
 
 keywords:
   - newrelic

--- a/library/common-library/DEVELOPERS.md
+++ b/library/common-library/DEVELOPERS.md
@@ -398,6 +398,41 @@ data:
 ```
 
 
+## _endpoints.tpl
+### `newrelic.common.<endpointName>Endpoint`
+This is a collection of functions that returns the correct endpoint based on the region that the chart is being deployed to.
+It will first check if the user has set a customer endpoint in their chart, if not it will check the region and return the correct endpoint for that region.
+If no endpoint can be found it will call `fail` and abort the installation.
+
+Each function has a corresponding value that it checks to be used as an override for the endpoint.
+For example `insights_collector_endpoint` will check the following value in the values.yaml:
+```yaml
+insightsCollectorEndpoint: "https://custom-endpoint.com"  
+global:
+  insightsCollectorEndpoint: "https://custom-endpoint.com"
+```
+
+Usage:
+```mustache
+otlphttp/newrelic:
+  endpoint: {{ include "newrelic.common.otlp_endpoint" . }}
+```
+
+| Available Functions                              | values.yaml value             |
+|--------------------------------------------------|-------------------------------|
+| `newrelic.common.collector_endpoint`             | `collectorEndpoint`           |
+| `newrelic.common.infra_api_endpoint`             | `infraApiEndpoint`            |
+| `newrelic.common.insights_collector_endpoint`    | `insightsCollectorEndpoint`   |
+| `newrelic.common.log_api_endpoint`               | `logApiEndpoint`              |
+| `newrelic.common.metric_api_endpoint`            | `metricApiEndpoint`           |
+| `newrelic.common.opamp_endpoint`                 | `opampEndpoint`               |
+| `newrelic.common.otlp_endpoint`                  | `otlpEndpoint`                |
+| `newrelic.common.public_keys_endpoint`           | `publicKeysEndpoint`          |
+| `newrelic.common.system_identity_oauth_endpoint` | `systemIdentityOauthEndpoint` |
+| `newrelic.common.synthetics_horde_endpoint`      | `syntheticsHordeEndpoint`     |
+| `newrelic.common.trace_api_endpoint`             | `traceApiEndpoint`            |
+
+
 
 ## _fedramp.tpl
 ### `newrelic.common.fedramp.enabled`
@@ -460,7 +495,42 @@ You just must have a template with these two lines:
 {{- include "newrelic.common.license.secret" . -}}
 ```
 
+## _resolve.tpl
+This file was created out of necessity. Every Helm chart in this repo has at least one instance of writing their own logic of this function.
+Most charts rewrite this logic multiple times throughout their templates. 
+By taking advantage of this helper function, we can avoid bloat and make our charts easier to read and maintain.
+Simply put, the functions in this tpl check to see if a value is set at the root level of the values.yaml, and at the global level, and does so in the correct order.
 
+### `newrelic.common.resolve`
+Looks up the supplied path/value at the root level of the values.yaml, and then at the global level. 
+If none can be found returns nothing. 
+
+the `key` field of the dict is the path to the value that you wish to lookup. 
+It can be a single key like `proxy` or a nested path like `some.nested.value`.
+Due to this function's built in null check, it doesn't matter if the full path exists in the values.yaml or not, it will not throw an error.
+
+usage: Non-nested value
+```mustache
+proxy: {{ include "newrelic.common.resolve" (dict "ctx" . "key" "proxy") -}}
+```
+this will search for `.Values.proxy` and `.Values.global.proxy`.
+
+usage: Nested value
+```mustache
+my_value: {{ include "newrelic.common.resolve" (dict "ctx" . "key" "some.nested.value") -}}
+```
+this will search for `.Values.some.nested.value` and `.Values.global.some.nested.value`
+
+### `newrelic.common.resolve_or`
+This function behaves exactly the same as `newrelic.common.resolve` but it returns a default value if the key is not found at the root or global level.
+The following two examples are equivalent, the only difference is that the second one uses `newrelic.common.resolve_or` to return a default value instead of an empty string when the key is not found.
+
+```mustache
+my_value: {{ include "newrelic.common.resolve" (dict "ctx" . "key" "custom.value") | default "inline-default" -}}
+```
+```mustache
+my_value: {{ include "newrelic.common.resolve_or" (dict "ctx" . "key" "custom"  "default" "myDefaultData") -}}
+``` 
 
 ## _insights.tpl
 ### `newrelic.common.insightsKey.secretName` and ### `newrelic.common.insightsKey.secretKeyName`
@@ -548,23 +618,15 @@ You just must have a template with these two lines:
 
 
 
-## _region.tpl
-### `newrelic.common.region.validate`
-Given a string, return a normalized name for the region if valid.
-
-This function does not need the context of the chart, only the value to be validated. The region returned
-honors the region [definition of the newrelic-client-go implementation](https://github.com/newrelic/newrelic-client-go/blob/cbe3e4cf2b95fd37095bf2ffdc5d61cffaec17e2/pkg/region/region_constants.go#L8-L21)
-so (as of 2024/09/14) it returns the region as "US", "EU", "Staging", or "Local".
-
-In case the region provided does not match these 4, the helper calls `fail` and abort the templating.
-
-Usage:
-```mustache
-{{ include "newrelic.common.region.validate" "us" }}
-```
+## _region.tpl 
+Odds are that you should not be using any of the functions in this TPL.
+Only use the functions in this TPL if you need to do something other than changing an endpoint URL based on the region.
+If you only need to know the region to update an endpoint see the documentation for `_endpoints.tpl` instead.
 
 ### `newrelic.common.region`
-It reads global and local variables for `region`:
+Consider using the convenience functions newrelic.common.region.is_<region> instead of pulling the region directly.
+
+`newrelic.common.region` reads global and local variables for `region`:
 ```yaml
 global:
   region:  # Note that this can be empty (nil) or "" (empty string)
@@ -578,15 +640,46 @@ This function gives protection so it enforces users to give the license key as a
 `values.yaml` or specify a global or local `region` value. To understand how the `region` value
 works, read the documentation of `newrelic.common.region.validate`.
 
-The function will change the region from US, EU or Staging based of the license key and the
-`nrStaging` toggle. Whichever region is computed from the license/toggle can be overridden by
-the `region` value.
+The function will change the region from US, EU, JP, GOV, STG, or DEV based of the license key, the
+`nrStaging` toggle and the `fedramp.enabled` toggle. Whichever region is computed from the license/toggles can be overridden by `region` or `global.region`.
 
 Usage:
 ```mustache
 {{ include "newrelic.common.region" . }}
 ```
 
+### `newrelic.common.region.validate`
+> You should not have a use case where you need to call this function directly
+
+Given a string, return a normalized name for the region if valid.
+
+This function does not need the context of the chart, only the value to be validated. The region returned will be one of `US`, `EU`, `JP`, `GOV`, `STG` or `DEV`.
+
+In case the region provided does not match these 4, the helper calls `fail` and abort the templating.
+
+Usage:
+```mustache
+{{ include "newrelic.common.region.validate" "us" }}
+```
+
+### `newrelic.common.region.is_<region>` (e.g. `newrelic.common.region.is_us`, `newrelic.common.region.is_`, etc.)
+This TPL has a number of helper functions to help you check if you're in a specific region.
+* `newrelic.common.region.is_us` -> checks if the region is for the United States
+* `newrelic.common.region.is_eu` -> checks if the region is for the European Union
+* `newrelic.common.region.is_jp` -> checks if the region is for Japan
+* `newrelic.common.region.is_gov` -> checks if the region is for a fedramp enabled account
+* `newrelic.common.region.is_stg` -> checks if the region is Staging
+* `newrelic.common.region.is_dev` -> checks if the region is for development
+
+These helper functions prevent us from having to copy and paste the same conditionals across all of our charts. 
+Usage:
+```mustache
+{{ if include "newrelic.common.region.is_us" . }}
+  {{/* Do Something. */}}
+{{ else }}
+  {{/* Do something else. */}}
+{{ end }}
+```
 
 
 ## _low-data-mode.tpl
@@ -607,7 +700,6 @@ Usage:
 ```mustache
 {{ include "newrelic.common.lowDataMode" . }}
 ```
-
 
 
 ## _privileged.tpl

--- a/library/common-library/DEVELOPERS.md
+++ b/library/common-library/DEVELOPERS.md
@@ -503,34 +503,34 @@ Simply put, the functions in this tpl check to see if a value is set at the root
 
 ### `newrelic.common.resolve`
 Looks up the supplied path/value at the root level of the values.yaml, and then at the global level. 
-If none can be found returns nothing. 
+If nothing is found, the function will either return nothing which can be used as a falsy condition, or will return a default value if one was supplied. 
 
-the `key` field of the dict is the path to the value that you wish to lookup. 
+The `key` field of the dict is the path to the value that you wish to lookup. 
 It can be a single key like `proxy` or a nested path like `some.nested.value`.
 Due to this function's built in null check, it doesn't matter if the full path exists in the values.yaml or not, it will not throw an error.
+However, if the path resolves to a non-indexable type before the end of the path is reached, it will throw an error.
 
 usage: Non-nested value
+this will search for `.Values.proxy` and `.Values.global.proxy`.
 ```mustache
 proxy: {{ include "newrelic.common.resolve" (dict "ctx" . "key" "proxy") -}}
 ```
-this will search for `.Values.proxy` and `.Values.global.proxy`.
 
 usage: Nested value
+this will search for `.Values.some.nested.value` and `.Values.global.some.nested.value`
 ```mustache
 my_value: {{ include "newrelic.common.resolve" (dict "ctx" . "key" "some.nested.value") -}}
 ```
-this will search for `.Values.some.nested.value` and `.Values.global.some.nested.value`
 
-### `newrelic.common.resolve_or`
-This function behaves exactly the same as `newrelic.common.resolve` but it returns a default value if the key is not found at the root or global level.
-The following two examples are equivalent, the only difference is that the second one uses `newrelic.common.resolve_or` to return a default value instead of an empty string when the key is not found.
+usage: With default value
+The following two examples are equivalent, the only difference is that the second one uses `newrelic.common.resolve` to return a default value instead of an empty string when the key is not found.
+```mustache
+my_value: {{ include "newrelic.common.resolve" (dict "ctx" . "key" "custom"  "default" "myDefaultData") -}}
+``` 
 
 ```mustache
 my_value: {{ include "newrelic.common.resolve" (dict "ctx" . "key" "custom.value") | default "inline-default" -}}
 ```
-```mustache
-my_value: {{ include "newrelic.common.resolve_or" (dict "ctx" . "key" "custom"  "default" "myDefaultData") -}}
-``` 
 
 ## _insights.tpl
 ### `newrelic.common.insightsKey.secretName` and ### `newrelic.common.insightsKey.secretKeyName`

--- a/library/common-library/templates/_endpoints.tpl
+++ b/library/common-library/templates/_endpoints.tpl
@@ -12,7 +12,7 @@ See below.
 
 {{- define "newrelic.common.endpoints.resolve" -}}                                                                                                                                                                                    
   {{- $region := include "newrelic.common.region" .ctx -}}                                                                                                                                                                            
-  {{- $endpoint := include "newrelic.common.resolve_or" (dict "ctx" .ctx "key" .key "default" (get .endpoints $region)) -}}
+  {{- $endpoint := include "newrelic.common.resolve" (dict "ctx" .ctx "key" .key "default" (get .endpoints $region)) -}}
   {{- required (printf "This chart does not have support for the region provided '%s'. Please either supply an override URL via .Values.%s or .Values.global.%s, or set a different region." $region .key .key) $endpoint -}}
 {{- end -}}    
 

--- a/library/common-library/templates/_endpoints.tpl
+++ b/library/common-library/templates/_endpoints.tpl
@@ -1,5 +1,5 @@
 {{/*Endpoint Lookup
-This funcion provides a region awear lookup for new relic endpoints.
+This function provides a region awear lookup for new relic endpoints.
 It first checks for an endpoint override in the following order:
 1. .Values.<key>
 2. .Values.global.<key>

--- a/library/common-library/templates/_endpoints.tpl
+++ b/library/common-library/templates/_endpoints.tpl
@@ -1,0 +1,136 @@
+{{/*Endpoint Lookup
+This funcion provides a region awear lookup for new relic endpoints.
+It first checks for an endpoint override in the following order:
+1. .Values.<key>
+2. .Values.global.<key>
+If no override is found, it will attempt to resolve the endpoint based on the region value.
+If no endpoint override is found and the region is not supported, an error will be thrown.
+
+All endpoints exposed to customers though NR helm charts should be defined in a dictionary in this file and wrapped with a convenience function.
+See below.
+*/}}
+
+{{- define "newrelic.common.endpoints.resolve" -}}                                                                                                                                                                                    
+  {{- $region := include "newrelic.common.region" .ctx -}}                                                                                                                                                                            
+  {{- $endpoint := include "newrelic.common.resolve_or" (dict "ctx" .ctx "key" .key "default" (get .endpoints $region)) -}}
+  {{- required (printf "This chart does not have support for the region provided '%s'. Please either supply an override URL via .Values.%s or .Values.global.%s, or set a different region." $region .key .key) $endpoint -}}
+{{- end -}}    
+
+
+{{/*-----------------------------ENDPOINTS-----------------------------*/}}
+
+{{/* Returns the New Relic collector endpoint for this region */}}
+{{- define "newrelic.common.collector_endpoint" -}}
+  {{- $endpoints := dict
+      "US"      "https://collector.newrelic.com"
+      "EU"      "https://collector.eu.newrelic.com"
+      "STG"     "https://staging-collector.newrelic.com"
+  -}}
+  {{- include "newrelic.common.endpoints.resolve" (dict "ctx" . "key" "collectorEndpoint" "endpoints" $endpoints) -}}
+{{- end -}}
+
+{{/* Returns the New Relic infra API endpoint for this region */}}
+{{- define "newrelic.common.infra_api_endpoint" -}}
+  {{- $endpoints := dict
+      "US"      "https://infra-api.newrelic.com"
+      "EU"      "https://infra-api.eu.newrelic.com"
+      "STG"     "https://staging-infra-api.newrelic.com"
+  -}}
+  {{- include "newrelic.common.endpoints.resolve" (dict "ctx" . "key" "infraApiEndpoint" "endpoints" $endpoints) -}}
+{{- end -}}
+
+{{/* Returns the New Relic insights collector endpoint for this region */}}
+{{- define "newrelic.common.insights_collector_endpoint" -}}
+  {{- $endpoints := dict
+      "US"      "https://insights-collector.newrelic.com"
+      "EU"      "https://insights-collector.eu01.nr-data.net"
+      "JP"      "https://insights-collector.jp.nr-data.net"
+      "STG"     "https://staging-insights-collector.newrelic.com"
+  -}}
+  {{- include "newrelic.common.endpoints.resolve" (dict "ctx" . "key" "insightsCollectorEndpoint" "endpoints" $endpoints) -}}
+{{- end -}}
+
+{{/* Returns the New Relic Log Api endpoint for this region */}}
+{{- define "newrelic.common.log_api_endpoint" -}}
+  {{- $endpoints := dict
+      "US"      "https://log-api.newrelic.com"
+      "EU"      "https://log-api.eu.newrelic.com"
+      "STG"     "https://staging-log-api.newrelic.com"
+  -}}
+  {{- include "newrelic.common.endpoints.resolve" (dict "ctx" . "key" "logApiEndpoint" "endpoints" $endpoints) -}}
+{{- end -}}
+
+{{/* Returns the New Relic metric API endpoint for this region */}}
+{{- define "newrelic.common.metric_api_endpoint" -}}
+  {{- $endpoints := dict
+      "US"      "https://metric-api.newrelic.com"
+      "EU"      "https://metric-api.eu.newrelic.com"
+      "JP"      "https://metric-api.jp.newrelic.com"
+      "STG"     "https://staging-metric-api.newrelic.com"
+  -}}
+  {{- include "newrelic.common.endpoints.resolve" (dict "ctx" . "key" "metricApiEndpoint" "endpoints" $endpoints) -}}
+{{- end -}}
+
+{{/* Returns the New Relic OpAmp endpoint for this region */}}
+{{- define "newrelic.common.opamp_endpoint" -}}
+  {{- $endpoints := dict
+      "US"      "https://opamp.service.newrelic.com"
+      "EU"      "https://opamp.service.eu.newrelic.com"
+      "STG"     "https://opamp.staging-service.newrelic.com"
+  -}}
+  {{- include "newrelic.common.endpoints.resolve" (dict "ctx" . "key" "opampEndpoint" "endpoints" $endpoints) -}}
+{{- end -}}
+
+{{/* Returns the New Relic Otel endpoint for this region */}}
+{{- define "newrelic.common.otlp_endpoint" -}}
+  {{- $endpoints := dict
+      "US"      "https://otlp.nr-data.net"
+      "EU"      "https://otlp.eu01.nr-data.net"
+      "JP"      "https://otlp.jp.nr-data.net"
+      "STG"     "https://staging-otlp.nr-data.net"
+      "GOV"     "https://gov-otlp.nr-data.net"
+  -}}
+  {{- include "newrelic.common.endpoints.resolve" (dict "ctx" . "key" "otlpEndpoint" "endpoints" $endpoints) -}}
+{{- end -}}
+
+{{/* Returns the New Relic public keys endpoint for this region */}}
+{{- define "newrelic.common.public_keys_endpoint" -}}
+  {{- $endpoints := dict
+      "US"      "https://publickeys.newrelic.com"
+      "EU"      "https://publickeys.eu.newrelic.com"
+      "STG"     "https://staging-publickeys.newrelic.com"
+  -}}
+  {{- include "newrelic.common.endpoints.resolve" (dict "ctx" . "key" "publicKeysEndpoint" "endpoints" $endpoints) -}}
+{{- end -}}
+
+{{/* Returns the New Relic system identity OAuth endpoint for this region */}}
+{{- define "newrelic.common.system_identity_oauth_endpoint" -}}
+  {{- $endpoints := dict
+      "US"      "https://system-identity-oauth.service.newrelic.com"
+      "EU"      "https://system-identity-oauth.service.newrelic.com"
+      "JP"      "https://system-identity-oauth.service.newrelic.com"
+      "STG"     "https://system-identity-oauth.staging-service.newrelic.com"
+  -}}
+  {{- include "newrelic.common.endpoints.resolve" (dict "ctx" . "key" "systemIdentityOauthEndpoint" "endpoints" $endpoints) -}}
+{{- end -}}
+
+{{/* Returns the New Relic Synthetics Horde endpoint for this region */}}
+{{- define "newrelic.common.synthetics_horde_endpoint" -}}
+  {{- $endpoints := dict
+      "US"      "https://synthetics-horde.nr-data.net"
+      "EU"      "https://synthetics-horde.eu01.nr-data.net"
+      "JP"      "https://synthetics-horde.jp.nr-data.net"
+      "STG"     "https://staging-synthetics-horde.nr-data.net"
+  -}}
+  {{- include "newrelic.common.endpoints.resolve" (dict "ctx" . "key" "syntheticsHordeEndpoint" "endpoints" $endpoints) -}}
+{{- end -}}
+
+{{/* Returns the New Relic trace API endpoint for this region */}}
+{{- define "newrelic.common.trace_api_endpoint" -}}
+  {{- $endpoints := dict
+      "US"      "https://trace-api.newrelic.com"
+      "EU"      "https://trace-api.eu.newrelic.com"
+      "STG"     "https://staging-trace-api.newrelic.com"
+  -}}
+  {{- include "newrelic.common.endpoints.resolve" (dict "ctx" . "key" "traceApiEndpoint" "endpoints" $endpoints) -}}
+{{- end -}}

--- a/library/common-library/templates/_fedramp.tpl
+++ b/library/common-library/templates/_fedramp.tpl
@@ -4,7 +4,6 @@
 {{- end -}}
 
 
-
 {{- /* Return FedRAMP value directly ready to be templated */ -}}
 {{- define "newrelic.common.fedramp.enabled.value" -}}
   {{- include "newrelic.common.fedramp.enabled" . | default "false" -}}

--- a/library/common-library/templates/_fedramp.tpl
+++ b/library/common-library/templates/_fedramp.tpl
@@ -1,25 +1,11 @@
 {{- /* Defines the fedRAMP flag */ -}}
 {{- define "newrelic.common.fedramp.enabled" -}}
-    {{- if .Values.fedramp -}}
-        {{- if .Values.fedramp.enabled -}}
-            {{- .Values.fedramp.enabled -}}
-        {{- end -}}
-    {{- else if .Values.global -}}
-        {{- if .Values.global.fedramp -}}
-             {{- if .Values.global.fedramp.enabled -}}
-                {{- .Values.global.fedramp.enabled -}}
-            {{- end -}}
-        {{- end -}}
-    {{- end -}}
+  {{- include "newrelic.common.resolve" (dict "ctx" . "key" "fedramp.enabled") -}}
 {{- end -}}
 
 
 
 {{- /* Return FedRAMP value directly ready to be templated */ -}}
 {{- define "newrelic.common.fedramp.enabled.value" -}}
-{{- if include "newrelic.common.fedramp.enabled" . -}}
-true
-{{- else -}}
-false
-{{- end -}}
+  {{- include "newrelic.common.fedramp.enabled" . | default "false" -}}
 {{- end -}}

--- a/library/common-library/templates/_region.tpl
+++ b/library/common-library/templates/_region.tpl
@@ -9,9 +9,13 @@ Return the region that is being used by the user
 {{- /* Defaults */ -}}
 {{- $region := "us" -}}
 {{- if include "newrelic.common.nrStaging" . -}}
-  {{- $region = "staging" -}}
+  {{- $region = "stg" -}}
+{{- else if include "newrelic.common.fedramp.enabled" . -}}
+  {{- $region = "gov" -}}
 {{- else if include "newrelic.common.region._isEULicenseKey" . -}}
   {{- $region = "eu" -}}
+{{- else if include "newrelic.common.region._isJPLicenseKey" . -}}
+  {{- $region = "jp" -}}
 {{- end -}}
 
 {{- include "newrelic.common.region.validate" (include "newrelic.common.region._fromValues" . | default $region ) -}}
@@ -32,15 +36,18 @@ Usage: `include "newrelic.common.region.validate" "us"`
   US
 {{- else if eq $region "eu" -}}
   EU
-{{- else if eq $region "staging" -}}
-  Staging
-{{- else if eq $region "local" -}}
-  Local
+{{- else if eq $region "jp" -}}
+  JP
+{{- else if eq $region "stg" -}}
+  STG
+{{- else if eq $region "gov" -}}
+  GOV
+{{- else if eq $region "dev" -}}
+  DEV
 {{- else -}}
-  {{- fail (printf "the region provided is not valid: %s not in \"US\" \"EU\" \"Staging\" \"Local\"" .) -}}
+  {{- fail (printf "the region provided is not valid: %s not in \"US\" \"EU\" \"JP\" \"GOV\" \"STG\" \"DEV\"" .) -}}
 {{- end -}}
 {{- end -}}
-
 
 
 {{/*
@@ -49,13 +56,7 @@ More intelligence should be used to compute the region.
 This helper is for internal use.
 */}}
 {{- define "newrelic.common.region._fromValues" -}}
-{{- if .Values.region -}}
-  {{- .Values.region -}}
-{{- else if .Values.global -}}
-  {{- if .Values.global.region -}}
-    {{- .Values.global.region -}}
-  {{- end -}}
-{{- end -}}
+{{- include "newrelic.common.resolve" (dict "ctx" . "key" "region") -}}
 {{- end -}}
 
 
@@ -70,5 +71,61 @@ This helper is for internal use.
   {{- if hasPrefix "eu" $license -}}
     true
   {{- end -}}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
+Returns "true" if the license key is for Japan region or empty string (falsehood) if not.
+This helper is for internal use.
+*/}}
+{{- define "newrelic.common.region._isJPLicenseKey" -}}
+{{- if not (include "newrelic.common.license._usesCustomSecret" .) -}}
+  {{- $license := include "newrelic.common.license._licenseKey" . -}}
+  {{- if hasPrefix "jpx" $license -}}
+    true
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Returns "true" if the region is US or empty string (falsehood) if not. */}}
+{{- define "newrelic.common.region.is_us" -}}
+{{- if eq (include "newrelic.common.region" .) "US" -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/* Returns "true" if the region is EU or empty string (falsehood) if not. */}}
+{{- define "newrelic.common.region.is_eu" -}}
+{{- if eq (include "newrelic.common.region" .) "EU" -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/* Returns "true" if the region is Japan or empty string (falsehood) if not. */}}
+{{- define "newrelic.common.region.is_jp" -}}
+{{- if eq (include "newrelic.common.region" .) "JP" -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/* Returns "true" if the region is GOV (FedRAMP) or empty string (falsehood) if not. */}}
+{{- define "newrelic.common.region.is_gov" -}}
+{{- if eq (include "newrelic.common.region" .) "GOV" -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/* Returns "true" if the region is STG (staging) or empty string (falsehood) if not. */}}
+{{- define "newrelic.common.region.is_stg" -}}
+{{- if eq (include "newrelic.common.region" .) "STG" -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/* Returns "true" if the region is DEV (Development) or empty string (falsehood) if not. */}}
+{{- define "newrelic.common.region.is_dev" -}}
+{{- if eq (include "newrelic.common.region" .) "DEV" -}}
+true
 {{- end -}}
 {{- end -}}

--- a/library/common-library/templates/_resolve.tpl
+++ b/library/common-library/templates/_resolve.tpl
@@ -1,0 +1,39 @@
+{{/* resolve
+Used to lookup generic values that can be overridden at the global or chart level. Resolve will first check if the value is set at the chart level, then it will check if the value is set at the global level.
+If the value is not set at either level, it will return an empty string.
+
+We have this exact logic implemented in multiple places across the charts, so we are centralizing it here to avoid duplication
+and to enforce a consistent override pattern across the charts.
+
+Hierarchy should be: values → global values → defaults.
+
+use:
+{{- include "newrelic.common.resolve" (dict "ctx" . "key" "myKey") -}}
+
+example:
+{{- include "newrelic.common.resolve" (dict "ctx" . "key" "collector_endpoint") -}}
+*/}}
+
+{{- define "newrelic.common.resolve" -}}
+  {{- $ctx := .ctx -}}
+  {{- $keys := splitList "." .key -}}
+  {{- $root := $ctx.Values | default $ctx -}}
+
+  {{- $val := $root -}}
+  {{- range $keys -}}
+    {{- if $val -}}
+      {{- $val = index $val . -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if $val -}}
+    {{- $val -}}
+  {{- else if $root.global -}}
+    {{- include "newrelic.common.resolve" (dict "ctx" $root.global "key" .key) -}}
+  {{- end -}}
+{{- end -}}
+
+
+{{- define "newrelic.common.resolve_or" -}}
+  {{- include "newrelic.common.resolve" (dict "ctx" .ctx "key" .key) | default .default -}}
+{{- end -}}

--- a/library/common-library/templates/_resolve.tpl
+++ b/library/common-library/templates/_resolve.tpl
@@ -21,13 +21,17 @@ example:
 
   {{- $val := $root -}}
   {{- range $keys -}}
-    {{- if $val -}}
+    {{- if or ($val) (kindIs "bool" $val) -}}
       {{- $val = index $val . -}}
+    {{- else -}}
+      {{- $val = "" -}}
     {{- end -}}
   {{- end -}}
 
-  {{- if $val -}}
+  {{- if or ($val) -}}
     {{- $val -}}
+  {{- else if (kindIs "bool" $val) -}}
+    {{/* If we get here, we know $val is a falsy bool, so let's return a falsy statement */}}
   {{- else if $root.global -}}
     {{- include "newrelic.common.resolve" (dict "ctx" $root.global "key" .key) -}}
   {{- end -}}

--- a/library/common-library/templates/_resolve.tpl
+++ b/library/common-library/templates/_resolve.tpl
@@ -8,10 +8,12 @@ and to enforce a consistent override pattern across the charts.
 Hierarchy should be: values → global values → defaults.
 
 use:
-{{- include "newrelic.common.resolve" (dict "ctx" . "key" "myKey") -}}
+{{- include "newrelic.common.resolve" (dict "ctx" . "key" "myKey" ) -}}
+{{- include "newrelic.common.resolve" (dict "ctx" . "key" "myKey" "default" "defaulValue" ) -}}
 
-example:
+examples:
 {{- include "newrelic.common.resolve" (dict "ctx" . "key" "collector_endpoint") -}}
+{{- include "newrelic.common.resolve" (dict "ctx" . "key" "collector_endpoint" "default" "some value") -}}
 */}}
 
 {{- define "newrelic.common.resolve" -}}
@@ -19,25 +21,22 @@ example:
   {{- $keys := splitList "." .key -}}
   {{- $root := $ctx.Values | default $ctx -}}
 
-  {{- $val := $root -}}
+  {{- $value := $root -}}
   {{- range $keys -}}
-    {{- if or ($val) (kindIs "bool" $val) -}}
-      {{- $val = index $val . -}}
+    {{- if ($value) -}}
+      {{- $value = index $value . -}}
     {{- else -}}
-      {{- $val = "" -}}
+      {{- $value = "" -}}
     {{- end -}}
   {{- end -}}
 
-  {{- if or ($val) -}}
-    {{- $val -}}
-  {{- else if (kindIs "bool" $val) -}}
-    {{/* If we get here, we know $val is a falsy bool, so let's return a falsy statement */}}
+  {{- if ($value) -}}
+    {{- $value -}}
+  {{- else if (kindIs "bool" $value) -}}
+    {{/* If we get here, we know $value is a falsy bool, so let's return a falsy statement */}}
   {{- else if $root.global -}}
     {{- include "newrelic.common.resolve" (dict "ctx" $root.global "key" .key) -}}
+  {{- else if .default -}}
+    .default
   {{- end -}}
-{{- end -}}
-
-
-{{- define "newrelic.common.resolve_or" -}}
-  {{- include "newrelic.common.resolve" (dict "ctx" .ctx "key" .key) | default .default -}}
 {{- end -}}


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

#### Which issue this PR fixes
Adds support for Japan and GOV regions in region TPL. 
Talking with DB we decided to make region names more uniform so shortened staging and local to "dev"
Which is why we are bumping the chart version to 2.0.0

Digging through this chart it looks like the ONLY thing that regions are used for is to set ULS, which makes sense. There really shouldn't be any changes to our charts other than collection endpoints.

So I scraped all of the endpoints in this repo, and created an "endpoint" template that uses the region template to automatically give the right endpoint. I flushed out the JP endpoints using Discovery and to decide the name of each endpoint. 

Added some helper functions for users who really want to know what region they are in for reasons other than endpoints. 

Also added some functions to make checking for value overrides in the root and global fields a lot easier. 
This is probably the number one duplicated code block that we have. So having a function we can call instead of re-writing this logic over and over is a huge boon to our helm charts. 

#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Tell the world about the latest changes in the chart.
<!--END-RELEASE-NOTES-->
