### PR TITLE
[newrelic-logging] Add Helm chart E2E test for default install (NR-587117)

### DIFF
--- a/.github/workflows/newrelic-logging-e2e-external.yml
+++ b/.github/workflows/newrelic-logging-e2e-external.yml
@@ -1,7 +1,7 @@
-name: Newrelic Logging chart E2E
+name: Newrelic Logging chart E2E (External Contribution)
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - 'charts/newrelic-logging/**'
       - '.github/workflows/newrelic-logging-e2e.yml'
@@ -16,14 +16,17 @@ env:
   MINIKUBE_VERSION: 'v1.38.1'
 
 jobs:
-  e2e-test:
+  e2e-test-external:
     name: Run Tests
-    # Do not run e2e tests if PR has skip-e2e label or if it's from a forked repo (external contribution)
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e') && github.event.pull_request.head.repo.full_name == 'newrelic/helm-charts' }}
+    # Do not run e2e tests if PR has skip-e2e label or if it's a non-forked repo (internal contribution)
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e') && github.event.pull_request.head.repo.full_name != 'newrelic/helm-charts' }}
     runs-on: ubuntu-latest
+    environment: E2E # Required so that approval is required to run this job since it is untrusted (forked).
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.18.0
         with:

--- a/.github/workflows/newrelic-logging-e2e.yml
+++ b/.github/workflows/newrelic-logging-e2e.yml
@@ -1,0 +1,44 @@
+name: Newrelic Logging chart E2E
+
+on:
+  pull_request:
+    paths:
+      - 'charts/newrelic-logging/**'
+      - '.github/workflows/newrelic-logging-e2e.yml'
+
+permissions:
+  contents: read
+
+env:
+  # NOTICE that apart from this, the versions in the chart linter matrix needs to be bumped too.
+  LATEST_K8S_VERSION: 'v1.35.0'
+  MINIKUBE_VERSION: 'v1.38.1'
+
+jobs:
+  e2e-test:
+    name: Run Tests
+    # Do not run e2e tests if PR has skip-e2e label or if it's from a forked repo (external contribution)
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e') && github.event.pull_request.head.repo.full_name == 'newrelic/helm-charts' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.18.0
+        with:
+          minikube version: ${{ env.MINIKUBE_VERSION }}
+          kubernetes version: ${{ env.LATEST_K8S_VERSION }}
+          # default driver doesn't support 'eval $$(minikube docker-env)'.
+          driver: docker
+          container runtime: containerd
+          github token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run e2e-test
+        uses: newrelic/newrelic-integration-e2e-action@v1
+        with:
+          retry_seconds: 90
+          retry_attempts: 10
+          agent_enabled: false
+          spec_path: charts/newrelic-logging/e2e/test-specs.yml
+          account_id: ${{ secrets.K8S_AGENTS_E2E_ACCOUNT_ID }}
+          api_key: ${{ secrets.K8S_AGENTS_E2E_API_KEY }}
+          license_key: ${{ secrets.K8S_AGENTS_E2E_LICENSE_KEY }}

--- a/charts/newrelic-logging/e2e/e2e-resources.yml
+++ b/charts/newrelic-logging/e2e/e2e-resources.yml
@@ -1,0 +1,34 @@
+---
+# Log producer: emits uniquely-marked lines to stdout so the newrelic-logging
+# DaemonSet tails them from the container log and forwards them to New Relic.
+# The marker (nr-logging-e2e-marker) is what test-specs.yml asserts on.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nr-logging-e2e-logger
+  namespace: default
+  labels:
+    app: nr-logging-e2e-logger
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nr-logging-e2e-logger
+  template:
+    metadata:
+      labels:
+        app: nr-logging-e2e-logger
+    spec:
+      containers:
+        - name: logger
+          image: busybox:1.36
+          command: ["/bin/sh", "-c"]
+          args:
+            - while true; do echo "nr-logging-e2e-marker $(date -u +%Y-%m-%dT%H:%M:%SZ)"; sleep 2; done
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 32Mi

