### PR TITLE
[nr-k8s-otel-collector] fix: collect kubelet/cadvisor metrics on GKE Autopilot

### DIFF
--- a/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
@@ -90,7 +90,7 @@ data:
         insecure_skip_verify: true
         metrics:
           {{- if include "newrelic.common.gkeAutopilot" . }}
-          # Disabled on GKE-Autopilot: /pods (nodes/proxy) is blocked there, crash-looping the receiver.
+          # Disabled on GKE Autopilot: /pods (nodes/proxy) is blocked there, crash-looping the receiver.
           k8s.container.cpu_limit_utilization:
             enabled: false
           k8s.pod.cpu_limit_utilization:
@@ -126,7 +126,7 @@ data:
                 - role: node
               relabel_configs:
                 {{- if include "newrelic.common.gkeAutopilot" . }}
-                # nodes/proxy is blocked on GKE-Autopilot; direct-dial the kubelet cadvisor endpoint (authorizes via nodes/metrics).
+                # nodes/proxy is blocked on GKE Autopilot; direct-dial the kubelet cadvisor endpoint (authorizes via nodes/metrics).
                 - replacement: ${KUBE_NODE_NAME}:10250
                   target_label: __address__
                 - replacement: /metrics/cadvisor

--- a/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
@@ -85,15 +85,27 @@ data:
       kubelet_stats:
         collection_interval: {{ .Values.receivers.kubeletstats.scrapeInterval }}
         metric_groups: [node, pod, container, volume]
-        {{- if not (include "newrelic.common.gkeAutopilot" .) }}
+        # GKE Autopilot disables the read-only kubelet port (:10255); the authenticated
+        # port (:10250) is reachable on every provider, so use it unconditionally.
         endpoint: "${KUBE_NODE_NAME}:10250"
         auth_type: "serviceAccount"
         insecure_skip_verify: true
-        {{- else }}
-        endpoint: "${KUBE_NODE_NAME}:10255"
-        auth_type: "none"
-        {{- end }}
         metrics:
+          {{- if include "newrelic.common.gkeAutopilot" . }}
+          # These *_utilization metrics require the kubelet /pods endpoint (nodes/proxy),
+          # which GKE Autopilot blocks. Leaving them enabled makes the receiver call /pods,
+          # get a 403, and crash-loop — dropping ALL kubelet metrics. Disable on Autopilot.
+          k8s.container.cpu_limit_utilization:
+            enabled: false
+          k8s.pod.cpu_limit_utilization:
+            enabled: false
+          k8s.pod.cpu_request_utilization:
+            enabled: false
+          k8s.pod.memory_limit_utilization:
+            enabled: false
+          k8s.pod.memory_request_utilization:
+            enabled: false
+          {{- else }}
           k8s.container.cpu_limit_utilization:
             enabled: true
           k8s.pod.cpu_limit_utilization:
@@ -104,6 +116,7 @@ data:
             enabled: true
           k8s.pod.memory_request_utilization:
             enabled: true
+          {{- end }}
           k8s.pod.volume.usage:
             enabled: true
 
@@ -116,6 +129,14 @@ data:
               kubernetes_sd_configs:
                 - role: node
               relabel_configs:
+                {{- if include "newrelic.common.gkeAutopilot" . }}
+                # GKE Autopilot blocks the API-server nodes/proxy path; scrape the kubelet's
+                # cadvisor endpoint directly on the authenticated port (authorizes via nodes/metrics).
+                - replacement: ${KUBE_NODE_NAME}:10250
+                  target_label: __address__
+                - replacement: /metrics/cadvisor
+                  target_label: __metrics_path__
+                {{- else }}
                 - replacement: kubernetes.default.svc.cluster.local:443
                   target_label: __address__
                 - regex: (.+)
@@ -123,6 +144,7 @@ data:
                   source_labels:
                     - __meta_kubernetes_node_name
                   target_label: __metrics_path__
+                {{- end }}
                 - action: replace
                   target_label: job_label
                   replacement: cadvisor
