### PR TITLE
[agent-control-bootstrap] feat(watch): watching resources

### DIFF
--- a/charts/agent-control-bootstrap/Chart.yaml
+++ b/charts/agent-control-bootstrap/Chart.yaml
@@ -3,7 +3,7 @@ name: agent-control-bootstrap
 description: Bootstraps New Relic' Agent Control
 
 type: application
-version: 1.7.3
+version: 1.7.4
 # renovate: chartName=agent-control-deployment
 appVersion: 1.6.4
 annotations:

--- a/charts/agent-control-bootstrap/templates/rbac-cd.yaml
+++ b/charts/agent-control-bootstrap/templates/rbac-cd.yaml
@@ -13,14 +13,14 @@ rules:
   # Namespaces - Required to create Flux namespace and agents namespace
   - apiGroups: [ "" ]
     resources: [ namespaces ]
-    verbs: [ get, list, create, patch, update ]
+    verbs: [ get, list, watch, create, patch, update ]
 
   # CRDs - Required to install Flux CRDs
   # Note: 'delete' removed as installation job only creates/updates CRDs, never deletes them.
   # Uninstall job has separate permissions for deletion.
   - apiGroups: [ apiextensions.k8s.io ]
     resources: [ customresourcedefinitions ]
-    verbs: [ get, list, create, update, patch ]
+    verbs: [ get, list, watch, create, update, patch ]
 
   # Flux Resources - Required for Agent Control to create HelmRepository and HelmRelease
   # Note: Only helmrepositories and helmreleases are needed. The installation job creates these
@@ -50,7 +50,7 @@ rules:
     resources:
       - clusterroles
       - clusterrolebindings
-    verbs: [ get, list, create, update, patch, bind, escalate ]
+    verbs: [ get, list, watch, create, update, patch, bind, escalate ]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -79,7 +79,7 @@ rules:
   # ServiceAccounts - Required to create Flux controller service accounts
   - apiGroups: [ "" ]
     resources: [ serviceaccounts ]
-    verbs: [ get, list, create, update, patch, delete ]
+    verbs: [ get, list, watch, create, update, patch, delete ]
 
   # RBAC - Required to create Roles for Flux controllers (namespace-scoped)
   # Security Note: The 'bind' and 'escalate' verbs are required for bootstrapping Flux.
@@ -92,7 +92,7 @@ rules:
     resources:
       - roles
       - rolebindings
-    verbs: [ get, list, create, update, patch, delete, bind, escalate ]
+    verbs: [ get, list, watch, create, update, patch, delete, bind, escalate ]
 
   # Deployments - Required for Flux controllers and agent workloads
   - apiGroups: [ apps ]
@@ -122,7 +122,7 @@ rules:
   # Services - Required for Flux notification webhook
   - apiGroups: [ "" ]
     resources: [ services ]
-    verbs: [ get, list, create, update, patch, delete ]
+    verbs: [ get, list, watch, create, update, patch, delete ]
 
   # Events - Required for Flux to emit events
   - apiGroups: [ "" ]
@@ -132,7 +132,7 @@ rules:
   # Leases - Required for Flux leader election
   - apiGroups: [ coordination.k8s.io ]
     resources: [ leases ]
-    verbs: [ get, list, create, update, patch, delete ]
+    verbs: [ get, list, watch create, update, patch, delete ]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This fix is to mitigate an issue that we are facing from time to time with the ci/cd pipeline https://github.com/newrelic/newrelic-agent-control/actions/runs/25091889289/job/73519561304

The root cause seems to be a race condition in the Helm binary itself, a watch is usually not needed since all resources are created and ready without the need to wait on them with a watch.