--- a/charts/newrelic-logging/e2e/e2e-resources.yml
+++ b/charts/newrelic-logging/e2e/e2e-resources.yml
@@ -1,7 +1,6 @@
 ---
-# Log producer: emits uniquely-marked lines to stdout so the newrelic-logging
-# DaemonSet tails them from the container log and forwards them to New Relic.
-# The marker (nr-logging-e2e-marker) is what test-specs.yml asserts on.
+# Emits marker lines for newrelic-logging to pick up and ship to New Relic.
+# test-specs.yml checks for the "nr-logging-e2e-marker" text.
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/newrelic-logging/e2e/e2e-resources.yml
+++ b/charts/newrelic-logging/e2e/e2e-resources.yml
@@ -1,6 +1,8 @@
 ---
 # Emits marker lines for newrelic-logging to pick up and ship to New Relic.
 # test-specs.yml checks for the "nr-logging-e2e-marker" text.
+# This runs in a different namespace than the chart on purpose — the logging
+# agent reads logs from every namespace, not just its own, so it still works.
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/newrelic-logging/e2e/e2e-values.yml
+++ b/charts/newrelic-logging/e2e/e2e-values.yml
@@ -1,0 +1,5 @@
+# Default-install E2E values.
+# licenseKey and cluster are injected via `--set global.*` in test-specs.yml.
+# Left intentionally minimal so this scenario exercises the chart's defaults.
+# Additional scenarios (namespace filtering, multi-line, lowDataMode) will add
+# their own values files alongside this one.

--- a/charts/newrelic-logging/e2e/e2e-values.yml
+++ b/charts/newrelic-logging/e2e/e2e-values.yml
@@ -1,2 +1,0 @@
-# Empty on purpose — this scenario tests the chart's own defaults.
-# licenseKey and cluster are set via --set in test-specs.yml instead.

--- a/charts/newrelic-logging/e2e/e2e-values.yml
+++ b/charts/newrelic-logging/e2e/e2e-values.yml
@@ -1,5 +1,2 @@
-# Default-install E2E values.
-# licenseKey and cluster are injected via `--set global.*` in test-specs.yml.
-# Left intentionally minimal so this scenario exercises the chart's defaults.
-# Additional scenarios (namespace filtering, multi-line, lowDataMode) will add
-# their own values files alongside this one.
+# Empty on purpose — this scenario tests the chart's own defaults.
+# licenseKey and cluster are set via --set in test-specs.yml instead.

--- a/charts/newrelic-logging/e2e/test-specs.yml
+++ b/charts/newrelic-logging/e2e/test-specs.yml
@@ -1,8 +1,7 @@
 description: New Relic newrelic-logging chart E2E
 
-# The e2e-action appends `WHERE <custom_test_key> = '<SCENARIO_TAG>'` to every NRQL query,
-# scoping each run to its own data. The chart records `cluster_name` from `global.cluster`,
-# which we set to ${SCENARIO_TAG} on install below — so every query is scoped to this run.
+# Every NRQL query below is auto-scoped to this run via cluster_name, which
+# we set to ${SCENARIO_TAG} when installing the chart.
 custom_test_key: cluster_name
 
 scenarios:
@@ -20,15 +19,13 @@ scenarios:
       - kubectl delete namespace nr-${SCENARIO_TAG} || true
     tests:
       nrqls:
-        # Assert the marker lines emitted by the log-producer (e2e-resources.yml) reached NRDB.
-        # No WHERE/SINCE here: the action appends the cluster_name scope clause automatically.
+        # Checks the marker log actually arrived.
         - query: "SELECT filter(count(*), WHERE message LIKE '%nr-logging-e2e-marker%') AS markerCount FROM Log"
           expected_results:
             - key: "markerCount"
               lowerBoundedValue: 1
