### PR TITLE
[pipeline-control-gateway]  feat: add customConfigMap and config-watcher sidecar for DaemonSet mode

### DIFF
--- a/charts/pipeline-control-gateway/Chart.yaml
+++ b/charts/pipeline-control-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: pipeline-control-gateway
 type: application
-version: 2.3.1
+version: 2.4.0
 dependencies:
   - name: common-library
     version: 1.4.0

--- a/charts/pipeline-control-gateway/templates/_config_watcher.tpl
+++ b/charts/pipeline-control-gateway/templates/_config_watcher.tpl
@@ -1,0 +1,65 @@
+{{- /*
+A helper to render the config-watcher sidecar container.
+Accepts a dict with:
+  - customConfigMap: the ConfigMap name to watch
+  - root: the root context (.)
+*/ -}}
+{{- define "nrKubernetesOtel.configWatcher.container" -}}
+- name: config-watcher
+  image: {{ .root.Values.configWatcher.image }}
+  imagePullPolicy: {{ .root.Values.configWatcher.imagePullPolicy }}
+  command:
+    - /bin/bash
+    - -c
+    - |
+      set -e
+
+      CONFIGMAP_NAME="{{ .customConfigMap }}"
+      NAMESPACE="{{ .root.Release.Namespace }}"
+      POD_NAME="${MY_POD_NAME}"
+
+      echo "Config watcher started. Monitoring ConfigMap: ${CONFIGMAP_NAME}"
+      echo "Will restart pod: ${POD_NAME} in namespace: ${NAMESPACE} when a configuration update is detected"
+
+      # Get initial resource version
+      LAST_VERSION=$(kubectl get configmap "${CONFIGMAP_NAME}" -n "${NAMESPACE}" -o jsonpath='{.metadata.resourceVersion}')
+      echo "Initial ConfigMap resourceVersion: ${LAST_VERSION}"
+
+      # The Kubernetes API server terminates watch streams after its
+      # --min-request-timeout (typically every 30-60 min).
+      # Watch ConfigMap changes on a loop so it reconnects on those
+      # natural terminations and transient errors.
+      while true; do
+        echo "Opening watch on ConfigMap ${CONFIGMAP_NAME}..."
+        while read -r CURRENT_VERSION; do
+          if [ -z "$CURRENT_VERSION" ]; then
+            sleep 1
+            continue
+          fi
+
+          echo "Event received. ResourceVersion: ${CURRENT_VERSION}"
+
+          if [ "$CURRENT_VERSION" != "$LAST_VERSION" ]; then
+            echo "ConfigMap change detected! ResourceVersion changed from ${LAST_VERSION} to ${CURRENT_VERSION}"
+            echo "Deleting pod ${POD_NAME} to trigger restart..."
+
+            kubectl delete pod "${POD_NAME}" -n "${NAMESPACE}" --grace-period={{ .root.Values.configWatcher.gracePeriod }}
+
+            echo "Pod deletion initiated. Kubernetes will recreate the pod with new config."
+            exit 0
+          fi
+
+          LAST_VERSION="${CURRENT_VERSION}"
+        done < <(kubectl get configmap "${CONFIGMAP_NAME}" -n "${NAMESPACE}" --watch -o jsonpath='{.metadata.resourceVersion}{"\n"}' || true)
+
+        echo "Watch stream ended (server timeout or transient error). Reconnecting in 2s..."
+        sleep 2
+      done
+  env:
+    - name: MY_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+  resources:
+    {{- toYaml .root.Values.configWatcher.resources | nindent 4 }}
+{{- end -}}

