### PR TITLE
[common-library] add GOV (FedRAMP) log and metric API endpoints

### DIFF
--- a/library/common-library/Chart.yaml
+++ b/library/common-library/Chart.yaml
@@ -3,7 +3,7 @@ name: common-library
 description: Provides helpers to provide consistency on all the charts
 
 type: library
-version: 2.3.2
+version: 2.3.3
 
 keywords:
   - newrelic

--- a/library/common-library/templates/_endpoints.tpl
+++ b/library/common-library/templates/_endpoints.tpl
@@ -58,6 +58,7 @@ See below.
       "EU"      "https://log-api.eu.newrelic.com"
       "JP"      "https://log-api.jp.nr-data.net"
       "STG"     "https://staging-log-api.newrelic.com"
+      "GOV"     "https://gov-log-api.newrelic.com"
   -}}
   {{- include "newrelic.common.endpoints.resolve" (dict "ctx" . "key" "logApiEndpoint" "endpoints" $endpoints) -}}
 {{- end -}}
@@ -69,6 +70,7 @@ See below.
       "EU"      "https://metric-api.eu.newrelic.com"
       "JP"      "https://metric-api.jp.nr-data.net"
       "STG"     "https://staging-metric-api.newrelic.com"
+      "GOV"     "https://gov-metric-api.newrelic.com"
   -}}
   {{- include "newrelic.common.endpoints.resolve" (dict "ctx" . "key" "metricApiEndpoint" "endpoints" $endpoints) -}}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds GOV (FedRAMP) endpoints for the Log API (gov-log-api.newrelic.com) and Metric API (gov-metric-api.newrelic.com) to the region-aware endpoint helpers, so charts can resolve FedRAMP-compliant endpoints when global.fedramp.enabled is true.


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #


### Verification (consumed via newrelic-logging chart, common-library 2.3.3)

**1. Helm render with `global.fedramp.enabled=true`** — GOV log/metric endpoints resolve correctly:

```
- name: ENDPOINT
  value: "https://gov-log-api.newrelic.com/log/v1"
- name: METRICS_HOST
  value: "gov-metric-api.newrelic.com"
```

**2. Unit test** (`charts/newrelic-logging/tests/endpoint_region_selection_test.yaml`):

```
PASS  test endpoint selection based on region settings
Tests:       9 passed, 9 total
```

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Tell the world about the latest changes in the chart.
<!--END-RELEASE-NOTES-->