-      # Unlike `after:` above, a failing command here fails the scenario.
-      # Logs can arrive fine even if the pod is crash-looping, so we
-      # check pod health too, not just that logs showed up.
+      # A failing script here fails the scenario (unlike `after:`, which is cleanup-only).
+      # We also check pod health, since logs can arrive fine even if the pod is crash-looping.
       scripts:
         - kubectl logs -n nr-${SCENARIO_TAG} -l app.kubernetes.io/name=newrelic-logging --all-containers --prefix=true --tail=200 || true  # for debugging, doesn't affect pass/fail
         - kubectl get pods -n nr-${SCENARIO_TAG} -o wide  # for debugging, doesn't affect pass/fail

--- a/charts/newrelic-logging/e2e/test-specs.yml
+++ b/charts/newrelic-logging/e2e/test-specs.yml
@@ -34,3 +34,35 @@ scenarios:
         - kubectl get pods -n nr-${SCENARIO_TAG} -o wide  # for debugging, doesn't affect pass/fail
         - kubectl wait --for=condition=Ready pod -n nr-${SCENARIO_TAG} -l app.kubernetes.io/name=newrelic-logging --timeout=60s  # fails if the pod never became healthy
         - kubectl get pods -n nr-${SCENARIO_TAG} -l app.kubernetes.io/name=newrelic-logging -o json | jq -e '[.items[].status.containerStatuses[].restartCount] | all(. == 0)' > /dev/null  # fails if the pod restarted
+
+  - description: lowDataMode strips extra metadata but keeps the fields the chart says it will
+    before:
+      - helm repo add newrelic https://helm-charts.newrelic.com
+      - helm dependency update ../
+      - helm upgrade --install ${SCENARIO_TAG} --namespace nr-${SCENARIO_TAG} --create-namespace ../ --values e2e-values.yml --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG} --set lowDataMode=true
+      - kubectl apply -f e2e-resources.yml
+    after:
+      - kubectl logs -l app.kubernetes.io/name=newrelic-logging --all-containers --prefix=true || true
+      - kubectl get pods -A -o wide || true
+      - kubectl delete -f e2e-resources.yml || true
+      - helm uninstall ${SCENARIO_TAG} --namespace nr-${SCENARIO_TAG} || true
+      - kubectl delete namespace nr-${SCENARIO_TAG} || true
+    tests:
+      nrqls:
+        # lowDataMode strips most metadata, but a few basic fields should still survive.
+        # This checks those fields didn't get dropped by mistake.
+        - query: "SELECT filter(count(*), WHERE message LIKE '%nr-logging-e2e-marker%' AND pod_name IS NOT NULL AND container_name IS NOT NULL AND namespace_name IS NOT NULL) AS retainedCount FROM Log"
+          expected_results:
+            - key: "retainedCount"
+              lowerBoundedValue: 1
+        # The test pod has a label, which normally shows up as `labels.app` on the log.
+        # lowDataMode should remove labels — this checks it actually did.
+        - query: "SELECT filter(count(*), WHERE message LIKE '%nr-logging-e2e-marker%' AND labels.app IS NOT NULL) AS labelLeakCount FROM Log"
+          expected_results:
+            - key: "labelLeakCount"
+              value: 0
+      scripts:
+        - kubectl logs -n nr-${SCENARIO_TAG} -l app.kubernetes.io/name=newrelic-logging --all-containers --prefix=true --tail=200 || true  # for debugging, doesn't affect pass/fail
+        - kubectl get pods -n nr-${SCENARIO_TAG} -o wide  # for debugging, doesn't affect pass/fail
+        - kubectl wait --for=condition=Ready pod -n nr-${SCENARIO_TAG} -l app.kubernetes.io/name=newrelic-logging --timeout=60s  # fails if the pod never became healthy
+        - kubectl get pods -n nr-${SCENARIO_TAG} -l app.kubernetes.io/name=newrelic-logging -o json | jq -e '[.items[].status.containerStatuses[].restartCount] | all(. == 0)' > /dev/null  # fails if the pod restarted

--- a/charts/newrelic-logging/e2e/test-specs.yml
+++ b/charts/newrelic-logging/e2e/test-specs.yml
@@ -9,7 +9,7 @@ scenarios:
     before:
       - helm repo add newrelic https://helm-charts.newrelic.com
       - helm dependency update ../
