### PR TITLE
[newrelic-logging] support GOV (FedRAMP) endpoints via common-library 2.3.3

### DIFF
--- a/charts/newrelic-logging/Chart.lock
+++ b/charts/newrelic-logging/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: https://helm-charts.newrelic.com
-  version: 2.3.1
-digest: sha256:ff23c3a4c0a51e4de9d2015b09bad1fbe227741ef620c8646f14c09820623b20
-generated: "2026-06-10T12:12:55.184563+05:30"
+  version: 2.3.3
+digest: sha256:0b85ba8fc894ed0fd1832688a954efdaeb80df7c9fe60c225eb124db7fbd409c
+generated: "2026-07-01T13:51:52.766749+05:30"

--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.38.2
+version: 1.38.3
 appVersion: 3.6.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
@@ -14,5 +14,5 @@ keywords:
   - newrelic
 dependencies:
   - name: common-library
-    version: 2.3.1
+    version: 2.3.3
     repository: "https://helm-charts.newrelic.com"

--- a/charts/newrelic-logging/tests/endpoint_region_selection_test.yaml
+++ b/charts/newrelic-logging/tests/endpoint_region_selection_test.yaml
@@ -106,6 +106,41 @@ tests:
         template: templates/daemonset-windows.yaml
 
 
+  - it: selects FedRAMP (GOV) endpoints when global.fedramp.enabled is true
+    set:
+      licenseKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaFFFFNRAL
+      global:
+        fedramp:
+          enabled: true
+      enableWindows: true
+    asserts:
+      # Linux
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENDPOINT
+            value: "https://gov-log-api.newrelic.com/log/v1"
+        template: templates/daemonset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: METRICS_HOST
+            value: "gov-metric-api.newrelic.com"
+        template: templates/daemonset.yaml
+      # Windows
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENDPOINT
+            value: "https://gov-log-api.newrelic.com/log/v1"
+        template: templates/daemonset-windows.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: METRICS_HOST
+            value: "gov-metric-api.newrelic.com"
+        template: templates/daemonset-windows.yaml
+
   - it: selects custom logs endpoint if provided
     set:
       licenseKey: euaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaFFFFNRAL


### PR DESCRIPTION
#### What this PR does / why we need it:

Enables New Relic Kubernetes Logging to target GOV (FedRAMP) endpoints. Consumer-side follow-up to #[2318](https://github.com/newrelic/helm-charts/pull/2318), which added the GOV endpoints to common-library.

- Bump `common-library` dependency 2.3.1 → 2.3.3 (Chart.yaml + Chart.lock)
- Bump chart version 1.38.2 → 1.38.3
- Add `tests/endpoint_region_selection_test.yaml` covering region → endpoint resolution (staging / US / EU / GOV / custom / defaults)

When `global.fedramp.enabled=true`, endpoints resolve to:
- Log API → `https://gov-log-api.newrelic.com/log/v1`
- Metric host → `gov-metric-api.newrelic.com

## Verification

update on the GOV endpoint test

Deployed the chart with --set global.fedramp.enabled=true and confirmed it picks the GOV endpoint — DaemonSet env ENDPOINT=https://gov-log-api.newrelic.com/log/v1, and the plugin logs the same URL it dials at runtime.

Sent logs with a US ingestion key → they landed in [NRDB](https://onenr.io/0gR7POl8xjo), but in a regular US account (756053). Reason: routing to an account/cell is decided by the license key, not the endpoint. The gov endpoint just authenticates the key and routes to that key's account — so a US key lands in a US cell even via the gov endpoint; a fed-account key would route to a fed cell.

So:
- fedramp.enabled=true correctly targets the GOV endpoint and the full ingest pipeline works
- Data landed in a US cell because the key is a US key — this doesn't confirm fed-cell ingestion


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

**Note:** Not tested against the real GOV (FedRAMP) endpoint — I don't have access to a FedRAMP account/license key. GOV endpoint resolution is verified via unit tests + rendered output; end-to-end ingest was validated only on the US path.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)


# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Tell the world about the latest changes in the chart.
<!--END-RELEASE-NOTES-->
