### PR TITLE
[nr-k8s-otel-collector] fix: let custom collector components override built-in defaults

### DIFF
--- a/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
@@ -11,7 +11,6 @@ data:
     {{- . | nindent 4 }}
     {{- else }}
     receivers:
-      {{- include "nrKubernetesOtel.daemonset.configMap.extraConfig.receivers" . | nindent 6 }}
       host_metrics:
         # TODO (chris): this is a linux specific configuration
         {{- if not (or (include "newrelic.common.gkeAutopilot" .) (include "newrelic.common.openShift" .)) }}
@@ -219,11 +218,9 @@ data:
           - id: container-parser
             type: container
 
+      {{- include "nrKubernetesOtel.daemonset.configMap.extraConfig.receivers" . | nindent 6 }}
 
     processors:
-      {{- include "nrKubernetesOtel.daemonset.configMap.extraConfig.processors" . | nindent 6 }}
-      {{- include "nrKubernetesOtel.custom.processors" . | nindent 6 }}
-
       groupbyattrs:
         keys:
           - pod
@@ -877,18 +874,19 @@ data:
         timeout: 30s
         send_batch_size : 800
 
-    exporters:
-      {{- include "nrKubernetesOtel.daemonset.configMap.extraConfig.exporters" . | nindent 6 }}
-      {{- include "nrKubernetesOtel.custom.exporters" . | nindent 6 }}
+      {{- include "nrKubernetesOtel.daemonset.configMap.extraConfig.processors" . | nindent 6 }}
+      {{- include "nrKubernetesOtel.custom.processors" . | nindent 6 }}
 
+    exporters:
       otlp_http/newrelic:
         endpoint: {{ include "newrelic.common.otlp_endpoint" . }}
         headers:
           api-key: ${env:NR_LICENSE_KEY}
 
-    connectors:
-      {{- include "nrKubernetesOtel.daemonset.configMap.extraConfig.connectors" . | nindent 6 }}
+      {{- include "nrKubernetesOtel.daemonset.configMap.extraConfig.exporters" . | nindent 6 }}
+      {{- include "nrKubernetesOtel.custom.exporters" . | nindent 6 }}
 
+    connectors:
       routing/nr_logs_pipelines:
         default_pipelines: [logs/pipeline]
         table:
@@ -947,6 +945,8 @@ data:
           - context: metric
             condition: instrumentation_scope.name == "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver"
             pipelines: [metrics/nr]
+
+      {{- include "nrKubernetesOtel.daemonset.configMap.extraConfig.connectors" . | nindent 6 }}
 
     {{- with include "nrKubernetesOtel.daemonset.configMap.extraConfig.extensions" . }}
     extensions:

--- a/charts/nr-k8s-otel-collector/templates/deployment-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/deployment-configmap.yaml
@@ -11,7 +11,6 @@ data:
     {{- . | nindent 4 }}
     {{- else }}
     receivers:
-      {{- include "nrKubernetesOtel.deployment.configMap.extraConfig.receivers" . | nindent 6 }}
       otlp:
         protocols:
           http:
@@ -178,10 +177,9 @@ data:
                   replacement: otel-collector-deployment
       {{- end }}
 
-    processors:
-      {{- include "nrKubernetesOtel.deployment.configMap.extraConfig.processors" . | nindent 6 }}
-      {{- include "nrKubernetesOtel.custom.processors" . | nindent 6 }}
+      {{- include "nrKubernetesOtel.deployment.configMap.extraConfig.receivers" . | nindent 6 }}
 
+    processors:
       transform/promote_job_label:
         metric_statements:
           - context: datapoint
@@ -748,17 +746,19 @@ data:
         timeout: 30s
         send_batch_size : 800
 
+      {{- include "nrKubernetesOtel.deployment.configMap.extraConfig.processors" . | nindent 6 }}
+      {{- include "nrKubernetesOtel.custom.processors" . | nindent 6 }}
+
     exporters:
-      {{- include "nrKubernetesOtel.deployment.configMap.extraConfig.exporters" . | nindent 6 }}
-      {{- include "nrKubernetesOtel.custom.exporters" . | nindent 6 }}
       otlp_http/newrelic:
         endpoint: {{ include "newrelic.common.otlp_endpoint" . }}
         headers:
           api-key: ${env:NR_LICENSE_KEY}
 
