### PR TITLE
[pipeline-control-gateway] Add CLUSTER_NAME env var for fluxless deployments

### DIFF
--- a/charts/pipeline-control-gateway/templates/daemonset.yaml
+++ b/charts/pipeline-control-gateway/templates/daemonset.yaml
@@ -94,7 +94,7 @@ spec:
             - name: FLEET_ID
               value: "{{ .Values.fleet_id }}"
             - name: CLUSTER_NAME
-              value: "{{ .Values.global.cluster }}"
+              value: {{ include "newrelic.common.cluster" . }}
             {{- with .Values.daemonset.envs }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}

--- a/charts/pipeline-control-gateway/templates/deployment.yaml
+++ b/charts/pipeline-control-gateway/templates/deployment.yaml
@@ -86,7 +86,7 @@ spec:
             - name: FLEET_ID
               value: "{{ .Values.fleet_id }}"
             - name: CLUSTER_NAME
-              value: "{{ .Values.global.cluster }}"
+              value: {{ include "newrelic.common.cluster" . }}
             {{- with .Values.deployment.envs }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
## What this PR does / why we need it

Adds `CLUSTER_NAME` environment variable to the PCG pod container spec in both `deployment.yaml` and `daemonset.yaml`. This is required for fluxless deployments where `pcg_fed_logs` is disabled — the PCG API replaces `{{ .Values.global.cluster }}` with `${env:CLUSTER_NAME}` (OTel env var syntax) in the prometheus/monitoring receiver config. Without this env var on the pod, OTel cannot resolve the cluster name at runtime, resulting in empty `clusterName` in self-monitoring metrics.

## Which issue this PR fixes

fixes NR-572984

## Special notes for your reviewer

This is part of a two-part fix:
1. **PCG API change** (separate repo) — replaces Helm template literals with OTel env var syntax in fluxless configs
2. **This Helm chart change** — provides the `CLUSTER_NAME` env var so OTel can resolve it at runtime

Uses `{{ include "newrelic.common.cluster" . }}` (common-library helper) which is nil-safe and handles both `cluster` and `global.cluster` values.

For flux mode, this env var is harmless — Helm's `tpl` already bakes the cluster name directly into the configmap.

## Checklist

- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [pipeline-control-gateway])