@@ -157,14 +179,27 @@ data:
               scheme: https
               tls_config:
                 ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                {{- if include "newrelic.common.gkeAutopilot" . }}
+                # Direct kubelet cert won't match server_name "kubernetes"; skip verification.
+                insecure_skip_verify: true
+                {{- else }}
                 insecure_skip_verify: false
                 server_name: kubernetes
+                {{- end }}
             - job_name: kubelet
               scrape_interval: {{ .Values.receivers.prometheus.scrapeInterval }}
               bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
               kubernetes_sd_configs:
                 - role: node
               relabel_configs:
+                {{- if include "newrelic.common.gkeAutopilot" . }}
+                # GKE Autopilot blocks the API-server nodes/proxy path; scrape the kubelet
+                # /metrics endpoint directly on the authenticated port (authorizes via nodes/metrics).
+                - replacement: ${KUBE_NODE_NAME}:10250
+                  target_label: __address__
+                - replacement: /metrics
+                  target_label: __metrics_path__
+                {{- else }}
                 - replacement: kubernetes.default.svc.cluster.local:443
                   target_label: __address__
                 - regex: (.+)
@@ -172,6 +207,7 @@ data:
                   source_labels:
                     - __meta_kubernetes_node_name
                   target_label: __metrics_path__
+                {{- end }}
                 - action: replace
                   target_label: job_label
                   replacement: kubelet
@@ -181,8 +217,13 @@ data:
               scheme: https
               tls_config:
                 ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                {{- if include "newrelic.common.gkeAutopilot" . }}
+                # Direct kubelet cert won't match server_name "kubernetes"; skip verification.
+                insecure_skip_verify: true
+                {{- else }}
                 insecure_skip_verify: false
                 server_name: kubernetes
+                {{- end }}
             {{- if (((.Values.receivers).collectorMetrics).enabled) }}
             - job_name: otel-collector
               scrape_interval: {{ ((.Values.receivers).collectorMetrics).scrapeInterval | default "1m" }}

--- a/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
@@ -85,16 +85,12 @@ data:
       kubelet_stats:
         collection_interval: {{ .Values.receivers.kubeletstats.scrapeInterval }}
         metric_groups: [node, pod, container, volume]
-        # GKE Autopilot disables the read-only kubelet port (:10255); the authenticated
-        # port (:10250) is reachable on every provider, so use it unconditionally.
         endpoint: "${KUBE_NODE_NAME}:10250"
         auth_type: "serviceAccount"
         insecure_skip_verify: true
         metrics:
           {{- if include "newrelic.common.gkeAutopilot" . }}
-          # These *_utilization metrics require the kubelet /pods endpoint (nodes/proxy),
-          # which GKE Autopilot blocks. Leaving them enabled makes the receiver call /pods,
-          # get a 403, and crash-loop — dropping ALL kubelet metrics. Disable on Autopilot.
+          # Disabled on GKE-Autopilot: /pods (nodes/proxy) is blocked there, crash-looping the receiver.
           k8s.container.cpu_limit_utilization:
             enabled: false
           k8s.pod.cpu_limit_utilization:
@@ -130,8 +126,7 @@ data:
                 - role: node
               relabel_configs:
                 {{- if include "newrelic.common.gkeAutopilot" . }}
-                # GKE Autopilot blocks the API-server nodes/proxy path; scrape the kubelet's
-                # cadvisor endpoint directly on the authenticated port (authorizes via nodes/metrics).
+                # nodes/proxy is blocked on GKE-Autopilot; direct-dial the kubelet cadvisor endpoint (authorizes via nodes/metrics).
                 - replacement: ${KUBE_NODE_NAME}:10250
                   target_label: __address__
                 - replacement: /metrics/cadvisor
@@ -180,7 +175,6 @@ data:
               tls_config:
                 ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
                 {{- if include "newrelic.common.gkeAutopilot" . }}
-                # Direct kubelet cert won't match server_name "kubernetes"; skip verification.
                 insecure_skip_verify: true
                 {{- else }}
                 insecure_skip_verify: false
