### PR TITLE
[synthetics-job-manager] Bump node-api-runtime to 1.0.52 and node-browser-runtime to 2.0.17

### DIFF
--- a/charts/synthetics-job-manager/Chart.yaml
+++ b/charts/synthetics-job-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: synthetics-job-manager
 description: New Relic Synthetics Containerized Job Manager
 type: application
-version: 3.0.61
+version: 3.0.62
 appVersion: release-532
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
@@ -28,7 +28,7 @@ keywords:
   - newrelic
 dependencies:
   - name: ping-runtime
-    version: 1.0.39
+    version: 1.0.40
     condition: ping-runtime.enabled
   - name: node-api-runtime
     version: 1.0.52

--- a/charts/synthetics-job-manager/Chart.yaml
+++ b/charts/synthetics-job-manager/Chart.yaml
@@ -31,8 +31,8 @@ dependencies:
     version: 1.0.39
     condition: ping-runtime.enabled
   - name: node-api-runtime
-    version: 1.0.51
+    version: 1.0.52
     condition: node-api-runtime.enabled
   - name: node-browser-runtime
-    version: 2.0.16
+    version: 2.0.17
     condition: node-browser-runtime.enabled

--- a/charts/synthetics-job-manager/charts/node-api-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/node-api-runtime/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: node-api-runtime
 description: New Relic Synthetics Api Runtime
 type: application
-version: 1.0.51
-appVersion: rc1.20
+version: 1.0.52
+appVersion: rc1.21
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith

--- a/charts/synthetics-job-manager/charts/node-browser-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/node-browser-runtime/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: node-browser-runtime
 description: New Relic Synthetics Browser Runtime
 type: application
-version: 2.0.16
-appVersion: rc1.20
+version: 2.0.17
+appVersion: rc1.21
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith


### PR DESCRIPTION
## Summary
- Bump `node-api-runtime` chart to 1.0.52 (appVersion `rc1.21`)
- Bump `node-browser-runtime` chart to 2.0.17 (appVersion `rc1.21`)
- Update `synthetics-job-manager` Chart.yaml dependencies to reference the new versions

## Test plan
- [ ] `helm dependency update charts/synthetics-job-manager`
- [ ] `helm lint charts/synthetics-job-manager`
- [ ] Verify rendered manifests use the new image tags