### PR TITLE
[agent-control-deployment] drop permissions

### DIFF
--- a/charts/agent-control-deployment/Chart.yaml
+++ b/charts/agent-control-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to install New Relic Agent Control on Kubernetes
 
 type: application
 
-version: 1.7.15
+version: 1.7.16
 
 dependencies:
   - name: common-library

--- a/charts/agent-control-deployment/templates/rbac.yaml
+++ b/charts/agent-control-deployment/templates/rbac.yaml
@@ -19,10 +19,6 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups: [ "" ]
-    resources: [ "namespaces" ]
-    verbs:
-      - get
   ###
   # AC is capable of manage following resources defined as part of an Agent Type.
   - apiGroups:

--- a/charts/agent-control-deployment/templates/service-account-uninstallation.yaml
+++ b/charts/agent-control-deployment/templates/service-account-uninstallation.yaml
@@ -24,10 +24,6 @@ metadata:
   name: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "uninstall-job-resources") }}
 rules:
   - apiGroups: [ "" ]
-    resources: [ "namespaces" ]
-    verbs:
-      - get
-  - apiGroups: [ "" ]
     resources: [ "pods" ]
     verbs:
       - get

--- a/charts/agent-control-deployment/tests/service_account_uninstallation_test.yaml
+++ b/charts/agent-control-deployment/tests/service_account_uninstallation_test.yaml
@@ -31,10 +31,6 @@ tests:
           path: rules
           value:
             - apiGroups: [ "" ]
-              resources: [ "namespaces" ]
-              verbs:
-                - get
-            - apiGroups: [ "" ]
               resources: [ "pods" ]
               verbs:
                 - get


### PR DESCRIPTION
#### What this PR does / why we need it:
no

We are dropping the permissions not needed anymore. 

We are mounting such ClusterRoles with RoleBindings therefore the cluster-wide resources are dropped anyway
