### PR TITLE
[agent-control-deployment] bump common-library dependency [NR-554515]

### DIFF
--- a/charts/agent-control-deployment/Chart.lock
+++ b/charts/agent-control-deployment/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: https://helm-charts.newrelic.com
-  version: 1.4.0
-digest: sha256:5655aeb5921ac47b5413c3873218309e4a5a78bc0d75d6dd7aabe13ad0e63cc7
-generated: "2026-01-13T17:46:47.864451-08:00"
+  version: 2.2.0
+digest: sha256:6c7e1a82e5483ac9762ee5f213234c2fbdd56fa7bdfbfe747e8221a10640680b
+generated: "2026-05-13T08:46:23.323657+02:00"

--- a/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control-deployment/Chart.yaml
@@ -8,7 +8,7 @@ version: 1.7.1
 
 dependencies:
   - name: common-library
-    version: 1.4.0
+    version: 2.2.0
     repository: https://helm-charts.newrelic.com
 
 keywords:

--- a/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 
 type: application
 
-version: 1.7.1
+version: 1.7.2
 
 dependencies:
   - name: common-library

--- a/charts/agent-control-deployment/templates/_helpers.tpl
+++ b/charts/agent-control-deployment/templates/_helpers.tpl
@@ -1,59 +1,28 @@
 {{- /*
-Return to which endpoint should the agent control connect to get fleet_control data
+Return the OpAMP endpoint the agent control connects to for fleet_control data.
+The base URL is resolved per-region by the common-library helper, which also
+honors overrides via `.Values.opampEndpoint` / `.Values.global.opampEndpoint`.
 */ -}}
 {{- define "newrelic-agent-control.config.endpoints.fleet_control" -}}
-{{- $region := include "newrelic.common.region" . -}}
-
-{{- if eq $region "Staging" -}}
-  https://opamp.staging-service.newrelic.com/v1/opamp
-{{- else if eq $region "EU" -}}
-  https://opamp.service.eu.newrelic.com/v1/opamp
-{{- else if eq $region "US" -}}
-  https://opamp.service.newrelic.com/v1/opamp
-{{- else if eq $region "Local" -}}
-  {{- /* Accessing the value directly without protection. A developer should now how to read the error. */ -}}
-  {{ .Values.development.backend.fleet_control }}
-{{- else -}}
-  {{- fail "Unknown/unsupported region set for this chart" -}}
-{{- end -}}
+{{ include "newrelic.common.opamp_endpoint" . }}/v1/opamp
 {{- end -}}
 
 {{- /*
-Return to which endpoint should the agent control connect to get the public key for signature validation
+Return the endpoint from which the agent control fetches the public key used
+for signature validation. Override via `.Values.publicKeysEndpoint` /
+`.Values.global.publicKeysEndpoint`.
 */ -}}
 {{- define "newrelic-agent-control.config.endpoints.public_key_server_url" -}}
-{{- $region := include "newrelic.common.region" . -}}
-
-{{- if eq $region "Staging" -}}
-  https://staging-publickeys.newrelic.com/r/blob-management/global/agentconfiguration/jwks.json
-{{- else if eq $region "EU" -}}
-  https://publickeys.eu.newrelic.com/r/blob-management/global/agentconfiguration/jwks.json
-{{- else if eq $region "US" -}}
-  https://publickeys.newrelic.com/r/blob-management/global/agentconfiguration/jwks.json
-{{- else -}}
-  {{- fail "Unknown/unsupported region set for this chart" -}}
+{{ include "newrelic.common.public_keys_endpoint" . }}/r/blob-management/global/agentconfiguration/jwks.json
 {{- end -}}
-{{- end -}}
-
 
 {{- /*
-Return to which endpoint should the agent control ask to renew its token
+Return the endpoint the agent control uses to renew its auth token. Override
+via `.Values.systemIdentityOauthEndpoint` /
+`.Values.global.systemIdentityOauthEndpoint`.
 */ -}}
 {{- define "newrelic-agent-control.config.endpoints.tokenRenewal" -}}
