### PR TITLE
[pipeline-control-gateway] fix: DaemonSet config path when customConfigMap is set

### DIFF
--- a/charts/pipeline-control-gateway/Chart.yaml
+++ b/charts/pipeline-control-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: pipeline-control-gateway
 type: application
-version: 2.4.0
+version: 2.4.1
 dependencies:
   - name: common-library
     version: 1.4.0

--- a/charts/pipeline-control-gateway/templates/daemonset.yaml
+++ b/charts/pipeline-control-gateway/templates/daemonset.yaml
@@ -48,7 +48,11 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.daemonset.customConfigMap }}
+          args: ["./pipeline-control-gateway", "--config", "/config/deployment-config.yaml"]
+          {{- else }}
           args: ["./pipeline-control-gateway", "--config", "/config/daemonset-config.yaml"]
+          {{- end }}
           resources:
             {{- toYaml .Values.daemonset.resources | nindent 12 }}
           {{- with .Values.daemonset.envsFrom }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes the DaemonSet config file path when `customConfigMap` is set. Agent Control writes config under the key `deployment-config.yaml` in the external ConfigMap regardless of mode (Deployment or DaemonSet). The DaemonSet template now conditionally uses `/config/deployment-config.yaml` when `customConfigMap` is set, and `/config/daemonset-config.yaml` when using the chart-generated ConfigMap.

Without this fix, DaemonSet pods crash with `CrashLoopBackOff` because they look for `/config/daemonset-config.yaml` which doesn't exist in the external ConfigMap.

#### Which issue this PR fixes

- fixes NR-569112

#### Special notes for your reviewer:

- Tested with `helm template` for both cases (with/without customConfigMap)
- Verified on EKS cluster: pods were in CrashLoopBackOff before fix, running correctly after

#### Checklist
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[pipeline-control-gateway]`)