-    connectors:
-      {{- include "nrKubernetesOtel.deployment.configMap.extraConfig.connectors" . | nindent 6 }}
+      {{- include "nrKubernetesOtel.deployment.configMap.extraConfig.exporters" . | nindent 6 }}
+      {{- include "nrKubernetesOtel.custom.exporters" . | nindent 6 }}
 
+    connectors:
       routing/nr_logs_pipelines:
         default_pipelines: [logs/pipeline]
         table:
@@ -796,6 +796,8 @@ data:
           - context: metric
             condition: instrumentation_scope.attributes["job_label"] == "scheduler"
             pipelines: [metrics/nr_controlplane]
+
+      {{- include "nrKubernetesOtel.deployment.configMap.extraConfig.connectors" . | nindent 6 }}
 
     {{- with include "nrKubernetesOtel.deployment.configMap.extraConfig.extensions" . }}
     extensions:

--- a/charts/nr-k8s-otel-collector/tests/config_map_test.yaml
+++ b/charts/nr-k8s-otel-collector/tests/config_map_test.yaml
@@ -493,3 +493,77 @@ tests:
         matchRegex:
           path: data["daemonset-config.yaml"]
           pattern: endpoint:\s*https://otlp.jp.nr-data.net
+
+  - it: custom processors override the same-named built-in processor (last occurrence wins)
+    set:
+      cluster: my-cluster
+      licenseKey: us-key
+      processors:
+        resource_detection/cloudproviders:
+          zzz_override_marker: applied
+    asserts:
+      # The built-in resource_detection/cloudproviders (with its full detector list) must render
+      # BEFORE the custom override, so the collector's last-key-wins parsing applies the override.
+      - matchRegex:
+          path: data["daemonset-config.yaml"]
+          pattern: 'detectors: \[gcp, eks, ec2, aks, azure, oraclecloud\][\S\s]*zzz_override_marker: applied'
+        template: templates/daemonset-configmap.yaml
+
+  - it: custom processors override the same-named built-in processor on the deployment (last occurrence wins)
+    set:
+      cluster: my-cluster
+      licenseKey: us-key
+      processors:
+        memory_limiter:
+          zzz_override_marker: applied
+    asserts:
+      # The built-in memory_limiter must render BEFORE the custom override so last-key-wins applies it.
+      - matchRegex:
+          path: data["deployment-config.yaml"]
+          pattern: 'spike_limit_percentage: 25[\S\s]*zzz_override_marker: applied'
+        template: templates/deployment-configmap.yaml
+
+  - it: custom exporters override the same-named built-in exporter (last occurrence wins)
+    set:
+      cluster: my-cluster
+      licenseKey: us-key
+      exporters:
+        otlp_http/newrelic:
+          zzz_override_marker: applied
+    asserts:
+      # The built-in otlp_http/newrelic must render BEFORE the custom override so last-key-wins applies it.
+      - matchRegex:
+          path: data["deployment-config.yaml"]
+          pattern: 'api-key: \$\{env:NR_LICENSE_KEY\}[\S\s]*zzz_override_marker: applied'
+        template: templates/deployment-configmap.yaml
+      - matchRegex:
+          path: data["daemonset-config.yaml"]
+          pattern: 'api-key: \$\{env:NR_LICENSE_KEY\}[\S\s]*zzz_override_marker: applied'
+        template: templates/daemonset-configmap.yaml
+
+  - it: extraConfig receivers and connectors render after the built-in definitions
+    set:
+      cluster: my-cluster
+      licenseKey: us-key
+      deployment.configMap.extraConfig.receivers: zzzExtraReceiverMarker
+      deployment.configMap.extraConfig.connectors: zzzExtraConnectorMarker
+      daemonset.configMap.extraConfig.receivers: zzzExtraReceiverMarker
+      daemonset.configMap.extraConfig.connectors: zzzExtraConnectorMarker
+    asserts:
+      # A built-in receiver must render before the custom one, which must still sit inside the receivers block.
+      - matchRegex:
+          path: data["daemonset-config.yaml"]
+          pattern: 'host_metrics:[\S\s]*zzzExtraReceiverMarker[\S\s]*processors:'
+        template: templates/daemonset-configmap.yaml
+      - matchRegex:
+          path: data["daemonset-config.yaml"]
+          pattern: 'routing/nr_logs_pipelines:[\S\s]*zzzExtraConnectorMarker'
+        template: templates/daemonset-configmap.yaml
+      - matchRegex:
+          path: data["deployment-config.yaml"]
+          pattern: 'otlp:[\S\s]*zzzExtraReceiverMarker[\S\s]*processors:'
+        template: templates/deployment-configmap.yaml
+      - matchRegex:
+          path: data["deployment-config.yaml"]
+          pattern: 'routing/nr_logs_pipelines:[\S\s]*zzzExtraConnectorMarker'
+        template: templates/deployment-configmap.yaml