@@ -193,8 +187,6 @@ data:
                 - role: node
               relabel_configs:
                 {{- if include "newrelic.common.gkeAutopilot" . }}
-                # GKE Autopilot blocks the API-server nodes/proxy path; scrape the kubelet
-                # /metrics endpoint directly on the authenticated port (authorizes via nodes/metrics).
                 - replacement: ${KUBE_NODE_NAME}:10250
                   target_label: __address__
                 - replacement: /metrics

--- a/charts/nr-k8s-otel-collector/tests/gke_auto_pilot_test.yaml
+++ b/charts/nr-k8s-otel-collector/tests/gke_auto_pilot_test.yaml
@@ -33,3 +33,71 @@ tests:
           path: data["daemonset-config.yaml"]
           pattern: ^\s*receivers:[\S\s]*processors:[\S\s]*exporters:[\S\s]*service:[\S\s]*pipelines:[\S\s]*logs/ingress:[\S\s]*$
         template: templates/daemonset-configmap.yaml
+  - it: provider GKE_AUTOPILOT points kubelet_stats at the authenticated port 10250, not the disabled read-only 10255
+    set:
+      cluster: my-cluster
+      licenseKey: us-whatever
+      provider: GKE_AUTOPILOT
+    asserts:
+      - matchRegex:
+          path: data["daemonset-config.yaml"]
+          pattern: 'endpoint: "\$\{KUBE_NODE_NAME\}:10250"'
+        template: templates/daemonset-configmap.yaml
+      - notMatchRegex:
+          path: data["daemonset-config.yaml"]
+          pattern: 'endpoint: "\$\{KUBE_NODE_NAME\}:10255"'
+        template: templates/daemonset-configmap.yaml
+  - it: provider GKE_AUTOPILOT disables the /pods-dependent utilization metrics (they 403 and crash the receiver on Autopilot)
+    set:
+      cluster: my-cluster
+      licenseKey: us-whatever
+      provider: GKE_AUTOPILOT
+    asserts:
+      - matchRegex:
+          path: data["daemonset-config.yaml"]
+          pattern: 'k8s\.pod\.cpu_request_utilization:\s+enabled: false'
+        template: templates/daemonset-configmap.yaml
+      - matchRegex:
+          path: data["daemonset-config.yaml"]
+          pattern: 'k8s\.pod\.memory_request_utilization:\s+enabled: false'
+        template: templates/daemonset-configmap.yaml
+      - matchRegex:
+          path: data["daemonset-config.yaml"]
+          pattern: 'k8s\.container\.cpu_limit_utilization:\s+enabled: false'
+        template: templates/daemonset-configmap.yaml
+  - it: non-autopilot keeps the utilization metrics enabled on port 10250
+    set:
+      cluster: my-cluster
+      licenseKey: us-whatever
+    asserts:
+      - matchRegex:
+          path: data["daemonset-config.yaml"]
+          pattern: 'endpoint: "\$\{KUBE_NODE_NAME\}:10250"'
+        template: templates/daemonset-configmap.yaml
+      - matchRegex:
+          path: data["daemonset-config.yaml"]
+          pattern: 'k8s\.pod\.cpu_request_utilization:\s+enabled: true'
+        template: templates/daemonset-configmap.yaml
+  - it: provider GKE_AUTOPILOT direct-dials the cadvisor prometheus job (bypasses the blocked nodes/proxy path)
+    set:
+      cluster: my-cluster
+      licenseKey: us-whatever
+      provider: GKE_AUTOPILOT
+    asserts:
+      - matchRegex:
+          path: data["daemonset-config.yaml"]
+          pattern: 'replacement: /metrics/cadvisor'
+        template: templates/daemonset-configmap.yaml
+      - notMatchRegex:
+          path: data["daemonset-config.yaml"]
+          pattern: 'proxy/metrics/cadvisor'
+        template: templates/daemonset-configmap.yaml
+  - it: non-autopilot cadvisor prometheus job uses the API-server nodes/proxy path
+    set:
+      cluster: my-cluster
+      licenseKey: us-whatever
+    asserts:
+      - matchRegex:
+          path: data["daemonset-config.yaml"]
+          pattern: 'proxy/metrics/cadvisor'
+        template: templates/daemonset-configmap.yaml


