### PR TITLE
[agent-control-deployment] staging region on install job

### DIFF
--- a/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 
 type: application
 
-version: 1.7.2
+version: 1.7.3
 
 dependencies:
   - name: common-library

--- a/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml
+++ b/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml
@@ -63,7 +63,7 @@ spec:
               # Unset variables are intentionally allowed; the CLI handles empty values.
               newrelic-agent-control-cli register-system-identity --namespace "{{ .Release.Namespace }}" \
                   --secret-name "{{ include "newrelic-agent-control.auth.secret.name" . }}" \
-                  --region "{{ include "newrelic.common.region" . }}" \
+                  --region "{{ if include "newrelic.common.region.is_stg" . }}staging{{ else }}{{ include "newrelic.common.region" . }}{{ end }}" \
                   --auth-parent-client-id "$NEW_RELIC_AUTH_CLIENT_ID" \
                   --auth-parent-client-secret "$NEW_RELIC_AUTH_CLIENT_SECRET" \
                   --auth-parent-token "$NEW_RELIC_AUTH_TOKEN" \

--- a/charts/agent-control-deployment/tests/preinstall_job_test.yaml
+++ b/charts/agent-control-deployment/tests/preinstall_job_test.yaml
@@ -162,6 +162,31 @@ tests:
           path: spec.template.spec.containers[0].image
           value: some-registry/some_namespace/test-image:0.0.100
 
+  - it: when nrStaging is true, the CLI should be invoked with --region staging (not STG)
+    set:
+      nrStaging: true
+      systemIdentity:
+        parentIdentity:
+          fromSecret: test-client-name
+        organizationId: test
+    asserts:
+      - documentIndex: 0
+        matchRegex:
+          path: spec.template.spec.containers[0].args[1]
+          pattern: '--region "staging"'
+
+  - it: when not staging, the CLI should be invoked with the region helper output (e.g. US)
+    set:
+      systemIdentity:
+        parentIdentity:
+          fromSecret: test-client-name
+        organizationId: test
+    asserts:
+      - documentIndex: 0
+        matchRegex:
+          path: spec.template.spec.containers[0].args[1]
+          pattern: '--region "US"'
+
   - it: setting specific pullPolicy for system identity registration image should use the provided data
     set:
       systemIdentity:


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This PR fixes the agent-control-deployment install job on staging, the `newrelic-agent-control-cli` requires `"staging"` as `--region` argument and it was receiving `"stg"`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Tell the world about the latest changes in the chart.
<!--END-RELEASE-NOTES-->
