### PR TITLE
[agent-control-deployment] adjust rbac to support config maps [NR-552592]

### DIFF
--- a/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 
 type: application
 
-version: 1.6.4
+version: 1.6.5
 
 dependencies:
   - name: common-library

--- a/charts/agent-control-deployment/templates/rbac.yaml
+++ b/charts/agent-control-deployment/templates/rbac.yaml
@@ -6,6 +6,8 @@ metadata:
     {{- include "newrelic.common.labels" . | nindent 4 }}
   name: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "resources") }}
 rules:
+  ###
+  # AC uses config-maps to handle internal state and also supports them as resources that can be part of an Agent Type
   - apiGroups: [ "" ]
     resources: [ "configmaps" ]
     verbs:
@@ -16,6 +18,7 @@ rules:
       - deletecollection
       - patch
       - update
+      - watch
   - apiGroups: [ "" ]
     resources: [ "namespaces" ]
     verbs:


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds the `watch` verb for ConfigMaps to the existing rbac. This allows support for ConfigMaps in AC's agents.

#### Special notes for your reviewer:

If a more restrictive rbac was required the user could configure it through `.Values.rbac.create: false`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Tell the world about the latest changes in the chart.
<!--END-RELEASE-NOTES-->