### PR DESCRIPTION
#### What this PR does / why we need it:

[NR-607820](https://new-relic.atlassian.net/browse/NR-607820)
On GKE Autopilot the collector was silently collecting **zero** kubelet/cAdvisor metrics — node/pod/container CPU, memory, filesystem, and network (~25% of the k8s UI metric set). Three problems in the `provider: GKE_AUTOPILOT` path caused it:

1. **`kubelet_stats` used the read-only port `:10255`** (`auth_type: none`). GKE disables that port by default on clusters running 1.32+ ([Disable the kubelet read-only port](https://cloud.google.com/kubernetes-engine/docs/how-to/disable-kubelet-readonly-port)), so every scrape returned `connection refused`.
2. **The `*_utilization` metrics force a kubelet `/pods` call**, which requires `nodes/proxy` — a permission that, per the same Google doc, *"cannot be granted on GKE Autopilot clusters."* That 403s and crash-loops the receiver, dropping **all** kubelet metrics.
3. **The prometheus `cadvisor`/`kubelet` jobs scraped via the API-server `nodes/proxy` path**, which is likewise blocked on Autopilot.

**The fix** follows Google's documented guidance (use the authenticated `:10250` port; avoid `nodes/proxy` by scraping the kubelet's own metric endpoints):

- `kubelet_stats` → `:10250` + `auth_type: serviceAccount` (the port every other provider already uses), and disable the 5 `/pods`-dependent `*_utilization` metrics on Autopilot so the receiver no longer crash-loops.
- prometheus `cadvisor`/`kubelet` jobs → scrape the kubelet directly at `:10250/metrics/cadvisor` and `:10250/metrics`, which authorize via `nodes/metrics` instead of the blocked `nodes/proxy`.

All changes are gated behind the `gkeAutopilot` provider check — **non-Autopilot providers render exactly as before.**

#### Special notes for your reviewer:

- Validated live on a GKE Autopilot cluster (v1.35): before = 0 kubelet/cAdvisor metrics; after = node/pod/container/volume + cAdvisor `container_*` flowing. **Config-only — no privileged container, no hostPath, no allowlist.**
- Two `kubelet_stats` utilization ratios (`k8s.pod.cpu_request_limit_ratio`, `k8s.pod.memory_request_limit_ratio`) remain unavailable on Autopilot — they require the kubelet `/pods` endpoint (`nodes/proxy`), which stays blocked even with `nodes/pods` granted. This matches Google's guidance to read pod data from the Kubernetes API instead; the underlying request/limit data is still available via kube-state-metrics.
- `:10250` scrapes use `insecure_skip_verify: true`, consistent with the existing `kubelet_stats` receiver's long-standing behaviour across all providers. (Verified TLS is achievable on Autopilot and can follow separately.)
- Unit tests added in `tests/gke_auto_pilot_test.yaml` assert the rendered config for both the Autopilot and non-Autopilot paths.

#### Checklist
- [x] Title of the PR starts with chart name

_Chart version is handled by the automated release process for `nr-k8s-otel-collector`, so no manual version bump is included. No new values were added, so no README changes are needed._

# Release Notes to Publish (nr-k8s-otel-collector)

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Fixed metric collection on GKE Autopilot: the collector now scrapes the authenticated kubelet port (`:10250`) instead of the disabled read-only port (`:10255`), scrapes cAdvisor/kubelet directly instead of the blocked `nodes/proxy` path, and disables the `/pods`-dependent utilization metrics that were crash-looping the receiver. Node, pod, container, volume, and cAdvisor metrics are now collected on GKE Autopilot.
<!--END-RELEASE-NOTES-->


[NR-607820]: https://new-relic.atlassian.net/browse/NR-607820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