### PR TITLE
[agent-control-deployment] feat(fluxless): cd_enabled option

### DIFF
--- a/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 
 type: application
 
-version: 1.6.6
+version: 1.7.0
 
 dependencies:
   - name: common-library

--- a/charts/agent-control-deployment/README.md
+++ b/charts/agent-control-deployment/README.md
@@ -74,7 +74,7 @@ In the example below, open-telemetry is a managed agent that will be deployed.
 agents:
   open-telemetry:
     # -- Agent type <namespace>/<name>:<version>
-    agent_type: newrelic/io.opentelemetry.collector:0.1.0
+    agent_type: newrelic/com.newrelic.opentelemetry.collector:0.1.0
 ```
 </td>
 		</tr>
@@ -438,19 +438,13 @@ proxy:
 			<td>toolkitImage</td>
 			<td>object</td>
 			<td>See <a href="values.yaml">values.yaml</a></td>
-			<td>The image that contains the necessary tools to setup Agent Control</td>
+			<td>The image that contains the necessary tools to setup Agent Control The tag should be aligned with  `image.tag`.</td>
 		</tr>
 		<tr>
 			<td>toolkitImage.pullSecrets</td>
 			<td>list</td>
 			<td>`[]`</td>
 			<td>The secrets that are needed to pull images from a custom registry.</td>
-		</tr>
-		<tr>
-			<td>toolkitImage.tag</td>
-			<td>string</td>
-			<td>`"1.11.0"`</td>
-			<td>Should be aligned with `image.tag`</td>
 		</tr>
 		<tr>
 			<td>verboseLog</td>

--- a/charts/agent-control-deployment/README.md
+++ b/charts/agent-control-deployment/README.md
@@ -103,6 +103,12 @@ agents:
 			<td>The name of the Kubernetes Secret resource containing the credentials.</td>
 		</tr>
 		<tr>
+			<td>config.cdEnabled</td>
+			<td>bool</td>
+			<td>true</td>
+			<td>If disabled agentControl will assume that no CD is available. I.e. no flux object will be created and flux will not be upgraded or monitored.</td>
+		</tr>
+		<tr>
 			<td>config.cdReleaseName</td>
 			<td>string</td>
 			<td>agent-control-cd</td>

--- a/charts/agent-control-deployment/templates/_helpers.tpl
+++ b/charts/agent-control-deployment/templates/_helpers.tpl
@@ -72,6 +72,7 @@ cluster name, licenses, and custom attributes
 {{- /* Add ac_remote_update and cd_remote_update to the config */ -}}
 {{- $k8s = mustMerge $k8s (dict "ac_remote_update" .Values.config.acRemoteUpdate "cd_remote_update" .Values.config.cdRemoteUpdate) -}}
 {{- $k8s = mustMerge $k8s (dict "ac_release_name" .Release.Name "cd_release_name" .Values.config.cdReleaseName) -}}
+{{- $k8s = mustMerge $k8s (dict "cd_enabled" .Values.config.cdEnabled) -}}
 {{- $authSecret := .Values.config.authSecret | default dict -}}
 {{- $sName := $authSecret.secretName | default "agent-control-auth" -}}
 {{- $sKey  := $authSecret.secretKeyName | default "private_key" -}}

--- a/charts/agent-control-deployment/tests/configmap_agentcontrol_config_test.yaml
+++ b/charts/agent-control-deployment/tests/configmap_agentcontrol_config_test.yaml
@@ -24,6 +24,7 @@ tests:
               auth_secret:
                 secret_key_name: private_key
                 secret_name: agent-control-auth
+              cd_enabled: true
               cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster
@@ -53,6 +54,7 @@ tests:
               auth_secret:
                 secret_key_name: private_key
                 secret_name: agent-control-auth
+              cd_enabled: true
               cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster
@@ -89,6 +91,7 @@ tests:
               auth_secret:
                 secret_key_name: private_key
                 secret_name: agent-control-auth
+              cd_enabled: true
               cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster
@@ -117,6 +120,7 @@ tests:
               auth_secret:
                 secret_key_name: private_key
                 secret_name: agent-control-auth
+              cd_enabled: true
               cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster
@@ -145,6 +149,7 @@ tests:
               auth_secret:
                 secret_key_name: private_key
                 secret_name: agent-control-auth
+              cd_enabled: true
               cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster
@@ -179,6 +184,7 @@ tests:
               auth_secret:
                 secret_key_name: private_key
                 secret_name: agent-control-auth
+              cd_enabled: true
               cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster
@@ -215,6 +221,7 @@ tests:
               auth_secret:
                 secret_key_name: private_key
                 secret_name: agent-control-auth
+              cd_enabled: true
               cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster
@@ -256,6 +263,7 @@ tests:
               auth_secret:
                 secret_key_name: private_key
                 secret_name: agent-control-auth
+              cd_enabled: true
               cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: config-cluster
@@ -291,6 +299,7 @@ tests:
               auth_secret:
                 secret_key_name: private_key
                 secret_name: agent-control-auth
+              cd_enabled: true
               cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster
@@ -320,6 +329,7 @@ tests:
               auth_secret:
                 secret_key_name: private_key
                 secret_name: agent-control-auth
+              cd_enabled: true
               cd_release_name: agent-control-cd
               cd_remote_update: false
               cluster_name: my-cluster
@@ -418,6 +428,7 @@ tests:
               auth_secret:
                 secret_key_name: private_key
                 secret_name: agent-control-auth
+              cd_enabled: true
               cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster
@@ -449,6 +460,7 @@ tests:
               auth_secret:
                 secret_key_name: private_key
                 secret_name: agent-control-auth
+              cd_enabled: true
               cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster
@@ -481,6 +493,7 @@ tests:
               auth_secret:
                 secret_key_name: private_key
                 secret_name: agent-control-auth
+              cd_enabled: true
               cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster
@@ -520,6 +533,7 @@ tests:
               auth_secret:
                 secret_key_name: private_key
                 secret_name: agent-control-auth
+              cd_enabled: true
               cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster
@@ -561,6 +575,7 @@ tests:
               auth_secret:
                 secret_key_name: private_key
                 secret_name: agent-control-auth
+              cd_enabled: true
               cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster
@@ -605,6 +620,7 @@ tests:
               auth_secret:
                 secret_key_name: private_key
                 secret_name: agent-control-auth
+              cd_enabled: true
               cd_release_name: agent-control-cd
               cd_remote_update: true
               cluster_name: my-cluster

--- a/charts/agent-control-deployment/values.yaml
+++ b/charts/agent-control-deployment/values.yaml
@@ -173,6 +173,9 @@ config:
   # -- The name of the release for the CD chart.
   # @default -- agent-control-cd
   cdReleaseName: agent-control-cd
+  # -- If disabled agentControl will assume that no CD is available. I.e. no flux object will be created and flux will not be upgraded or monitored.
+  # @default -- true
+  cdEnabled: true
   # -- Configuration for the authentication secret needed for OpAMP connection.
   authSecret:
     # -- (string) The name of the Kubernetes Secret resource containing the credentials.

--- a/charts/agent-control-deployment/values.yaml
+++ b/charts/agent-control-deployment/values.yaml
@@ -19,7 +19,7 @@ subAgentsNamespace: "newrelic"
 image:
   registry:
   repository: newrelic/newrelic-agent-control
-  tag: "1.12.0"
+  tag: "1.14.0"
   pullPolicy: IfNotPresent
   # -- The secrets that are needed to pull images from a custom registry.
   pullSecrets: []
@@ -31,7 +31,7 @@ image:
 toolkitImage:
   registry:
   repository: newrelic/newrelic-agent-control-cli
-  tag: "1.12.0"
+  tag: "1.14.0"
   pullPolicy: IfNotPresent
   # -- The secrets that are needed to pull images from a custom registry.
   pullSecrets: []
@@ -135,7 +135,7 @@ config:
   # agents:
   #   open-telemetry:
   #     # -- Agent type <namespace>/<name>:<version>
-  #     agent_type: agent_type: newrelic/com.newrelic.opentelemetry.collector:0.1.0
+  #     agent_type: newrelic/com.newrelic.opentelemetry.collector:0.1.0
   # ```
   #
   # @default -- `{}` (See <a href="values.yaml">values.yaml</a>)


### PR DESCRIPTION

#### What this PR does / why we need it:
Related to https://github.com/newrelic/newrelic-agent-control/pull/2470

Once this is merged a new PR is going to be created to do the same for the bootstrap 
