### PR TITLE
[agent-control-deployment] feat: cleanup resources on uninstall [NR-572127]

### DIFF
--- a/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 
 type: application
 
-version: 1.7.13
+version: 1.7.14
 
 dependencies:
   - name: common-library

--- a/charts/agent-control-deployment/README.md
+++ b/charts/agent-control-deployment/README.md
@@ -447,6 +447,12 @@ proxy:
 			<td>The secrets that are needed to pull images from a custom registry.</td>
 		</tr>
 		<tr>
+			<td>uninstallation.log.level</td>
+			<td>string</td>
+			<td>debug</td>
+			<td>Log level for the uninstallation job.</td>
+		</tr>
+		<tr>
 			<td>verboseLog</td>
 			<td>bool</td>
 			<td>`false`</td>

--- a/charts/agent-control-deployment/templates/service-account-uninstallation.yaml
+++ b/charts/agent-control-deployment/templates/service-account-uninstallation.yaml
@@ -1,5 +1,5 @@
 
-{{- if and (not .Values.cdEnabled) .Values.rbac.create -}}
+{{- if .Values.rbac.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -28,7 +28,29 @@ rules:
     verbs:
       - get
   - apiGroups: [ "" ]
-    resources: [ "configmaps" ]
+    resources: [ "pods" ]
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: [ "" ]
+    resources: [ "configmaps", "secrets" ]
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+      - deletecollection
+  - apiGroups: [ "source.toolkit.fluxcd.io", "helm.toolkit.fluxcd.io" ]
+    resources: [ "helmrepositories", "helmreleases" ]
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+      - deletecollection
+  - apiGroups: [ "newrelic.com" ]
+    resources: [ "*" ]
     verbs:
       - get
       - list

--- a/charts/agent-control-deployment/templates/uninstallation-job.yaml
+++ b/charts/agent-control-deployment/templates/uninstallation-job.yaml
@@ -1,4 +1,3 @@
-{{- if not .Values.cdEnabled -}}
 {{- $uninstallJobName := include "newrelic.common.naming.truncateToDNSWithSuffix" ( dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "uninstall-job" ) -}}
 apiVersion: batch/v1
 kind: Job
@@ -29,7 +28,12 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |-
-              echo "Removing configMaps created by AgentControl"
-              kubectl delete configmaps -l app.kubernetes.io/managed-by=newrelic-agent-control
-              kubectl delete configmaps -l app.kubernetes.io/managed-by=newrelic-agent-control -n {{ .Values.subAgentsNamespace }}
-{{- end -}}
+              echo "Waiting for the Agent Control pod to terminate..."
+              kubectl wait --for=delete pod \
+                -l app.kubernetes.io/name={{ include "newrelic.common.naming.name" . }},app.kubernetes.io/instance={{ .Release.Name }} \
+                -n {{ .Release.Namespace }} --timeout=60s || true
+              echo "Removing Agent Control managed resources..."
+              newrelic-agent-control-cli uninstall-agent-control \
+                --namespace "{{ .Release.Namespace }}" \
+                --namespace-agents "{{ .Values.subAgentsNamespace }}" \
+                --log-level "{{ .Values.uninstallation.log.level }}"

--- a/charts/agent-control-deployment/tests/service_account_uninstallation_test.yaml
+++ b/charts/agent-control-deployment/tests/service_account_uninstallation_test.yaml
@@ -1,0 +1,66 @@
+suite: uninstallation RBAC values are honored
+templates:
+  - templates/service-account-uninstallation.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+tests:
+  - it: renders the ServiceAccount, ClusterRole and RoleBindings when rbac.create is true
+    set:
+      rbac:
+        create: true
+    asserts:
+      - hasDocuments:
+          count: 4
+
+  - it: does not render when rbac.create is false
+    set:
+      rbac:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: grants the ClusterRole the rules the sweep and wait step need
+    set:
+      rbac:
+        create: true
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: rules
+          value:
+            - apiGroups: [ "" ]
+              resources: [ "namespaces" ]
+              verbs:
+                - get
+            - apiGroups: [ "" ]
+              resources: [ "pods" ]
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups: [ "" ]
+              resources: [ "configmaps", "secrets" ]
+              verbs:
+                - get
+                - list
+                - watch
+                - delete
+                - deletecollection
+            - apiGroups: [ "source.toolkit.fluxcd.io", "helm.toolkit.fluxcd.io" ]
+              resources: [ "helmrepositories", "helmreleases" ]
+              verbs:
+                - get
+                - list
+                - watch
+                - delete
+                - deletecollection
+            - apiGroups: [ "newrelic.com" ]
+              resources: [ "*" ]
+              verbs:
+                - get
+                - list
+                - watch
+                - delete
+                - deletecollection

--- a/charts/agent-control-deployment/tests/uninstallation_job_test.yaml
+++ b/charts/agent-control-deployment/tests/uninstallation_job_test.yaml
@@ -1,0 +1,48 @@
+suite: uninstall job template
+templates:
+  - templates/uninstallation-job.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+tests:
+  - it: calls uninstall-agent-control without --release-name
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: 'newrelic-agent-control-cli uninstall-agent-control'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: '--namespace "my-namespace"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: '--namespace-agents "newrelic"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: '--log-level "debug"'
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: '--release-name'
+
+  - it: waits for the Agent Control pod to terminate before sweeping
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: 'kubectl wait --for=delete pod \\\s*\n\s*-l app\.kubernetes\.io/name=agent-control,app\.kubernetes\.io/instance=my-release \\\s*\n\s*-n my-namespace --timeout=60s \|\| true'
+
+  - it: honors a custom subAgentsNamespace
+    set:
+      subAgentsNamespace: agents-ns
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: '--namespace-agents "agents-ns"'
+
+  - it: honors a custom uninstallation log level
+    set:
+      uninstallation:
+        log:
+          level: trace
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: '--log-level "trace"'

--- a/charts/agent-control-deployment/values.yaml
+++ b/charts/agent-control-deployment/values.yaml
@@ -14,6 +14,12 @@ customSecretLicenseKey: ""
 # @default -- "newrelic"
 subAgentsNamespace: "newrelic"
 
+uninstallation:
+  log:
+    # -- Log level for the uninstallation job.
+    # @default -- debug
+    level: "debug"
+
 # -- Image for the New Relic Agent Control
 # @default -- See <a href="values.yaml">values.yaml</a>
 image:


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This PR extends the uninstallation-job for `agent-control-deployment` in order to cleanup the Agent Control resources on uninstallation.

Before the change only ConfigMaps where removed when the chart was used standalone.

Uses the k8s CLI's updates on
- https://github.com/newrelic/newrelic-agent-control/pull/2742
- https://github.com/newrelic/newrelic-agent-control/pull/2751

#### Special notes for your reviewer:

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Tell the world about the latest changes in the chart.
<!--END-RELEASE-NOTES-->
