### PR TITLE
[common-library] Correct JP metric endpoint to metric-api.jp.nr-data.net

### DIFF
--- a/library/common-library/Chart.yaml
+++ b/library/common-library/Chart.yaml
@@ -3,7 +3,7 @@ name: common-library
 description: Provides helpers to provide consistency on all the charts
 
 type: library
-version: 2.3.1
+version: 2.3.2
 
 keywords:
   - newrelic

--- a/library/common-library/templates/_endpoints.tpl
+++ b/library/common-library/templates/_endpoints.tpl
@@ -67,7 +67,7 @@ See below.
   {{- $endpoints := dict
       "US"      "https://metric-api.newrelic.com"
       "EU"      "https://metric-api.eu.newrelic.com"
-      "JP"      "https://metric-api.jp.newrelic.com"
+      "JP"      "https://metric-api.jp.nr-data.net"
       "STG"     "https://staging-metric-api.newrelic.com"
   -}}
   {{- include "newrelic.common.endpoints.resolve" (dict "ctx" . "key" "metricApiEndpoint" "endpoints" $endpoints) -}}


### PR DESCRIPTION

#### What this PR does / why we need it:

JP endpoint naming has been regularized now such that metric-api.jp.nr-data.net is the hostname now. This mirrors a similar change for log-api in #2284.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)