-      - helm upgrade --install ${SCENARIO_TAG} --namespace nr-${SCENARIO_TAG} --create-namespace ../ --values e2e-values.yml --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG}
+      - helm upgrade --install ${SCENARIO_TAG} --namespace nr-${SCENARIO_TAG} --create-namespace ../ --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG}
       - kubectl apply -f e2e-resources.yml
     after:
       - kubectl logs -l app.kubernetes.io/name=newrelic-logging --all-containers --prefix=true || true
@@ -36,7 +36,7 @@ scenarios:
     before:
       - helm repo add newrelic https://helm-charts.newrelic.com
       - helm dependency update ../
-      - helm upgrade --install ${SCENARIO_TAG} --namespace nr-${SCENARIO_TAG} --create-namespace ../ --values e2e-values.yml --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG} --set lowDataMode=true
+      - helm upgrade --install ${SCENARIO_TAG} --namespace nr-${SCENARIO_TAG} --create-namespace ../ --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG} --set lowDataMode=true
       - kubectl apply -f e2e-resources.yml
     after:
       - kubectl logs -l app.kubernetes.io/name=newrelic-logging --all-containers --prefix=true || true

--- a/charts/newrelic-logging/e2e/test-specs.yml
+++ b/charts/newrelic-logging/e2e/test-specs.yml
@@ -1,0 +1,28 @@
+description: New Relic newrelic-logging chart E2E
+
+# The e2e-action appends `WHERE <custom_test_key> = '<SCENARIO_TAG>'` to every NRQL query,
+# scoping each run to its own data. The chart records `cluster_name` from `global.cluster`,
+# which we set to ${SCENARIO_TAG} on install below — so every query is scoped to this run.
+custom_test_key: cluster_name
+
+scenarios:
+  - description: Default install forwards container logs to New Relic
+    before:
+      - helm repo add newrelic https://helm-charts.newrelic.com
+      - helm dependency update ../
+      - helm upgrade --install ${SCENARIO_TAG} --namespace nr-${SCENARIO_TAG} --create-namespace ../ --values e2e-values.yml --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG}
+      - kubectl apply -f e2e-resources.yml
+    after:
+      - kubectl logs -l app.kubernetes.io/name=newrelic-logging --all-containers --prefix=true || true
+      - kubectl get pods -A -o wide || true
+      - kubectl delete -f e2e-resources.yml || true
+      - helm uninstall ${SCENARIO_TAG} --namespace nr-${SCENARIO_TAG} || true
+      - kubectl delete namespace nr-${SCENARIO_TAG} || true
+    tests:
+      nrqls:
+        # Assert the marker lines emitted by the log-producer (e2e-resources.yml) reached NRDB.
+        # No WHERE/SINCE here: the action appends the cluster_name scope clause automatically.
+        - query: "SELECT filter(count(*), WHERE message LIKE '%nr-logging-e2e-marker%') AS markerCount FROM Log"
+          expected_results:
+            - key: "markerCount"
+              lowerBoundedValue: 1

--- a/charts/newrelic-logging/e2e/test-specs.yml
+++ b/charts/newrelic-logging/e2e/test-specs.yml
@@ -26,3 +26,11 @@ scenarios:
           expected_results:
             - key: "markerCount"
               lowerBoundedValue: 1
+      # Unlike `after:` above, a failing command here fails the scenario.
+      # Logs can arrive fine even if the pod is crash-looping, so we
+      # check pod health too, not just that logs showed up.
+      scripts:
+        - kubectl logs -n nr-${SCENARIO_TAG} -l app.kubernetes.io/name=newrelic-logging --all-containers --prefix=true --tail=200 || true  # for debugging, doesn't affect pass/fail
+        - kubectl get pods -n nr-${SCENARIO_TAG} -o wide  # for debugging, doesn't affect pass/fail
+        - kubectl wait --for=condition=Ready pod -n nr-${SCENARIO_TAG} -l app.kubernetes.io/name=newrelic-logging --timeout=60s  # fails if the pod never became healthy
+        - kubectl get pods -n nr-${SCENARIO_TAG} -l app.kubernetes.io/name=newrelic-logging -o json | jq -e '[.items[].status.containerStatuses[].restartCount] | all(. == 0)' > /dev/null  # fails if the pod restarted

