### PR TITLE
[nr-ebpf-agent] Add check for customOtlpEndpoint

### DIFF
--- a/charts/nr-ebpf-agent/Chart.yaml
+++ b/charts/nr-ebpf-agent/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.0
+version: 1.5.1
 
 dependencies:
   - name: common-library

--- a/charts/nr-ebpf-agent/templates/nr-ebpf-agent-daemonset.yaml
+++ b/charts/nr-ebpf-agent/templates/nr-ebpf-agent-daemonset.yaml
@@ -126,7 +126,7 @@ spec:
               fieldRef:
                 fieldPath: status.hostIP
           - name: OTLP_ENDPOINT
-            value: {{ include "newrelic.common.otlp_endpoint" . | trimPrefix "https://" }}:443
+            value: {{ if .Values.customOtlpEndpoint }}{{ .Values.customOtlpEndpoint }}{{ else }}{{ include "newrelic.common.otlp_endpoint" . | trimPrefix "https://" }}:443{{ end }}
           - name: TLS_ENABLED
             value: '{{ if or (kindIs "invalid" .Values.customOtlpEndpointTlsEnabled) (eq (toString .Values.customOtlpEndpointTlsEnabled) "") }}true{{ else }}{{ .Values.customOtlpEndpointTlsEnabled }}{{ end }}'
         {{- if and .Values.customOtlpEndpointTlsCertSecret .Values.customOtlpEndpointTlsCertSecretKey }}


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

`customOtlpEndpoint` is documented in `values.yaml` as taking precedence over the region-based OTLP endpoint, but the `nr-ebpf-agent` DaemonSet template never actually read that value — the `OTLP_ENDPOINT` env var always rendered the region-based `newrelic.common.otlp_endpoint` default, silently ignoring any override.

This PR restores that behavior:
- When `customOtlpEndpoint` is set, it is used verbatim (no scheme trimming, no forced `:443` suffix), so values that already include their own port (e.g. `https://my-otlp.example.com:4317`) render correctly instead of getting mangled.
- When `customOtlpEndpoint` is not set, behavior is unchanged — it falls back to the existing region-based default with `:443` appended.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

Verified via `helm template` against the following cases:
- Default (US region, no override): `otlp.nr-data.net:443`
- Region override (EU, no override): `otlp.eu01.nr-data.net:443`
- `customOtlpEndpoint` without a port: used as-is
- `customOtlpEndpoint` with a port: used as-is, no duplicate `:443`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Tell the world about the latest changes in the chart.
<!--END-RELEASE-NOTES-->
