### PR TITLE
Bump newrelic-fluentbit-output image to 3.8.0

### DIFF
--- a/charts/newrelic-logging/Chart.yaml
+++ b/charts/newrelic-logging/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: A Helm chart to deploy New Relic Kubernetes Logging as a DaemonSet, supporting both Linux and Windows nodes and containers
 name: newrelic-logging
-version: 1.39.0
-appVersion: 3.7.0
+version: 1.40.0
+appVersion: 3.8.0
 home: https://github.com/newrelic/kubernetes-logging
 icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
 maintainers:

--- a/charts/newrelic-logging/tests/images_test.yaml
+++ b/charts/newrelic-logging/tests/images_test.yaml
@@ -17,16 +17,16 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/newrelic/newrelic-fluentbit-output:3.7.0
+          value: docker.io/newrelic/newrelic-fluentbit-output:3.8.0
         template: templates/daemonset.yaml
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/newrelic/newrelic-fluentbit-output:3.7.0-windows-ltsc-2019
+          value: docker.io/newrelic/newrelic-fluentbit-output:3.8.0-windows-ltsc-2019
         template: templates/daemonset-windows.yaml
         documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/newrelic/newrelic-fluentbit-output:3.7.0-windows-ltsc-2022
+          value: docker.io/newrelic/newrelic-fluentbit-output:3.8.0-windows-ltsc-2022
         template: templates/daemonset-windows.yaml
         documentIndex: 1
   - it: global registry is used if set


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This PR bumps the image for newrelic-logging integration, it uses the plugin version 3.8.0 that uses fluent-bit 5.0.9 for docker images. Related PR: https://github.com/newrelic/newrelic-fluent-bit-output/pull/265

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - upgrade the newrelic-fluentbit-output image to 3.8.0.
  
  
#### Testing Steps:
Here are the steps I followed:
1. Installed published nri-bundle(baseline,newrelic-logging3.7.0) on minikube
2. Temporarily pointed nri-bundle's dependency at my local chart, rebuilt dependencies
3. helm upgradein place image confirmednewrelic-fluentbit-output:3.8.0, logs show clean startup with no errors, no other bundle components disrupted

Attached snapshot for reference: 
<img width="3398" height="1760" alt="image" src="https://github.com/user-attachments/assets/202c3ce1-5421-423a-95c1-53bc26615518" />

  

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)

# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Tell the world about the latest changes in the chart.
<!--END-RELEASE-NOTES-->
