### PR TITLE
[nr-k8s-otel-collector] feat: generate release notes from commits instead of PR body

### DIFF
--- a/.github/workflows/nr-k8s-otel-post-release.yml
+++ b/.github/workflows/nr-k8s-otel-post-release.yml
@@ -16,13 +16,25 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Create release notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr list --search "${{ github.event.release.target_commitish }}" --state merged --json title,body,number
-          scripts/get-pr-release-notes.sh ${{ github.event.release.target_commitish }} ${{ env.RELEASE_FILE }}
+          CURRENT_TAG="${{ github.event.release.tag_name }}"
+          PREV_TAG=$(git describe --tags --abbrev=0 --match='nr-k8s-otel-collector-*' "${CURRENT_TAG}~1" 2>/dev/null || echo "")
+
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous tag found, skipping changelog generation"
+            echo "## 🚀 What's Changed" > ${{ env.RELEASE_FILE }}
+            echo "" >> ${{ env.RELEASE_FILE }}
+            echo "Initial release" >> ${{ env.RELEASE_FILE }}
+          else
+            scripts/generate-otel-release-notes.sh "${CURRENT_TAG}" "${PREV_TAG}" ${{ env.RELEASE_FILE }}
+          fi
+
           gh release edit ${{ github.event.release.tag_name }} \
             --notes-file ${{ env.RELEASE_FILE }}
 

--- a/scripts/generate-otel-release-notes.sh
+++ b/scripts/generate-otel-release-notes.sh
@@ -66,8 +66,6 @@ function generate_changelog() {
       done <<< "$commits"
     fi
 
-    echo ""
-    echo "**Full Changelog**: https://github.com/${GITHUB_REPOSITORY:-newrelic/helm-charts}/compare/${prev_tag}...${current_tag}"
   } > "$output_file"
 
   echo "Release notes written to ${output_file}:"

--- a/scripts/generate-otel-release-notes.sh
+++ b/scripts/generate-otel-release-notes.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+#
+# Generate release notes for nr-k8s-otel-collector from git commits between tags.
+#
+# Usage: ./generate-otel-release-notes.sh <current_tag> <prev_tag> <output_file>
+#
+# Example: ./generate-otel-release-notes.sh nr-k8s-otel-collector-0.12.0 nr-k8s-otel-collector-0.11.0 RELEASE.md
+#
+
+set -e
+
+CHART_PATH="charts/nr-k8s-otel-collector"
+
+function main() {
+  if [[ $# -ne 3 ]]; then
+    echo "Usage: ${0##*/} <current_tag> <prev_tag> <output_file>"
+    exit 1
+  fi
+
+  local current_tag="$1"
+  local prev_tag="$2"
+  local output_file="$3"
+
+  generate_changelog "$current_tag" "$prev_tag" "$output_file"
+}
+
+function strip_conventional_prefix() {
+  local subject="$1"
+  local repo="${GITHUB_REPOSITORY:-newrelic/helm-charts}"
+  # Strip optional [bracket-prefix] (e.g. "[nr-k8s-otel-collector] ")
+  subject=$(echo "$subject" | sed -E 's/^\[[^]]*\][[:space:]]*//')
+  # Strip conventional commit type: feat(scope)!: or feat!: or feat: (hyphens allowed in type for e.g. "nr-k8s-otel-collector:")
+  subject=$(echo "$subject" | sed -E 's/^[a-z][a-z0-9-]*(\([^)]*\))?!?:[[:space:]]*//')
+  # Capitalize first letter (awk used for bash 3.2 compatibility on macOS)
+  subject=$(echo "$subject" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')
+  # Convert (#1234) to linked PR reference
+  echo "$subject" | sed -E "s|\\(#([0-9]+)\\)|([#\1](https://github.com/${repo}/pull/\1))|g"
+}
+
+function generate_changelog() {
+  local current_tag="$1"
+  local prev_tag="$2"
+  local output_file="$3"
+
+  echo "Generating changelog: ${prev_tag}..${current_tag}"
+
+  # Get commits touching the chart between tags, excluding the bot version bump commit
+  local commits
+  commits=$(git log "${prev_tag}..${current_tag}" \
+    --pretty=format:"%s" \
+    --no-merges \
+    -- "${CHART_PATH}" | \
+    grep -v "^chore(nr-k8s-otel-collector): bump version" || true)
+
+  {
+    echo "## 🚀 What's Changed"
+    echo ""
+
+    if [ -z "$commits" ]; then
+      echo "No user-facing changes since ${prev_tag}"
+    else
+      while IFS= read -r subject; do
+        local description
+        description=$(strip_conventional_prefix "$subject")
+        echo "* ${description}"
+      done <<< "$commits"
+    fi
+
+    echo ""
+    echo "**Full Changelog**: https://github.com/${GITHUB_REPOSITORY:-newrelic/helm-charts}/compare/${prev_tag}...${current_tag}"
+  } > "$output_file"
+
+  echo "Release notes written to ${output_file}:"
+  cat "$output_file"
+}
+
+main "$@"


### PR DESCRIPTION

#### What this PR does / why we need it:

#### Which issue this PR fixes
- update release-notes script for otel-weekly release to look at the commits for that releasee instead of the PR body
Example from testing version 0.12.0 from 0.11.1

```
## 🚀 What's Changed

* Adopt latest NRDOT image  ([#2246](https://github.com/newrelic/helm-charts/pull/2246))

```

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)

# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Tell the world about the latest changes in the chart.
<!--END-RELEASE-NOTES-->
