### PR TITLE
[nr-k8s-otel-collector] feat: Add cloud resource ids

### DIFF
--- a/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
@@ -758,10 +758,7 @@ data:
           # EKS
           - context: resource
             conditions:
-              - resource.attributes["cloud.provider"] == "aws"
-              - resource.attributes["cloud.account.id"] != nil
-              - resource.attributes["cloud.region"] != nil
-              - resource.attributes["cloud.k8s.cluster.name"] != nil
+              - resource.attributes["cloud.provider"] == "aws" and resource.attributes["cloud.account.id"] != nil and resource.attributes["cloud.region"] != nil and resource.attributes["cloud.k8s.cluster.name"] != nil
             statements:
               - set(resource.attributes["cloud.k8s.cluster.name"], resource.attributes["k8s.cluster.name"])
               # arn:aws:eks:us-west-1:246230979963:cluster/dbudziwojski-tst1
@@ -769,10 +766,7 @@ data:
           # AKS
           - context: resource
             conditions:
-              - resource.attributes["cloud.provider"] == "azure"
-              - resource.attributes["cloud.account.id"] != nil
-              - resource.attributes["azure.resourcegroup.name"] != nil
-              - resource.attributes["cloud.k8s.cluster.name"] != nil
+              - resource.attributes["cloud.provider"] == "azure" and resource.attributes["cloud.account.id"] != nil and resource.attributes["azure.resourcegroup.name"] != nil and resource.attributes["cloud.k8s.cluster.name"] != nil
             statements:
               - set(resource.attributes["cloud.k8s.cluster.name"], resource.attributes["k8s.cluster.name"])
               # /subscriptions/f038e9fc-3c25-459e-9bea-879af3be645e/resourceGroups/k8sAgentsUsersResourceGroup/providers/Microsoft.ContainerService/managedClusters/canary-aks-1-30

--- a/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
@@ -761,16 +761,38 @@ data:
               - resource.attributes["cloud.provider"] == "aws" and resource.attributes["cloud.account.id"] != nil and resource.attributes["cloud.region"] != nil and resource.attributes["cloud.k8s.cluster.name"] != nil
             statements:
               - set(resource.attributes["cloud.k8s.cluster.name"], resource.attributes["k8s.cluster.name"])
-              # arn:aws:eks:us-west-1:246230979963:cluster/dbudziwojski-tst1
+              # arn:aws:eks:{region}:{accountId}:cluster/{clusterName}
               - set(resource.attributes["cloud.resource_id"], Concat(["arn:aws:eks:", resource.attributes["cloud.region"], ":", resource.attributes["cloud.account.id"], ":cluster/", resource.attributes["cloud.k8s.cluster.name"]], ""))
-          # AKS
+          # AKS + Parse cluster resource group from node resource group
           - context: resource
             conditions:
               - resource.attributes["cloud.provider"] == "azure" and resource.attributes["cloud.account.id"] != nil and resource.attributes["azure.resourcegroup.name"] != nil and resource.attributes["cloud.k8s.cluster.name"] != nil
             statements:
