### PR TITLE
[agent-control-bootstrap] drop permissions drop permissions bootstrap

### DIFF
--- a/charts/agent-control-bootstrap/Chart.yaml
+++ b/charts/agent-control-bootstrap/Chart.yaml
@@ -3,7 +3,7 @@ name: agent-control-bootstrap
 description: Bootstraps New Relic' Agent Control
 
 type: application
-version: 1.8.10
+version: 1.8.11
 # renovate: chartName=agent-control-deployment
 appVersion: 1.7.16
 annotations:

--- a/charts/agent-control-bootstrap/Chart.yaml
+++ b/charts/agent-control-bootstrap/Chart.yaml
@@ -5,7 +5,7 @@ description: Bootstraps New Relic' Agent Control
 type: application
 version: 1.8.10
 # renovate: chartName=agent-control-deployment
-appVersion: 1.7.14
+appVersion: 1.7.16
 annotations:
   # renovate: chartName=agent-control-cd
   agentControlCdVersion: 1.0.0

--- a/charts/agent-control-bootstrap/templates/rbac-ac.yaml
+++ b/charts/agent-control-bootstrap/templates/rbac-ac.yaml
@@ -21,10 +21,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups: [ "" ]
-    resources: [ "namespaces" ]
-    verbs:
-      - get
   - apiGroups: [ "apps" ]
     resources: [ "deployments", "daemonsets", "statefulsets" ]
     verbs:
@@ -63,10 +59,6 @@ metadata:
     {{- include "newrelic.common.labels" . | nindent 4 }}
   name: {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "uninstall-job-resources") }}
 rules:
-  - apiGroups: [ "" ]
-    resources: [ "namespaces" ]
-    verbs:
-      - get
   - apiGroups: [ "apps" ]
     resources: [ "deployments", "daemonsets", "statefulsets" ]
     verbs:

--- a/charts/agent-control-bootstrap/values.yaml
+++ b/charts/agent-control-bootstrap/values.yaml
@@ -7,7 +7,7 @@ fullnameOverride: ""
 toolkitImage:
   registry:
   repository: newrelic/newrelic-agent-control-cli
-  tag: "1.20.0"
+  tag: "1.21.0"
   pullPolicy: IfNotPresent
   # -- The secrets that are needed to pull images from a custom registry.
   pullSecrets: []


### PR DESCRIPTION
We are dropping the permissions not needed anymore.

We are mounting such ClusterRoles with RoleBindings therefore the cluster-wide resources are dropped anyway
