### PR TITLE
[pipeline-control-gateway] NR-551079: add DaemonSet support                                                                                                                                          

### DIFF
--- a/charts/pipeline-control-gateway/Chart.yaml
+++ b/charts/pipeline-control-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: pipeline-control-gateway
 type: application
-version: 2.2.1
+version: 2.3.0
 dependencies:
   - name: common-library
     version: 1.4.0

--- a/charts/pipeline-control-gateway/templates/_affinity.tpl
+++ b/charts/pipeline-control-gateway/templates/_affinity.tpl
@@ -8,3 +8,14 @@ A helper to return the affinity to apply to the deployment.
     {{- include "newrelic.common.affinity" . -}}
 {{- end -}}
 {{- end -}}
+
+{{- /*
+A helper to return the affinity to apply to the daemonset.
+*/ -}}
+{{- define "nrKubernetesOtel.daemonset.affinity" -}}
+{{- if .Values.daemonset.affinity -}}
+    {{- toYaml .Values.daemonset.affinity -}}
+{{- else if include "newrelic.common.affinity" . -}}
+    {{- include "newrelic.common.affinity" . -}}
+{{- end -}}
+{{- end -}}

--- a/charts/pipeline-control-gateway/templates/_config_map.tpl
+++ b/charts/pipeline-control-gateway/templates/_config_map.tpl
@@ -8,3 +8,14 @@
     {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{- /* Defines if the daemonset config map has to be created or not */ -}}
+{{- define "nrKubernetesOtel.daemonset.configMap.config" -}}
+
+{{- /* Look for a local creation of a daemonset config map */ -}}
+{{- if get .Values.daemonset "configMap" | kindIs "map" -}}
+    {{- if .Values.daemonset.configMap.config -}}
+        {{- toYaml .Values.daemonset.configMap.config -}}
+    {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/pipeline-control-gateway/templates/_naming.tpl
+++ b/charts/pipeline-control-gateway/templates/_naming.tpl
@@ -11,6 +11,10 @@
 {{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "config") -}}
 {{- end -}}
 
+{{- define "nrKubernetesOtel.daemonset.configMap.fullname" -}}
+{{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "daemonset-config") -}}
+{{- end -}}
+
 {{- define "nrKubernetesOtel.hpa.fullname" -}}
 {{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "hpa") -}}
 {{- end -}}

--- a/charts/pipeline-control-gateway/templates/_node_selector.tpl
+++ b/charts/pipeline-control-gateway/templates/_node_selector.tpl
@@ -8,3 +8,14 @@ A helper to return the nodeSelector to apply to the deployment.
     {{- include "newrelic.common.nodeSelector" . -}}
 {{- end -}}
 {{- end -}}
+
+{{- /*
+A helper to return the nodeSelector to apply to the daemonset.
+*/ -}}
+{{- define "nrKubernetesOtel.daemonset.nodeSelector" -}}
+{{- if .Values.daemonset.nodeSelector -}}
+    {{- toYaml .Values.daemonset.nodeSelector -}}
+{{- else if include "newrelic.common.nodeSelector" . -}}
+    {{- include "newrelic.common.nodeSelector" . -}}
+{{- end -}}
+{{- end -}}

--- a/charts/pipeline-control-gateway/templates/_security_context.tpl
+++ b/charts/pipeline-control-gateway/templates/_security_context.tpl
@@ -19,3 +19,25 @@ A helper to return the container security context to apply to the deployment.
     {{- include "newrelic.common.securityContext.container" . -}}
 {{- end -}}
 {{- end -}}
+
+{{- /*
+A helper to return the pod security context to apply to the daemonset.
+*/ -}}
+{{- define "nrKubernetesOtel.daemonset.securityContext.pod" -}}
+{{- if .Values.daemonset.podSecurityContext -}}
+    {{- toYaml .Values.daemonset.podSecurityContext -}}
+{{- else if include "newrelic.common.securityContext.pod" . -}}
+    {{- include "newrelic.common.securityContext.pod" . -}}
+{{- end -}}
+{{- end -}}
+
+{{- /*
+A helper to return the container security context to apply to the daemonset.
+*/ -}}
+{{- define "nrKubernetesOtel.daemonset.securityContext.container" -}}
+{{- if .Values.daemonset.containerSecurityContext -}}
+    {{- toYaml .Values.daemonset.containerSecurityContext -}}
+{{- else if include "newrelic.common.securityContext.container" . -}}
+    {{- include "newrelic.common.securityContext.container" . -}}
+{{- end -}}
+{{- end -}}

--- a/charts/pipeline-control-gateway/templates/_tolerations.tpl
+++ b/charts/pipeline-control-gateway/templates/_tolerations.tpl
@@ -8,3 +8,14 @@ A helper to return the tolerations to apply to the deployment.
     {{- include "newrelic.common.tolerations" . -}}
 {{- end -}}
 {{- end -}}