--- a/charts/newrelic-logging/e2e/test-specs.yml
+++ b/charts/newrelic-logging/e2e/test-specs.yml
@@ -7,11 +7,11 @@ custom_test_key: cluster_name
 scenarios:
   - description: Default install forwards container logs to New Relic
     before:
-      - helm repo add newrelic https://helm-charts.newrelic.com
       - helm dependency update ../
       - helm upgrade --install ${SCENARIO_TAG} --namespace nr-${SCENARIO_TAG} --create-namespace ../ --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG}
+      - kubectl rollout status daemonset/${SCENARIO_TAG}-newrelic-logging -n nr-${SCENARIO_TAG} --timeout=60s
       - kubectl apply -f e2e-resources.yml
-    after:
+    after: &cleanup
       - kubectl logs -l app.kubernetes.io/name=newrelic-logging --all-containers --prefix=true || true
       - kubectl get pods -A -o wide || true
       - kubectl delete -f e2e-resources.yml || true
@@ -34,16 +34,11 @@ scenarios:
 
   - description: lowDataMode strips extra metadata but keeps the fields the chart says it will
     before:
-      - helm repo add newrelic https://helm-charts.newrelic.com
       - helm dependency update ../
       - helm upgrade --install ${SCENARIO_TAG} --namespace nr-${SCENARIO_TAG} --create-namespace ../ --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG} --set lowDataMode=true
+      - kubectl rollout status daemonset/${SCENARIO_TAG}-newrelic-logging -n nr-${SCENARIO_TAG} --timeout=60s
       - kubectl apply -f e2e-resources.yml
-    after:
-      - kubectl logs -l app.kubernetes.io/name=newrelic-logging --all-containers --prefix=true || true
-      - kubectl get pods -A -o wide || true
-      - kubectl delete -f e2e-resources.yml || true
-      - helm uninstall ${SCENARIO_TAG} --namespace nr-${SCENARIO_TAG} || true
-      - kubectl delete namespace nr-${SCENARIO_TAG} || true
+    after: *cleanup
     tests:
       nrqls:
         # lowDataMode strips most metadata, but a few basic fields should still survive.


### PR DESCRIPTION
#### What this PR does / why we need it:

1. Adds the Helm chart E2E scenario for `newrelic-logging`, closing the gap identified, the chart previously had only static template checks (`helm-unittest`) and an install smoke test (`ct install`), with nothing verifying that logs actually reach New Relic.

2. Also adds a pod-health check: after the NRQL check, it asserts the pod is Ready with zero
restarts. Log delivery alone can pass even while the pod is crash-looping (see [#2220](https://github.com/newrelic/helm-charts/issues/2220)) — this
check closes that gap.

This adds a PR-gated workflow (`newrelic-logging-e2e.yml`) that installs the chart on Minikube, deploys a log-producer emitting uniquely-marked lines, and asserts via NRQL that they arrive in `Log` data.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
- Two workflows: newrelic-logging-e2e.yml (internal PRs) and newrelic-logging-e2e-external.yml (fork PRs — gated behind the E2E environment, requiring approval from the K8S-AGENTS team before secrets are exposed).
- Scope: Linux only. Both scenarios (default install, lowDataMode) run against Minikube on ubuntu-latest. Windows nodes and other K8s distributions (EKS/GKE/AKS) are not covered by CI yet.
- Uses the existing K8S_AGENTS_E2E_ACCOUNT_ID / _API_KEY / _LICENSE_KEY secrets already configured in this repo.
- No chart version bump — this PR only adds test/CI scaffolding, no template or values changes.

Next steps:
- [x] Add Windows e2e coverage — tracked in https://new-relic.atlassian.net/browse/NR-601614, needs its own test harness (no Minikube equivalent for Windows nodes).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Tell the world about the latest changes in the chart.
<!--END-RELEASE-NOTES-->
