### PR TITLE
Workflows remove update-eks-sleek from notify-failure job

### DIFF
--- a/.github/workflows/post-release-nri-bundle.yml
+++ b/.github/workflows/post-release-nri-bundle.yml
@@ -176,7 +176,7 @@ jobs:
 
   notify-failure:
     if: ${{ always() && failure() }}
-    needs: [release-notes,announce-release,update-public-docs,update-eks-sleek]
+    needs: [release-notes,announce-release,update-public-docs]
     runs-on: ubuntu-latest
     steps:
       - name: Notify failure via Slack


### PR DESCRIPTION
#### What this PR does / why we need it:
Removes a dependency on a job that no longer exists. 
update-eks-sleek was removed in this PR 
https://github.com/newrelic/helm-charts/pull/2375 

However a this refrence to this job is now breaking this workflow. 
See this error:
https://github.com/newrelic/helm-charts/actions/runs/30887086217/workflow
 
#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)

# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Tell the world about the latest changes in the chart.
<!--END-RELEASE-NOTES-->