-{{- $region := include "newrelic.common.region" . -}}
-
-{{- if eq $region "Staging" -}}
-  https://system-identity-oauth.staging-service.newrelic.com/oauth2/token
-{{- else if eq $region "EU" -}}
-  https://system-identity-oauth.service.newrelic.com/oauth2/token
-{{- else if eq $region "US" -}}
-  https://system-identity-oauth.service.newrelic.com/oauth2/token
-{{- else if eq $region "Local" -}}
-  {{- /* Accessing the value directly without protection. A developer should now how to read the error. */ -}}
-  {{ .Values.development.backend.tokenRenewal }}
-{{- else -}}
-  {{- fail "Unknown/unsupported region set for this chart" -}}
-{{- end -}}
+{{ include "newrelic.common.system_identity_oauth_endpoint" . }}/oauth2/token
 {{- end -}}
 
 {{- /*

--- a/charts/agent-control-deployment/tests/configmap_agentcontrol_config_test.yaml
+++ b/charts/agent-control-deployment/tests/configmap_agentcontrol_config_test.yaml
@@ -276,109 +276,50 @@ tests:
             test: value
             test2: value2
 
-  - it: agent control's config always include cluster_name, namespace, defaults, and honor the EU endpoint.
+  - it: region=eu routes fleet_control through the EU endpoints
     set:
       cluster: my-cluster
       region: eu
     asserts:
-      - equal:
+      - matchRegex:
           path: data["local_config"]
-          value: |
-            agents: {}
-            fleet_control:
-              auth_config:
-                private_key_path: /etc/newrelic-agent-control/keys/from-secret.key
-                provider: local
-                token_url: https://system-identity-oauth.service.newrelic.com/oauth2/token
-              endpoint: https://opamp.service.eu.newrelic.com/v1/opamp
-              signature_validation:
-                public_key_server_url: https://publickeys.eu.newrelic.com/r/blob-management/global/agentconfiguration/jwks.json
-            k8s:
-              ac_release_name: my-release
-              ac_remote_update: true
-              auth_secret:
-                secret_key_name: private_key
-                secret_name: agent-control-auth
-              cd_enabled: true
-              cd_release_name: agent-control-cd
-              cd_remote_update: true
-              cluster_name: my-cluster
-              namespace: my-namespace
-              namespace_agents: newrelic
-            server:
-              enabled: true
-              host: 0.0.0.0
-              port: 51200
+          pattern: 'token_url: https://system-identity-oauth\.service\.newrelic\.com/oauth2/token'
+      - matchRegex:
+          path: data["local_config"]
+          pattern: 'endpoint: https://opamp\.service\.eu\.newrelic\.com/v1/opamp'
+      - matchRegex:
+          path: data["local_config"]
+          pattern: 'public_key_server_url: https://publickeys\.eu\.newrelic\.com/r/blob-management/global/agentconfiguration/jwks\.json'
 
-  - it: agent control's config honors the JP endpoints
-    # NOTE: requires common-library >= 2.2.0 (JP entries for opamp/public-keys endpoints).
-    # On common-library 2.1.1 this fails with "This chart does not have support for the region provided 'JP'".
+  - it: region=jp routes fleet_control through the JP endpoints
     set:
       cluster: my-cluster
       region: jp
     asserts:
-      - equal:
+      - matchRegex:
           path: data["local_config"]
-          value: |
-            agents: {}
-            fleet_control:
-              auth_config:
-                private_key_path: /etc/newrelic-agent-control/keys/from-secret.key
-                provider: local
-                token_url: https://system-identity-oauth.service.newrelic.com/oauth2/token
-              endpoint: https://opamp.service.jp.newrelic.com/v1/opamp
-              signature_validation:
-                public_key_server_url: https://publickeys.jp.newrelic.com/r/blob-management/global/agentconfiguration/jwks.json
-            k8s:
-              ac_release_name: my-release
-              ac_remote_update: true
-              auth_secret:
-                secret_key_name: private_key
-                secret_name: agent-control-auth
-              cd_enabled: true
-              cd_release_name: agent-control-cd
-              cd_remote_update: true
-              cluster_name: my-cluster
-              namespace: my-namespace
-              namespace_agents: newrelic
-            server:
-              enabled: true
-              host: 0.0.0.0
-              port: 51200
+          pattern: 'token_url: https://system-identity-oauth\.service\.newrelic\.com/oauth2/token'
+      - matchRegex:
+          path: data["local_config"]
+          pattern: 'endpoint: https://opamp\.service\.jp\.newrelic\.com/v1/opamp'
+      - matchRegex:
+          path: data["local_config"]
+          pattern: 'public_key_server_url: https://publickeys\.jp\.newrelic\.com/r/blob-management/global/agentconfiguration/jwks\.json'
 
   - it: nrStaging routes fleet_control through the staging endpoints
     set:
       cluster: my-cluster
       nrStaging: true
     asserts:
-      - equal:
+      - matchRegex:
           path: data["local_config"]
-          value: |
-            agents: {}
-            fleet_control:
-              auth_config:
-                private_key_path: /etc/newrelic-agent-control/keys/from-secret.key
-                provider: local
-                token_url: https://system-identity-oauth.staging-service.newrelic.com/oauth2/token
-              endpoint: https://opamp.staging-service.newrelic.com/v1/opamp
-              signature_validation:
-                public_key_server_url: https://staging-publickeys.newrelic.com/r/blob-management/global/agentconfiguration/jwks.json
-            k8s:
-              ac_release_name: my-release
-              ac_remote_update: true
-              auth_secret:
-                secret_key_name: private_key
-                secret_name: agent-control-auth
-              cd_enabled: true
-              cd_release_name: agent-control-cd
-              cd_remote_update: true
-              cluster_name: my-cluster
-              namespace: my-namespace
-              namespace_agents: newrelic
-            server:
-              enabled: true
-              host: 0.0.0.0
-              port: 51200
+          pattern: 'token_url: https://system-identity-oauth\.staging-service\.newrelic\.com/oauth2/token'
+      - matchRegex:
+          path: data["local_config"]
+          pattern: 'endpoint: https://opamp\.staging-service\.newrelic\.com/v1/opamp'
+      - matchRegex:
+          path: data["local_config"]
+          pattern: 'public_key_server_url: https://staging-publickeys\.newrelic\.com/r/blob-management/global/agentconfiguration/jwks\.json'
 
   - it: fleet_control endpoints can be overridden via values
     set:
@@ -387,34 +328,15 @@ tests:
       publicKeysEndpoint: https://publickeys.custom.example.com
       systemIdentityOauthEndpoint: https://oauth.custom.example.com
     asserts:
-      - equal:
+      - matchRegex:
           path: data["local_config"]
-          value: |
-            agents: {}
-            fleet_control:
-              auth_config:
-                private_key_path: /etc/newrelic-agent-control/keys/from-secret.key
-                provider: local
-                token_url: https://oauth.custom.example.com/oauth2/token
-              endpoint: https://opamp.custom.example.com/v1/opamp
-              signature_validation:
-                public_key_server_url: https://publickeys.custom.example.com/r/blob-management/global/agentconfiguration/jwks.json
-            k8s:
-              ac_release_name: my-release
-              ac_remote_update: true
-              auth_secret:
-                secret_key_name: private_key
-                secret_name: agent-control-auth
-              cd_enabled: true
-              cd_release_name: agent-control-cd
-              cd_remote_update: true
-              cluster_name: my-cluster
-              namespace: my-namespace
-              namespace_agents: newrelic
-            server:
-              enabled: true
-              host: 0.0.0.0
-              port: 51200
+          pattern: 'token_url: https://oauth\.custom\.example\.com/oauth2/token'
+      - matchRegex:
+          path: data["local_config"]
+          pattern: 'endpoint: https://opamp\.custom\.example\.com/v1/opamp'
+      - matchRegex:
+          path: data["local_config"]
+          pattern: 'public_key_server_url: https://publickeys\.custom\.example\.com/r/blob-management/global/agentconfiguration/jwks\.json'
 
   - it: remote_update flags can be changed
     set:

--- a/charts/agent-control-deployment/tests/configmap_agentcontrol_config_test.yaml
+++ b/charts/agent-control-deployment/tests/configmap_agentcontrol_config_test.yaml
@@ -310,6 +310,112 @@ tests:
               host: 0.0.0.0
               port: 51200
 
+  - it: agent control's config honors the JP endpoints
+    # NOTE: requires common-library >= 2.2.0 (JP entries for opamp/public-keys endpoints).
+    # On common-library 2.1.1 this fails with "This chart does not have support for the region provided 'JP'".
+    set:
+      cluster: my-cluster
+      region: jp
+    asserts:
+      - equal:
+          path: data["local_config"]
+          value: |
+            agents: {}
+            fleet_control:
+              auth_config:
+                private_key_path: /etc/newrelic-agent-control/keys/from-secret.key
+                provider: local
+                token_url: https://system-identity-oauth.service.newrelic.com/oauth2/token
+              endpoint: https://opamp.service.jp.newrelic.com/v1/opamp
+              signature_validation:
+                public_key_server_url: https://publickeys.jp.newrelic.com/r/blob-management/global/agentconfiguration/jwks.json
+            k8s:
+              ac_release_name: my-release
+              ac_remote_update: true
+              auth_secret:
+                secret_key_name: private_key
+                secret_name: agent-control-auth
+              cd_enabled: true
+              cd_release_name: agent-control-cd
+              cd_remote_update: true
+              cluster_name: my-cluster
+              namespace: my-namespace
+              namespace_agents: newrelic
+            server:
+              enabled: true
+              host: 0.0.0.0
+              port: 51200
+
+  - it: nrStaging routes fleet_control through the staging endpoints
+    set:
+      cluster: my-cluster
+      nrStaging: true
+    asserts:
+      - equal:
+          path: data["local_config"]
+          value: |
+            agents: {}
+            fleet_control:
+              auth_config:
+                private_key_path: /etc/newrelic-agent-control/keys/from-secret.key
+                provider: local
+                token_url: https://system-identity-oauth.staging-service.newrelic.com/oauth2/token
+              endpoint: https://opamp.staging-service.newrelic.com/v1/opamp
+              signature_validation:
+                public_key_server_url: https://staging-publickeys.newrelic.com/r/blob-management/global/agentconfiguration/jwks.json
+            k8s:
+              ac_release_name: my-release
+              ac_remote_update: true
+              auth_secret:
+                secret_key_name: private_key
+                secret_name: agent-control-auth
+              cd_enabled: true
+              cd_release_name: agent-control-cd
+              cd_remote_update: true
+              cluster_name: my-cluster
+              namespace: my-namespace
+              namespace_agents: newrelic
+            server:
+              enabled: true
+              host: 0.0.0.0
+              port: 51200
+
+  - it: fleet_control endpoints can be overridden via values
+    set:
+      cluster: my-cluster
+      opampEndpoint: https://opamp.custom.example.com
+      publicKeysEndpoint: https://publickeys.custom.example.com
+      systemIdentityOauthEndpoint: https://oauth.custom.example.com
+    asserts:
+      - equal:
+          path: data["local_config"]
+          value: |
+            agents: {}
+            fleet_control:
+              auth_config:
+                private_key_path: /etc/newrelic-agent-control/keys/from-secret.key
+                provider: local
+                token_url: https://oauth.custom.example.com/oauth2/token
+              endpoint: https://opamp.custom.example.com/v1/opamp
+              signature_validation:
+                public_key_server_url: https://publickeys.custom.example.com/r/blob-management/global/agentconfiguration/jwks.json
+            k8s:
+              ac_release_name: my-release
+              ac_remote_update: true
+              auth_secret:
+                secret_key_name: private_key
+                secret_name: agent-control-auth
+              cd_enabled: true
+              cd_release_name: agent-control-cd
+              cd_remote_update: true
+              cluster_name: my-cluster
+              namespace: my-namespace
+              namespace_agents: newrelic
+            server:
+              enabled: true
+              host: 0.0.0.0
+              port: 51200
+
   - it: remote_update flags can be changed
     set:
       cluster: my-cluster


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR:
- Bumps `common-library` from `1.4.0` → `2.X`.
- Adds support for JP region
- Replaces the hand-rolled region → endpoint switch in `_helpers.tpl` (~55 lines) with thin
  wrappers around `common-library`'s endpoint helpers (`opamp_endpoint`,
  `public_keys_endpoint`, `system_identity_oauth_endpoint`).
- Removes the undocumented `.Values.development.backend.*` dev escape hatch. Dev overrides
  now go through the standard `.Values.opampEndpoint` / `.Values.publicKeysEndpoint` /
  `.Values.systemIdentityOauthEndpoint` knobs (also honored under `.Values.global.*`).
- Adds unit tests locking in the STG rendering, the override path, and JP region.

#### ⚠️  Internal breaking changes

**Region identifier renames** (introduced when bumping common-library to 2.X):

`common-library` 2.x renamed the values returned by `newrelic.common.region`. Since AC's
old endpoint switch compared against the pre-2.x strings, those paths were silently dead
after the bump. Callers who set `.Values.region` explicitly must migrate:

| Before (`common-library` 1.x) | After (`common-library` 2.x) |
| ----------------------------- | ---------------------------- |
| `Staging`                     | `stg`                        |
| `Local`                       | `dev`                        |
| `US` / `EU`                   | unchanged (`us`/`eu` also accepted — validation is case-insensitive) |

Users relying on `nrStaging: true` (not `region: Staging`) are unaffected — the staging
routing still happens automatically.

`.Values.development.backend.*` **removed**:

The undocumented dev-only escape hatch under `.Values.development.backend.{fleet_control,tokenRenewal}`
is no longer read. It's replaced by the standard override mechanism shared with every other
New Relic chart.

**Before**
```yaml
region: Local
development:
  backend:
    fleet_control: http://localhost:8080/v1/opamp
    tokenRenewal: http://localhost:8080/oauth2/token
```

**After**
```yaml
# No region needed; these overrides apply in every region.
opampEndpoint: http://localhost:8080
systemIdentityOauthEndpoint: http://localhost:8080
# .Values.publicKeysEndpoint also available
# .Values.global.* variants work too
```

Note the values are now **base URLs** — the path suffixes (`/v1/opamp`, `/oauth2/token`,
`/r/blob-management/.../jwks.json`) are appended by the chart.

#### Unsupported regions (GOV and others) fail fast with an actionable error

`common-library`'s endpoint helpers don't define opamp/public-keys entries for GOV. Previously these regions were silently routed to US endpoints. Now they fail rendering with a clear message pointing at the exact override value:

```
This chart does not have support for the region provided 'GOV'. Please either supply an
override URL via .Values.opampEndpoint or .Values.global.opampEndpoint, or set a different
region.
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Tell the world about the latest changes in the chart.
<!--END-RELEASE-NOTES-->