-              - set(resource.attributes["cloud.k8s.cluster.name"], resource.attributes["k8s.cluster.name"])
-              # /subscriptions/f038e9fc-3c25-459e-9bea-879af3be645e/resourceGroups/k8sAgentsUsersResourceGroup/providers/Microsoft.ContainerService/managedClusters/canary-aks-1-30
-              - set(resource.attributes["cloud.resource_id"], Concat(["/subscriptions/", resource.attributes["cloud.account.id"], "/resourceGroups/", resource.attributes["azure.resourcegroup.name"], "/providers/Microsoft.ContainerService/managedClusters/", resource.attributes["cloud.k8s.cluster.name"]], ""))
+              # Rename node resource group (from IMDS) for clarity
+              - set(resource.attributes["azure.node.resourcegroup.name"], resource.attributes["azure.resourcegroup.name"])
+              - delete_key(resource.attributes, "azure.resourcegroup.name")
+              # Parse cluster resource group from pattern: MC_{clusterResourceGroup}_{clusterName}_{region}
+              - set(resource.attributes["_parts"], Split(resource.attributes["azure.node.resourcegroup.name"], "_"))
+              # Only set cluster RG if pattern matches exactly (4 parts starting with MC)
+              - set(resource.attributes["azure.resourcegroup.name"], resource.attributes["_parts"][1]) where Len(resource.attributes["_parts"]) == 4 and resource.attributes["_parts"][0] == "MC"
+              # /subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.ContainerService/managedClusters/{clusterName}
+              - set(resource.attributes["cloud.resource_id"], Concat(["/subscriptions/", resource.attributes["cloud.account.id"], "/resourceGroups/", resource.attributes["azure.resourcegroup.name"], "/providers/Microsoft.ContainerService/managedClusters/", resource.attributes["cloud.k8s.cluster.name"]], "")) where resource.attributes["azure.resourcegroup.name"] != nil
+              # Clean up temporary attributes
+              - delete_key(resource.attributes, "_parts")
+          # GKE Regional
+          - context: resource
+            conditions:
+              - resource.attributes["cloud.provider"] == "gcp" and resource.attributes["cloud.account.id"] != nil and resource.attributes["cloud.region"] != nil and resource.attributes["cloud.k8s.cluster.name"] != nil
+            statements:
+              # /projects/{projectId}/locations/{location}/clusters/{clusterName};
+              - set(resource.attributes["cloud.resource_id"], Concat(["/projects/", resource.attributes["cloud.account.id"], "/locations/", resource.attributes["cloud.region"], "/clusters/", resource.attributes["cloud.k8s.cluster.name"]], ""))
+          # GKE Zonal
+          - context: resource
+            conditions:
+              - resource.attributes["cloud.provider"] == "gcp" and resource.attributes["cloud.account.id"] != nil and resource.attributes["cloud.availability_zone"] != nil and resource.attributes["cloud.k8s.cluster.name"] != nil
+            statements:
+              # /projects/{projectId}/zones/{zone}/clusters/{clusterName};
+              - set(resource.attributes["cloud.resource_id"], Concat(["/projects/", resource.attributes["cloud.account.id"], "/zones/", resource.attributes["cloud.availability_zone"], "/clusters/", resource.attributes["cloud.k8s.cluster.name"]], ""))
 
       resource/newrelic:
         attributes:

--- a/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
@@ -760,7 +760,6 @@ data:
             conditions:
               - resource.attributes["cloud.provider"] == "aws" and resource.attributes["cloud.account.id"] != nil and resource.attributes["cloud.region"] != nil and resource.attributes["cloud.k8s.cluster.name"] != nil
             statements:
-              - set(resource.attributes["cloud.k8s.cluster.name"], resource.attributes["k8s.cluster.name"])
               # arn:aws:eks:{region}:{accountId}:cluster/{clusterName}
               - set(resource.attributes["cloud.resource_id"], Concat(["arn:aws:eks:", resource.attributes["cloud.region"], ":", resource.attributes["cloud.account.id"], ":cluster/", resource.attributes["cloud.k8s.cluster.name"]], ""))
           # AKS + Parse cluster resource group from node resource group

--- a/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
@@ -783,14 +783,14 @@ data:
             conditions:
               - resource.attributes["cloud.provider"] == "gcp" and resource.attributes["cloud.account.id"] != nil and resource.attributes["cloud.region"] != nil and resource.attributes["cloud.k8s.cluster.name"] != nil
             statements:
-              # /projects/{projectId}/locations/{location}/clusters/{clusterName};
+              # /projects/{projectId}/locations/{location}/clusters/{clusterName}
               - set(resource.attributes["cloud.resource_id"], Concat(["/projects/", resource.attributes["cloud.account.id"], "/locations/", resource.attributes["cloud.region"], "/clusters/", resource.attributes["cloud.k8s.cluster.name"]], ""))
           # GKE Zonal
           - context: resource
             conditions:
               - resource.attributes["cloud.provider"] == "gcp" and resource.attributes["cloud.account.id"] != nil and resource.attributes["cloud.availability_zone"] != nil and resource.attributes["cloud.k8s.cluster.name"] != nil
             statements:
-              # /projects/{projectId}/zones/{zone}/clusters/{clusterName};
+              # /projects/{projectId}/zones/{zone}/clusters/{clusterName}
               - set(resource.attributes["cloud.resource_id"], Concat(["/projects/", resource.attributes["cloud.account.id"], "/zones/", resource.attributes["cloud.availability_zone"], "/clusters/", resource.attributes["cloud.k8s.cluster.name"]], ""))
 
       resource/newrelic:

--- a/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
@@ -738,6 +738,45 @@ data:
         override: false
         eks:
           node_from_env_var: KUBE_NODE_NAME
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        aks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+
+      transform/create_cloud_cluster_id:
+        error_mode: ignore
+        metric_statements:
+          - context: resource
+            conditions:
+              - resource.attributes["k8s.cluster.name"] != nil
+            statements:
+              - set(resource.attributes["cloud.k8s.cluster.name"], resource.attributes["k8s.cluster.name"])
+              - delete_key(resource.attributes, "k8s.cluster.name")
+          # EKS
+          - context: resource
+            conditions:
+              - resource.attributes["cloud.provider"] == "aws"
+              - resource.attributes["cloud.account.id"] != nil
+              - resource.attributes["cloud.region"] != nil
+              - resource.attributes["cloud.k8s.cluster.name"] != nil
+            statements:
+              - set(resource.attributes["cloud.k8s.cluster.name"], resource.attributes["k8s.cluster.name"])
+              # arn:aws:eks:us-west-1:246230979963:cluster/dbudziwojski-tst1
+              - set(resource.attributes["cloud.resource_id"], Concat(["arn:aws:eks:", resource.attributes["cloud.region"], ":", resource.attributes["cloud.account.id"], ":cluster/", resource.attributes["cloud.k8s.cluster.name"]], ""))
+          # AKS
+          - context: resource
+            conditions:
+              - resource.attributes["cloud.provider"] == "azure"
+              - resource.attributes["cloud.account.id"] != nil
+              - resource.attributes["azure.resourcegroup.name"] != nil
+              - resource.attributes["cloud.k8s.cluster.name"] != nil
+            statements:
+              - set(resource.attributes["cloud.k8s.cluster.name"], resource.attributes["k8s.cluster.name"])
+              # /subscriptions/f038e9fc-3c25-459e-9bea-879af3be645e/resourceGroups/k8sAgentsUsersResourceGroup/providers/Microsoft.ContainerService/managedClusters/canary-aks-1-30
+              - set(resource.attributes["cloud.resource_id"], Concat(["/subscriptions/", resource.attributes["cloud.account.id"], "/resourceGroups/", resource.attributes["azure.resourcegroup.name"], "/providers/Microsoft.ContainerService/managedClusters/", resource.attributes["cloud.k8s.cluster.name"]], ""))
 
       resource/newrelic:
         attributes:
@@ -999,6 +1038,7 @@ data:
             - resource_detection/openshift
             {{- else  }}
             - resource_detection/cloudproviders
+            - transform/create_cloud_cluster_id
             {{- end }}
             - resource/newrelic
             {{- if include "nrKubernetesOtel.lowDataMode" . }}
@@ -1029,6 +1069,7 @@ data:
             - resource_detection/openshift
             {{- else  }}
             - resource_detection/cloudproviders
+            - transform/create_cloud_cluster_id
             {{- end }}
             - resource/newrelic
             {{- if include "nrKubernetesOtel.lowDataMode" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a new Kubernetes `cloud.resource_id` attribute that contains the cluster's cloud provider resource id. For EKS, this is the ARN, for AKS, this is the Resource ID, and for GKE, this is the self-link path. 

In AKS, we now populate `azure.node.resourcegroup.name` with the value previously available from `azure.resourcegroup.name`. `azure.resourcegroup.name` instead contains the cluster's resource group if parseable. For details, review the limitations section below.

### Resource ID Structures

EKS: `arn:aws:eks:{region}:{accountId}:cluster/{clusterName}`
AKS: `/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.ContainerService/managedClusters/{clusterName}`
GKE:
Regional: `/projects/{projectId}/locations/{location}/clusters/{clusterName}`
Zonal: `/projects/{projectId}/zones/{zone}/clusters/{clusterName}`

### AKS Limitation:
Resource IDs in AKS are derived from the node resource group ([details here on what this is](https://learn.microsoft.com/en-us/answers/questions/25725/why-are-two-resource-groups-created-with-aks)) which has the following structure: `MC_myResourceGroup_myAKSCluster_eastus`. As a result, if a cluster name or resource group contains an underscore, we are not able to parse the resource group from the cluster name. If this occurs, we will not return a `cloud.resource_id`. 


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)

# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Adds a new Kubernetes `cloud.resource_id` attribute that contains the cluster's cloud provider resource id. For EKS, this is the ARN, for AKS, this is the Resource ID, and for GKE, this is the self-link path. AKS cluster names or resource group names with underscores are not supported.
* `azure.node.resourcegroup.name` replaces value previously in `azure.resourcegroup.name`
* `azure.resourcegroup.name` now contains the cluster's resource group if parsable.
<!--END-RELEASE-NOTES-->