+
+{{- /*
+A helper to return the tolerations to apply to the daemonset.
+*/ -}}
+{{- define "nrKubernetesOtel.daemonset.tolerations" -}}
+{{- if .Values.daemonset.tolerations -}}
+    {{- toYaml .Values.daemonset.tolerations -}}
+{{- else if include "newrelic.common.tolerations" . -}}
+    {{- include "newrelic.common.tolerations" . -}}
+{{- end -}}
+{{- end -}}

--- a/charts/pipeline-control-gateway/templates/daemonset-configmap.yaml
+++ b/charts/pipeline-control-gateway/templates/daemonset-configmap.yaml
@@ -1,8 +1,8 @@
-{{- if not .Values.daemonset.enabled }}
+{{- if .Values.daemonset.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "nrKubernetesOtel.deployment.configMap.fullname" . }}
+  name: {{ include "nrKubernetesOtel.daemonset.configMap.fullname" . }}
   namespace: {{ .Release.Namespace }}
 data:
   gateway-config.yaml: |
@@ -10,11 +10,11 @@ data:
       Metric:
         - interval.ms
         - metricName
-  deployment-config.yaml: |
-    {{- with include "nrKubernetesOtel.deployment.configMap.config" . }}
+  daemonset-config.yaml: |
+    {{- with include "nrKubernetesOtel.daemonset.configMap.config" . }}
     {{- . | nindent 4 }}
     {{- end }}
-    {{- if not (include "nrKubernetesOtel.deployment.configMap.config" .) }}
+    {{- if not (include "nrKubernetesOtel.daemonset.configMap.config" .) }}
     {{- if .Values.generated }}
     {{- tpl (.Values.generated | toYaml) . | nindent 4 }}
     {{- else }}