### PR DESCRIPTION
#### What this PR does / why we need it:

Custom receivers, processors, exporters, and connectors defined via values (`.Values.processors`, `.Values.exporters`, and the `daemonset`/`deployment.configMap.extraConfig.*` paths) were rendered *before* the chart's built-in definitions in the ConfigMap. Because the OTel Collector resolves duplicate YAML keys as "last wins," any override of a built-in component by name was silently discarded, the hardcoded definition always won.

This moves the custom-component includes to the end of each block (`receivers`, `processors`, `exporters`, `connectors`) in both `daemonset-configmap.yaml` and `deployment-configmap.yaml`, so user-supplied values now take precedence. `extensions` was already correct (appended via `{{- with }}`).

**How we found it:** a DaemonSet stuck in permanent `CrashLoopBackOff` on an EKS canary cluster. The collector fails to start every time with:

```
error  graph/graph.go:437  Failed to start component
  error: failed to get instance metadata: operation error EC2: DescribeInstances,
         get identity: get credentials: request canceled, context deadline exceeded
  type: Processor, id: resource_detection/cloudproviders
Error: cannot start pipelines: failed to start "resource_detection/cloudproviders" processor: ...
```

The `ec2` (and `eks`) detector in `resource_detection/cloudproviders` times out reaching EC2 IMDS from pods in that environment. When any processor fails to start, the collector aborts every pipeline, so metrics and logs both go dark. The intended remediation is for operators to override `resource_detection/cloudproviders.detectors` via values to drop those detectors, but that override was being silently ignored due to this bug. Confirmed by patching the live ConfigMap with the override this PR unblocks: the collector then starts cleanly (`Everything is ready. Begin running and processing data.`).

#### Special notes for your reviewer:

Adds 4 regression tests to `config_map_test.yaml` asserting a same-named override renders after (and wins over) the built-in, covering all four component types across both configmaps. Verified they fail on the pre-fix templates and pass after. The pre-existing "custom processors/exporters" test only checked that a value appeared *somewhere* using a non-colliding key, which is why the bug shipped.

Validation: `helm lint` clean, `helm unittest` 222/222 pass. The default (no-override) rendered config is **semantically identical** before/after — the parsed YAML is unchanged; the only byte-level differences are whitespace-only lines that shift as the four blocks are reordered.

**⚠️ Upgrade impact:** each pod spec annotates `checksum/config` with a `sha256sum` of the rendered ConfigMap (`daemonset.yaml:20`, `deployment.yaml:22`), so the whitespace shift changes the checksum. Upgrading to this version triggers a one-time rolling restart of all collector DaemonSet and Deployment pods, even for users with no custom overrides. The effective config is unchanged, so collectors restart cleanly — expect a brief gap in collection during the rollout.

#### Checklist

- [ ] Chart Version bumped — not bumped here; this chart's version is handled by the separate weekly-release process
- [x] Variables documented in README.md — no new variables, existing values paths
- [x] Title of the PR starts with chart name

# Release Notes to Publish (nr-k8s-otel-collector)

<!--BEGIN-RELEASE-NOTES-->
## 🐛 Bug Fixes
* Fix custom `receivers`, `processors`, `exporters`, and `connectors` set via values being silently discarded when overriding a built-in component of the same name.
<!--END-RELEASE-NOTES-->