--- a/charts/pipeline-control-gateway/templates/daemonset-configmap.yaml
+++ b/charts/pipeline-control-gateway/templates/daemonset-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.daemonset.enabled }}
+{{- if and .Values.daemonset.enabled (not .Values.daemonset.customConfigMap) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/pipeline-control-gateway/templates/daemonset.yaml
+++ b/charts/pipeline-control-gateway/templates/daemonset.yaml
@@ -127,59 +127,8 @@ spec:
           volumeMounts:
             - name: daemonset-config
               mountPath: /config
-        {{- if and .Values.daemonset.customConfigMap .Values.daemonset.configWatcher.enabled }}
-        - name: config-watcher
-          image: {{ .Values.daemonset.configWatcher.image }}
-          imagePullPolicy: {{ .Values.daemonset.configWatcher.imagePullPolicy }}
-          command:
-            - /bin/bash
-            - -c
-            - |
-              set -e
-
-              CONFIGMAP_NAME="{{ .Values.daemonset.customConfigMap }}"
-              NAMESPACE="{{ .Release.Namespace }}"
-              POD_NAME="${MY_POD_NAME}"
-
-              echo "Config watcher started. Monitoring ConfigMap: ${CONFIGMAP_NAME}"
-              echo "Will restart pod: ${POD_NAME} in namespace: ${NAMESPACE} when a configuration update is detected"
-
-              LAST_VERSION=$(kubectl get configmap "${CONFIGMAP_NAME}" -n "${NAMESPACE}" -o jsonpath='{.metadata.resourceVersion}')
-              echo "Initial ConfigMap resourceVersion: ${LAST_VERSION}"
-
-              while true; do
-                echo "Opening watch on ConfigMap ${CONFIGMAP_NAME}..."
-                while read -r CURRENT_VERSION; do
-                  if [ -z "$CURRENT_VERSION" ]; then
-                    sleep 1
-                    continue
-                  fi
-
-                  echo "Event received. ResourceVersion: ${CURRENT_VERSION}"
-
-                  if [ "$CURRENT_VERSION" != "$LAST_VERSION" ]; then
-                    echo "ConfigMap change detected! ResourceVersion changed from ${LAST_VERSION} to ${CURRENT_VERSION}"
-                    echo "Deleting pod ${POD_NAME} to trigger restart..."
-
-                    kubectl delete pod "${POD_NAME}" -n "${NAMESPACE}" --grace-period={{ .Values.daemonset.configWatcher.gracePeriod }}
-
-                    echo "Pod deletion initiated. Kubernetes will recreate the pod with new config."
-                    exit 0
-                  fi
-
-                  LAST_VERSION="${CURRENT_VERSION}"
-                done < <(kubectl get configmap "${CONFIGMAP_NAME}" -n "${NAMESPACE}" --watch -o jsonpath='{.metadata.resourceVersion}{"\n"}' || true)
-
-                echo "Watch stream ended (server timeout or transient error). Reconnecting in 2s..."
-                sleep 2
-              done
-          env:
-            - name: MY_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-          resources:
-            {{- toYaml .Values.daemonset.configWatcher.resources | nindent 12 }}
+        {{- if and .Values.daemonset.customConfigMap .Values.configWatcher.enabled }}
+        {{- include "nrKubernetesOtel.configWatcher.container" (dict "customConfigMap" .Values.daemonset.customConfigMap "root" .) | nindent 8 }}
         {{- end }}
       volumes:
         - name: daemonset-config

--- a/charts/pipeline-control-gateway/templates/daemonset.yaml
+++ b/charts/pipeline-control-gateway/templates/daemonset.yaml
@@ -127,10 +127,69 @@ spec:
           volumeMounts:
             - name: daemonset-config
               mountPath: /config
+        {{- if and .Values.daemonset.customConfigMap .Values.daemonset.configWatcher.enabled }}
+        - name: config-watcher
+          image: {{ .Values.daemonset.configWatcher.image }}
+          imagePullPolicy: {{ .Values.daemonset.configWatcher.imagePullPolicy }}
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -e
+
+              CONFIGMAP_NAME="{{ .Values.daemonset.customConfigMap }}"
+              NAMESPACE="{{ .Release.Namespace }}"
+              POD_NAME="${MY_POD_NAME}"
+
+              echo "Config watcher started. Monitoring ConfigMap: ${CONFIGMAP_NAME}"
+              echo "Will restart pod: ${POD_NAME} in namespace: ${NAMESPACE} when a configuration update is detected"
+
+              LAST_VERSION=$(kubectl get configmap "${CONFIGMAP_NAME}" -n "${NAMESPACE}" -o jsonpath='{.metadata.resourceVersion}')
+              echo "Initial ConfigMap resourceVersion: ${LAST_VERSION}"
+
+              while true; do
+                echo "Opening watch on ConfigMap ${CONFIGMAP_NAME}..."
+                while read -r CURRENT_VERSION; do
+                  if [ -z "$CURRENT_VERSION" ]; then
+                    sleep 1
+                    continue
+                  fi
+
+                  echo "Event received. ResourceVersion: ${CURRENT_VERSION}"
+
+                  if [ "$CURRENT_VERSION" != "$LAST_VERSION" ]; then
+                    echo "ConfigMap change detected! ResourceVersion changed from ${LAST_VERSION} to ${CURRENT_VERSION}"
+                    echo "Deleting pod ${POD_NAME} to trigger restart..."
+
+                    kubectl delete pod "${POD_NAME}" -n "${NAMESPACE}" --grace-period={{ .Values.daemonset.configWatcher.gracePeriod }}
+
+                    echo "Pod deletion initiated. Kubernetes will recreate the pod with new config."
+                    exit 0
+                  fi
+
+                  LAST_VERSION="${CURRENT_VERSION}"
+                done < <(kubectl get configmap "${CONFIGMAP_NAME}" -n "${NAMESPACE}" --watch -o jsonpath='{.metadata.resourceVersion}{"\n"}' || true)
+
+                echo "Watch stream ended (server timeout or transient error). Reconnecting in 2s..."
+                sleep 2
+              done
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          resources:
+            {{- toYaml .Values.daemonset.configWatcher.resources | nindent 12 }}
+        {{- end }}
       volumes:
         - name: daemonset-config
+          {{- if .Values.daemonset.customConfigMap }}
+          configMap:
+            name: {{ .Values.daemonset.customConfigMap }}
+          {{- else }}
           configMap:
             name: {{ include "nrKubernetesOtel.daemonset.configMap.fullname" . }}
+          {{- end }}
       {{- with include "nrKubernetesOtel.daemonset.nodeSelector" . }}
       nodeSelector:
         {{- . | nindent 8 }}

--- a/charts/pipeline-control-gateway/templates/deployment-configmap.yaml
+++ b/charts/pipeline-control-gateway/templates/deployment-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.daemonset.enabled }}
+{{- if and (not .Values.daemonset.enabled) (not .Values.deployment.customConfigMap) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/pipeline-control-gateway/templates/deployment.yaml
+++ b/charts/pipeline-control-gateway/templates/deployment.yaml
@@ -123,64 +123,8 @@ spec:
           volumeMounts:
             - name: deployment-config
               mountPath: /config
-        {{- if and .Values.deployment.customConfigMap .Values.deployment.configWatcher.enabled }}
-        - name: config-watcher
-          image: {{ .Values.deployment.configWatcher.image }}
-          imagePullPolicy: {{ .Values.deployment.configWatcher.imagePullPolicy }}
-          command:
-            - /bin/bash
-            - -c
-            - |
-              set -e
-
-              CONFIGMAP_NAME="{{ .Values.deployment.customConfigMap }}"
-              NAMESPACE="{{ .Release.Namespace }}"
-              POD_NAME="${MY_POD_NAME}"
-
-              echo "Config watcher started. Monitoring ConfigMap: ${CONFIGMAP_NAME}"
-              echo "Will restart pod: ${POD_NAME} in namespace: ${NAMESPACE} when a configuration update is detected"
-
-              # Get initial resource version
-              LAST_VERSION=$(kubectl get configmap "${CONFIGMAP_NAME}" -n "${NAMESPACE}" -o jsonpath='{.metadata.resourceVersion}')
-              echo "Initial ConfigMap resourceVersion: ${LAST_VERSION}"
-
-              # The Kubernetes API server terminates watch streams after its
-              # --min-request-timeout (typically every 30-60 min).
-              # Watch ConfigMap changes on a loop so it reconnects on those
-              # natural terminations and transient errors.
-              while true; do
-                echo "Opening watch on ConfigMap ${CONFIGMAP_NAME}..."
-                while read -r CURRENT_VERSION; do
-                  if [ -z "$CURRENT_VERSION" ]; then
-                    sleep 1
-                    continue
-                  fi
-
-                  echo "Event received. ResourceVersion: ${CURRENT_VERSION}"
-
-                  if [ "$CURRENT_VERSION" != "$LAST_VERSION" ]; then
-                    echo "ConfigMap change detected! ResourceVersion changed from ${LAST_VERSION} to ${CURRENT_VERSION}"
-                    echo "Deleting pod ${POD_NAME} to trigger restart..."
-
-                    kubectl delete pod "${POD_NAME}" -n "${NAMESPACE}" --grace-period={{ .Values.deployment.configWatcher.gracePeriod }}
-
-                    echo "Pod deletion initiated. Kubernetes will recreate the pod with new config."
-                    exit 0
-                  fi
-
-                  LAST_VERSION="${CURRENT_VERSION}"
-                done < <(kubectl get configmap "${CONFIGMAP_NAME}" -n "${NAMESPACE}" --watch -o jsonpath='{.metadata.resourceVersion}{"\n"}' || true)
-
-                echo "Watch stream ended (server timeout or transient error). Reconnecting in 2s..."
-                sleep 2
-              done
-          env:
-            - name: MY_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-          resources:
-            {{- toYaml .Values.deployment.configWatcher.resources | nindent 12 }}
+        {{- if and .Values.deployment.customConfigMap .Values.configWatcher.enabled }}
+        {{- include "nrKubernetesOtel.configWatcher.container" (dict "customConfigMap" .Values.deployment.customConfigMap "root" .) | nindent 8 }}
         {{- end }}
       volumes:
         - name: deployment-config

--- a/charts/pipeline-control-gateway/templates/role.yaml
+++ b/charts/pipeline-control-gateway/templates/role.yaml
@@ -1,8 +1,10 @@
-{{- if and (include "newrelic.common.serviceAccount.create" .) .Values.deployment.customConfigMap .Values.deployment.configWatcher.enabled }}
+{{- $deploymentWatcher := and (not .Values.daemonset.enabled) .Values.deployment.customConfigMap .Values.deployment.configWatcher.enabled }}
+{{- $daemonsetWatcher := and .Values.daemonset.enabled .Values.daemonset.customConfigMap .Values.daemonset.configWatcher.enabled }}
+{{- if and (include "newrelic.common.serviceAccount.create" .) (or $deploymentWatcher $daemonsetWatcher) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "nrKubernetesOtel.deployment.fullname" . }}-config-watcher
+  name: {{ include "newrelic.common.naming.fullname" . }}-config-watcher
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "newrelic.common.labels" . | nindent 4 }}
@@ -10,7 +12,13 @@ rules:
   # Allow watching and getting the ConfigMap
   - apiGroups: [""]
     resources: ["configmaps"]