--- a/charts/pipeline-control-gateway/templates/daemonset.yaml
+++ b/charts/pipeline-control-gateway/templates/daemonset.yaml
@@ -1,0 +1,146 @@
+{{- if .Values.daemonset.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "nrKubernetesOtel.daemonset.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "newrelic.common.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "newrelic.common.labels.selectorLabels" . | nindent 6 }}
+      component: daemonset
+  updateStrategy:
+    type: {{ .Values.daemonset.updateStrategy.type }}
+    {{- if eq .Values.daemonset.updateStrategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.daemonset.updateStrategy.maxUnavailable }}
+    {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "newrelic.common.labels.podLabels" . | nindent 8 }}
+        component: daemonset
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/daemonset-configmap.yaml") . | sha256sum }}
+        {{- with .Values.daemonset.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}
+      {{- with include "nrKubernetesOtel.daemonset.securityContext.pod" . }}
+      securityContext:
+        {{- . | nindent 8 }}
+      {{- end }}
+      {{- with include "newrelic.common.priorityClassName" . }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with include "newrelic.common.dnsConfig" . }}
+      dnsConfig:
+        {{- . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: pipeline-control-gateway
+          {{- with include "nrKubernetesOtel.daemonset.securityContext.container" . }}
+          securityContext:
+            {{- . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ["./pipeline-control-gateway", "--config", "/config/daemonset-config.yaml"]
+          resources:
+            {{- toYaml .Values.daemonset.resources | nindent 12 }}
+          {{- with .Values.daemonset.envsFrom }}
+          envFrom:
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
+          env:
+            - name: NEW_RELIC_HOST
+              value: {{ include "nrKubernetesOtel.NrHost.endpoint" . }}
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: GATEWAY_CONFIG_FILE_PATH
+              value: /config/gateway-config.yaml
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: NEW_RELIC_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "newrelic.common.license.secretName" . }}
+                  key: {{ include "newrelic.common.license.secretKeyName" . }}
+            - name: FLEET_ID
+              value: "{{ .Values.fleet_id }}"
+            {{- with .Values.daemonset.envs }}
+            {{- . | toYaml | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: otlp-http
+              containerPort: {{ .Values.ports.otlpHttp }}
+              protocol: TCP
+            - name: otlp-grpc
+              containerPort: {{ .Values.ports.otlpGrpc }}
+              protocol: TCP
+            - name: nr-http
+              containerPort: {{ .Values.ports.nrHttp }}
+              protocol: TCP
+            - name: health-http
+              containerPort: {{ .Values.ports.healthHttp }}
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health/status
+              port: {{ .Values.ports.healthHttp }}
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /health/status
+              port: {{ .Values.ports.healthHttp }}
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          volumeMounts:
+            - name: daemonset-config
+              mountPath: /config
+      volumes:
+        - name: daemonset-config
+          configMap:
+            name: {{ include "nrKubernetesOtel.daemonset.configMap.fullname" . }}
+      {{- with include "nrKubernetesOtel.daemonset.nodeSelector" . }}
+      nodeSelector:
+        {{- . | nindent 8 }}
+      {{- end }}
+      {{- with include "nrKubernetesOtel.daemonset.affinity" . }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
+      {{- with include "nrKubernetesOtel.daemonset.tolerations" . }}
+      tolerations:
+        {{- . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/pipeline-control-gateway/templates/deployment.yaml
+++ b/charts/pipeline-control-gateway/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.daemonset.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -202,3 +203,4 @@ spec:
       tolerations:
         {{- . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/pipeline-control-gateway/templates/hpa.yaml
+++ b/charts/pipeline-control-gateway/templates/hpa.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.daemonset.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -29,3 +30,4 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+{{- end }}

--- a/charts/pipeline-control-gateway/templates/service.yaml
+++ b/charts/pipeline-control-gateway/templates/service.yaml
@@ -22,5 +22,9 @@ spec:
       targetPort: {{ .Values.ports.otlpGrpc }}
   selector:
     {{- include "newrelic.common.labels.selectorLabels" . | nindent 4 }}
+    {{- if .Values.daemonset.enabled }}
+    component: daemonset
+    {{- else }}
     component: deployment
+    {{- end }}
   internalTrafficPolicy: Cluster

--- a/charts/pipeline-control-gateway/values.yaml
+++ b/charts/pipeline-control-gateway/values.yaml
@@ -3,6 +3,45 @@
 # Declare variables to be passed into your templates.
 
 fullnameOverride: "pipeline-control-gateway"
+
+daemonset:
+  # -- Set to true to deploy as a DaemonSet (one pod per node) instead of a Deployment.
+  # When enabled, the HPA and Deployment are not created.
+  enabled: false
+  # -- Sets daemonset pod node selector. Overrides `nodeSelector` and `global.nodeSelector`
+  nodeSelector: {}
+  # -- Sets daemonset pod tolerations. Overrides `tolerations` and `global.tolerations`
+  tolerations: []
+  # -- Sets daemonset pod affinities. Overrides `affinity` and `global.affinity`
+  affinity: {}
+  # -- Annotations to be added to daemonset pods.
+  podAnnotations: {}
+  # -- Sets security context (at pod level) for the daemonset. Overrides `podSecurityContext` and `global.podSecurityContext`
+  podSecurityContext: {}
+  # -- Sets security context (at container level) for the daemonset. Overrides `containerSecurityContext` and `global.containerSecurityContext`
+  containerSecurityContext: {}
+  # -- Sets resources for the daemonset.
+  resources:
+    requests:
+      memory: "2048Mi"
+      cpu: "1000m"
+    limits:
+      memory: "2048Mi"
+      cpu: "1000m"
+  # -- Update strategy for the daemonset.
+  updateStrategy:
+    type: RollingUpdate
+    maxUnavailable: 1
+  # -- Additional environment variables for the daemonset container.
+  envs: []
+  # -- Additional envFrom sources for the daemonset container.
+  envsFrom: []
+  # -- Settings for daemonset configmap
+  # @default -- See `values.yaml`
+  configMap:
+    # -- OpenTelemetry config for the daemonset. If set, overrides default config.
+    config: {}
+
 autoscaling:
   minReplicas: 2
   maxReplicas: 10


### PR DESCRIPTION
  Is this a new chart:
  NO

  What this PR does / why we need it:
  Adds DaemonSet support to the pipeline-control-gateway chart. When daemonset.enabled is set to true, the chart deploys PCG as a DaemonSet (one pod per node) instead of a Deployment with
  HPA. This enables node-local telemetry collection patterns.

  Key changes:
  - New daemonset.yaml and daemonset-configmap.yaml templates
  - Helper templates extended for daemonset-specific nodeSelector, tolerations, affinity, and securityContext
  - Deployment, deployment-configmap, and HPA are conditionally disabled when daemonset mode is enabled
  - Service selector switches between deployment/daemonset component labels
  - DaemonSet uses same resource defaults as Deployment (2048Mi/1000m)
  - DaemonSet configmap uses same Values.generated pattern as deployment configmap
  - FLEET_ID and NEW_RELIC_HOST env vars included in daemonset template

  Special notes for your reviewer:
  - The daemonset and deployment modes are mutually exclusive, controlled by daemonset.enabled (default: false)
  - The daemonset configmap uses the same Values.generated pipeline configuration as the deployment configmap
  - All existing deployment functionality remains unchanged when daemonset.enabled is false
  - DaemonSet includes updateStrategy (RollingUpdate, maxUnavailable: 1)
  - Rebased on latest master (includes multi-fleet/fleet_id changes)

  Checklist:
  - Variables are documented in the README.md
  - Title of the PR starts with chart name