-    resourceNames: ["{{ .Values.deployment.customConfigMap }}"]
+    resourceNames:
+      {{- if $deploymentWatcher }}
+      - "{{ .Values.deployment.customConfigMap }}"
+      {{- end }}
+      {{- if $daemonsetWatcher }}
+      - "{{ .Values.daemonset.customConfigMap }}"
+      {{- end }}
     verbs: ["get", "watch"]
   # Allow deleting the pod to trigger restart
   - apiGroups: [""]

--- a/charts/pipeline-control-gateway/templates/role.yaml
+++ b/charts/pipeline-control-gateway/templates/role.yaml
@@ -1,6 +1,5 @@
-{{- $deploymentWatcher := and (not .Values.daemonset.enabled) .Values.deployment.customConfigMap .Values.deployment.configWatcher.enabled }}
-{{- $daemonsetWatcher := and .Values.daemonset.enabled .Values.daemonset.customConfigMap .Values.daemonset.configWatcher.enabled }}
-{{- if and (include "newrelic.common.serviceAccount.create" .) (or $deploymentWatcher $daemonsetWatcher) }}
+{{- $customConfigMap := ternary .Values.daemonset.customConfigMap .Values.deployment.customConfigMap .Values.daemonset.enabled }}
+{{- if and (include "newrelic.common.serviceAccount.create" .) $customConfigMap .Values.configWatcher.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -13,12 +12,7 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     resourceNames:
-      {{- if $deploymentWatcher }}
-      - "{{ .Values.deployment.customConfigMap }}"
-      {{- end }}
-      {{- if $daemonsetWatcher }}
-      - "{{ .Values.daemonset.customConfigMap }}"
-      {{- end }}
+      - "{{ $customConfigMap }}"
     verbs: ["get", "watch"]
   # Allow deleting the pod to trigger restart
   - apiGroups: [""]

--- a/charts/pipeline-control-gateway/templates/rolebinding.yaml
+++ b/charts/pipeline-control-gateway/templates/rolebinding.yaml
@@ -1,15 +1,17 @@
-{{- if and (include "newrelic.common.serviceAccount.create" .) .Values.deployment.customConfigMap .Values.deployment.configWatcher.enabled }}
+{{- $deploymentWatcher := and (not .Values.daemonset.enabled) .Values.deployment.customConfigMap .Values.deployment.configWatcher.enabled }}
+{{- $daemonsetWatcher := and .Values.daemonset.enabled .Values.daemonset.customConfigMap .Values.daemonset.configWatcher.enabled }}
+{{- if and (include "newrelic.common.serviceAccount.create" .) (or $deploymentWatcher $daemonsetWatcher) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "nrKubernetesOtel.deployment.fullname" . }}-config-watcher
+  name: {{ include "newrelic.common.naming.fullname" . }}-config-watcher
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "newrelic.common.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "nrKubernetesOtel.deployment.fullname" . }}-config-watcher
+  name: {{ include "newrelic.common.naming.fullname" . }}-config-watcher
 subjects:
   - kind: ServiceAccount
     name: {{ include "newrelic.common.serviceAccount.name" . }}

--- a/charts/pipeline-control-gateway/templates/rolebinding.yaml
+++ b/charts/pipeline-control-gateway/templates/rolebinding.yaml
@@ -1,6 +1,5 @@
-{{- $deploymentWatcher := and (not .Values.daemonset.enabled) .Values.deployment.customConfigMap .Values.deployment.configWatcher.enabled }}
-{{- $daemonsetWatcher := and .Values.daemonset.enabled .Values.daemonset.customConfigMap .Values.daemonset.configWatcher.enabled }}
-{{- if and (include "newrelic.common.serviceAccount.create" .) (or $deploymentWatcher $daemonsetWatcher) }}
+{{- $customConfigMap := ternary .Values.daemonset.customConfigMap .Values.deployment.customConfigMap .Values.daemonset.enabled }}
+{{- if and (include "newrelic.common.serviceAccount.create" .) $customConfigMap .Values.configWatcher.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/pipeline-control-gateway/values.yaml
+++ b/charts/pipeline-control-gateway/values.yaml
@@ -44,25 +44,26 @@ daemonset:
   # -- Custom external ConfigMap name for daemonset. Leave empty to use the chart-generated one.
   # @default -- `""`
   customConfigMap: ""
-  # -- Config watcher sidecar settings. Only applies when customConfigMap is set.
-  # @default -- See `values.yaml`
-  configWatcher:
-    # -- Enable the config-watcher sidecar that monitors the custom ConfigMap and restarts the pod on changes
-    enabled: true
-    # -- Config watcher image repository and tag
-    image: bitnami/kubectl:latest
-    # -- Config watcher image pull policy
-    imagePullPolicy: IfNotPresent
-    # -- Grace period in seconds for pod deletion when ConfigMap changes
-    gracePeriod: 30
-    # -- Resource limits and requests for the config-watcher sidecar
-    resources:
-      limits:
-        cpu: 100m
-        memory: 128Mi
-      requests:
-        cpu: 10m
-        memory: 64Mi
+
+# -- Config watcher sidecar settings. Applies to both deployment and daemonset when customConfigMap is set.
+# @default -- See `values.yaml`
+configWatcher:
+  # -- Enable the config-watcher sidecar that monitors the custom ConfigMap and restarts the pod on changes
+  enabled: true
+  # -- Config watcher image repository and tag
+  image: bitnami/kubectl:latest
+  # -- Config watcher image pull policy
+  imagePullPolicy: IfNotPresent
+  # -- Grace period in seconds for pod deletion when ConfigMap changes
+  gracePeriod: 30
+  # -- Resource limits and requests for the config-watcher sidecar
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
 
 autoscaling:
   minReplicas: 2
@@ -140,25 +141,6 @@ deployment:
   # -- Custom external ConfigMap name to use instead of the chart-generated one. Leave empty to use the internal ConfigMap.
   # @default -- `""`
   customConfigMap: ""
-  # -- Config watcher sidecar settings. Only applies when customConfigMap is set.
-  # @default -- See `values.yaml`
-  configWatcher:
-    # -- Enable the config-watcher sidecar that monitors the custom ConfigMap and restarts the pod on changes
-    enabled: true
-    # -- Config watcher image repository and tag
-    image: bitnami/kubectl:latest
-    # -- Config watcher image pull policy
-    imagePullPolicy: IfNotPresent
-    # -- Grace period in seconds for pod deletion when ConfigMap changes
-    gracePeriod: 30
-    # -- Resource limits and requests for the config-watcher sidecar
-    resources:
-      limits:
-        cpu: 100m
-        memory: 128Mi
-      requests:
-        cpu: 10m
-        memory: 64Mi
 
 # -- Sets all pods' node selector. Can be configured also with `global.nodeSelector`
 nodeSelector: {}

--- a/charts/pipeline-control-gateway/values.yaml
+++ b/charts/pipeline-control-gateway/values.yaml
@@ -41,6 +41,28 @@ daemonset:
   configMap:
     # -- OpenTelemetry config for the daemonset. If set, overrides default config.
     config: {}
+  # -- Custom external ConfigMap name for daemonset. Leave empty to use the chart-generated one.
+  # @default -- `""`
+  customConfigMap: ""
+  # -- Config watcher sidecar settings. Only applies when customConfigMap is set.
+  # @default -- See `values.yaml`
+  configWatcher:
+    # -- Enable the config-watcher sidecar that monitors the custom ConfigMap and restarts the pod on changes
+    enabled: true
+    # -- Config watcher image repository and tag
+    image: bitnami/kubectl:latest
+    # -- Config watcher image pull policy
+    imagePullPolicy: IfNotPresent
+    # -- Grace period in seconds for pod deletion when ConfigMap changes
+    gracePeriod: 30
+    # -- Resource limits and requests for the config-watcher sidecar
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 64Mi
 
 autoscaling:
   minReplicas: 2


### PR DESCRIPTION
 ---                                                                                                                                                                                                    
  What this PR does / why we need it:                                                                                                                                                                      
                                                                                                                                                                                                         
  Adds customConfigMap and configWatcher sidecar support for the DaemonSet mode in pipeline-control-gateway, matching the existing Deployment mode behavior.
                                                                                                                                                                                                           
  Changes:
  - values.yaml — Added daemonset.customConfigMap and daemonset.configWatcher settings                                                                                                                     
  - daemonset.yaml — Added config-watcher sidecar container and conditional volume source (custom vs chart-generated ConfigMap)                                                                            
  - daemonset-configmap.yaml — Skip chart-generated ConfigMap when external customConfigMap is provided                        
  - Chart.yaml — Version bump 2.3.1 → 2.4.0                                                                                                                                                                
                                                                                                                                                                                                           
  This allows the control plane (Agent Control) to push config updates to an external ConfigMap for DaemonSet mode, with the config-watcher sidecar automatically restarting pods when changes are detected
   — same pattern used in Deployment mode.                                                                                                                                                                 
                                                                                                                                                                                                           
  Which issue this PR fixes                                                                                                                                                                                
                                                                                                                                                                                                         
  - fixes NR-569112

  Special notes for your reviewer:                                                                                                                                                                         
   
  - DaemonSet customConfigMap uses the same ConfigMap name as Deployment mode (as its required for the flux less flow and confirmed by the AC team)                                                                                          
  - Config-watcher sidecar is identical to the Deployment version — watches ConfigMap resourceVersion and deletes the pod on change                                                                      
  - Tested with helm template for all three scenarios: daemonset+customConfigMap, daemonset without customConfigMap, and deployment mode (all pass)                                                        
                                                                                                                                                                                                           