### PR TITLE
[nr-k8s-otel-collector] feat: GKE Autopilot allowlist host-fs and host-namespace flags

### DIFF
--- a/charts/nr-k8s-otel-collector/.helmignore
+++ b/charts/nr-k8s-otel-collector/.helmignore
@@ -30,3 +30,8 @@ ci/
 e2e/
 examples/
 tests/
+
+# Local scratch / generated output (never part of the chart package)
+_scratch/
+otel_output/
+_claude/

--- a/charts/nr-k8s-otel-collector/.helmignore
+++ b/charts/nr-k8s-otel-collector/.helmignore
@@ -30,8 +30,3 @@ ci/
 e2e/
 examples/
 tests/
-
-# Local scratch / generated output (never part of the chart package)
-_scratch/
-otel_output/
-_claude/

--- a/charts/nr-k8s-otel-collector/README.md
+++ b/charts/nr-k8s-otel-collector/README.md
@@ -102,6 +102,8 @@ If using GKE Autopilot, please set the following configuration in your values.ya
 provider: "GKE_AUTOPILOT"
 ```
 
+Setting `gkeAutopilotAllowList: true` keeps the `host-fs` mount and the hostmetrics `root_path` that GKE Autopilot normally strips, so node filesystem metrics (`system.filesystem.*`) can be collected. GKE Autopilot only admits that mount if a `WorkloadAllowlist` permitting the `/` hostPath is installed in the cluster. That allowlist is installed by an `AllowlistSynchronizer` custom resource (`auto.gke.io/v1`) that references the allowlist path. Without it, this flag has no effect.
+
 ## OpenShift
 
 If using OpenShift, please set the following configuration in your values.yaml file in order for the agent to work with OpenShift.
@@ -174,6 +176,8 @@ to export data to this connector which can then be connected to the New Relic ma
 | daemonset.extraArgs | list | `[]` | Additional args for the daemonset container https://opentelemetry.io/docs/collector/configuration/ Example: extraArgs:   - "--config=yaml:service::telemetry::logs::level: debug"   - "--config=yaml:exporters::otlp_http/newrelic::endpoint: https://otlp.eu.nr-data.net" |
 | daemonset.extraVolumeMounts | list | `[]` | Additional volume mounts to be added to the daemonset container |
 | daemonset.extraVolumes | list | `[]` | Additional volumes to be added to the daemonset pod |
+| daemonset.hostNetwork | bool | `false` | Use the host network namespace for the daemonset pods. Re-scopes the hostmetrics network scraper from the pod's own interface to the node's, so `system.network.*` reflect node-level traffic. |
+| daemonset.hostPID | bool | `false` | Share the host PID namespace with the daemonset pods. Required for the hostmetrics `process` scraper to see processes outside the collector's own container (node-wide `process.*`). |
 | daemonset.nodeSelector | object | `{}` | Sets daemonset pod node selector. Overrides `nodeSelector` and `global.nodeSelector` |
 | daemonset.podAnnotations | object | `{}` | Annotations to be added to the daemonset. |
 | daemonset.podSecurityContext | object | `{}` | Sets security context (at pod level) for the daemonset. Overrides `podSecurityContext` and `global.podSecurityContext` |
@@ -198,8 +202,9 @@ to export data to this connector which can then be connected to the New Relic ma
 | dnsConfig | object | `{}` | Sets pod's dnsConfig. Can be configured also with `global.dnsConfig` |
 | enable_atp | bool | `false` | Enable Adaptive Telemetry Processor (ATP) for intelligent process metrics filtering. When disabled (default), ATP processors are not included in the pipeline. When enabled, activates ATP with opinionated process metrics collection. IMPORTANT: Requires setting images.collector.repository to newrelic/nrdot-collector |
 | exporters | string | `nil` | Define custom exporters here. See: https://opentelemetry.io/docs/collector/configuration/#exporters |
-| images | object | `{"collector":{"pullPolicy":"IfNotPresent","registry":"","repository":"newrelic/nrdot-collector","tag":"1.14.0"},"kubectl":{"pullPolicy":"IfNotPresent","registry":"","repository":"bitnami/kubectl","tag":"latest"},"pullSecrets":[]}` | Images used by the chart. |
-| images.collector | object | `{"pullPolicy":"IfNotPresent","registry":"","repository":"newrelic/nrdot-collector","tag":"1.14.0"}` | Image for the OpenTelemetry Collector. To use experimental features, you must use the image newrelic/nrdot-collector. See below for experimental features. |
+| gkeAutopilotAllowList | bool | `false` | Only applies when `provider: GKE_AUTOPILOT`. When true, keeps the host root filesystem mount (`host-fs` -> `/hostfs`) and the hostmetrics `root_path` that GKE Autopilot normally strips, so the hostmetrics filesystem scraper can read the node's filesystems (`system.filesystem.*`). Requires a GKE Autopilot allowlist admitting the `/` hostPath: a `WorkloadAllowlist` installed by an `AllowlistSynchronizer` (`auto.gke.io/v1`). Has no effect without one. |
+| images | object | `{"collector":{"pullPolicy":"IfNotPresent","registry":"","repository":"newrelic/nrdot-collector","tag":"1.19.0"},"kubectl":{"pullPolicy":"IfNotPresent","registry":"","repository":"bitnami/kubectl","tag":"latest"},"pullSecrets":[]}` | Images used by the chart. |
+| images.collector | object | `{"pullPolicy":"IfNotPresent","registry":"","repository":"newrelic/nrdot-collector","tag":"1.19.0"}` | Image for the OpenTelemetry Collector. To use experimental features, you must use the image newrelic/nrdot-collector. See below for experimental features. |
 | images.kubectl | object | `{"pullPolicy":"IfNotPresent","registry":"","repository":"bitnami/kubectl","tag":"latest"}` | Image for the initContainer that retrieves node allocatable resources. |
 | images.pullSecrets | list | `[]` | The secrets that are needed to pull images from a custom registry. |
 | kube-state-metrics.enableCustomResourceSamples | bool | `false` | Enable custom KSM-based CRD metrics |
@@ -237,8 +242,8 @@ to export data to this connector which can then be connected to the New Relic ma
 | receivers.hostmetrics.enabled | bool | `true` | Specifies whether the `hostmetrics` receiver is enabled |
 | receivers.hostmetrics.scrapeInterval | string | `1m` | Sets the scrape interval for the `hostmetrics` receiver |
 | receivers.k8sEvents.enabled | bool | `true` | Specifies whether the `k8s_events` receiver is enabled |
-| receivers.kubeletstats.enabled | bool | `true` | Specifies whether the `kubeletstats` receiver is enabled |
-| receivers.kubeletstats.scrapeInterval | string | `1m` | Sets the scrape interval for the `kubeletstats` receiver |
+| receivers.kubeletstats.enabled | bool | `true` | Specifies whether the `kubelet_stats` receiver is enabled |
+| receivers.kubeletstats.scrapeInterval | string | `1m` | Sets the scrape interval for the `kubelet_stats` receiver |
 | receivers.prometheus.enabled | bool | `true` | Specifies whether the `prometheus` receiver is enabled |
 | receivers.prometheus.ksmSelector | string | `app.kubernetes.io/name=kube-state-metrics` | Label selector that will be used to automatically discover an instance of kube-state-metrics running in the cluster. |
 | receivers.prometheus.scrapeInterval | string | `1m` | Sets the scrape interval for the `prometheus` receiver |

--- a/charts/nr-k8s-otel-collector/README.md.gotmpl
+++ b/charts/nr-k8s-otel-collector/README.md.gotmpl
@@ -106,6 +106,8 @@ If using GKE Autopilot, please set the following configuration in your values.ya
 provider: "GKE_AUTOPILOT"
 ```
 
+Setting `gkeAutopilotAllowList: true` keeps the `host-fs` mount and the hostmetrics `root_path` that GKE Autopilot normally strips, so node filesystem metrics (`system.filesystem.*`) can be collected. GKE Autopilot only admits that mount if a `WorkloadAllowlist` permitting the `/` hostPath is installed in the cluster. That allowlist is installed by an `AllowlistSynchronizer` custom resource (`auto.gke.io/v1`) that references the allowlist path. Without it, this flag has no effect.
+
 ## OpenShift
 
 If using OpenShift, please set the following configuration in your values.yaml file in order for the agent to work with OpenShift.

--- a/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
@@ -13,7 +13,7 @@ data:
     receivers:
       host_metrics:
         # TODO (chris): this is a linux specific configuration
-        {{- if or (not (or (include "newrelic.common.gkeAutopilot" .) (include "newrelic.common.openShift" .))) .Values.gkeAutopilotAllowList }}
+        {{- if or (not (or (include "newrelic.common.gkeAutopilot" .) (include "newrelic.common.openShift" .))) (and (include "newrelic.common.gkeAutopilot" .) .Values.gkeAutopilotAllowList) }}
         root_path: /hostfs
         {{- end }}
         collection_interval: {{ .Values.receivers.hostmetrics.scrapeInterval }}

--- a/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset-configmap.yaml
@@ -13,7 +13,7 @@ data:
     receivers:
       host_metrics:
         # TODO (chris): this is a linux specific configuration
-        {{- if not (or (include "newrelic.common.gkeAutopilot" .) (include "newrelic.common.openShift" .)) }}
+        {{- if or (not (or (include "newrelic.common.gkeAutopilot" .) (include "newrelic.common.openShift" .))) .Values.gkeAutopilotAllowList }}
         root_path: /hostfs
         {{- end }}
         collection_interval: {{ .Values.receivers.hostmetrics.scrapeInterval }}

--- a/charts/nr-k8s-otel-collector/templates/daemonset.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset.yaml
@@ -31,6 +31,12 @@ spec:
       securityContext:
         {{- . | nindent 8 }}
       {{- end }}
+      {{- if .Values.daemonset.hostPID }}
+      hostPID: true
+      {{- end }}
+      {{- if .Values.daemonset.hostNetwork }}
+      hostNetwork: true
+      {{- end }}
       {{- with include "newrelic.common.priorityClassName" . }}
       priorityClassName: {{ . }}
       {{- end }}

--- a/charts/nr-k8s-otel-collector/templates/daemonset.yaml
+++ b/charts/nr-k8s-otel-collector/templates/daemonset.yaml
@@ -151,7 +151,7 @@ spec:
             {{- . | toYaml | nindent 12 }}
             {{- end }}
           volumeMounts:
-            {{- if not ( include "newrelic.common.gkeAutopilot" . ) }}
+            {{- if or (not (include "newrelic.common.gkeAutopilot" .)) .Values.gkeAutopilotAllowList }}
             - name: host-fs
               mountPath: /hostfs
               readOnly: true
@@ -171,7 +171,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
       volumes:
-        {{- if not (include "newrelic.common.gkeAutopilot" .) }}
+        {{- if or (not (include "newrelic.common.gkeAutopilot" .)) .Values.gkeAutopilotAllowList }}
         - name: host-fs
           hostPath:
             path: /

--- a/charts/nr-k8s-otel-collector/tests/gke_auto_pilot_test.yaml
+++ b/charts/nr-k8s-otel-collector/tests/gke_auto_pilot_test.yaml
@@ -150,6 +150,17 @@ tests:
           path: data["daemonset-config.yaml"]
           pattern: 'root_path: /hostfs'
         template: templates/daemonset-configmap.yaml
+  - it: provider OPEN_SHIFT with gkeAutopilotAllowList does not add root_path
+    set:
+      cluster: my-cluster
+      licenseKey: us-whatever
+      provider: OPEN_SHIFT
+      gkeAutopilotAllowList: true
+    asserts:
+      - notMatchRegex:
+          path: data["daemonset-config.yaml"]
+          pattern: 'root_path: /hostfs'
+        template: templates/daemonset-configmap.yaml
   - it: daemonset.hostPID true sets hostPID on the pod spec
     set:
       cluster: my-cluster

--- a/charts/nr-k8s-otel-collector/tests/gke_auto_pilot_test.yaml
+++ b/charts/nr-k8s-otel-collector/tests/gke_auto_pilot_test.yaml
@@ -101,3 +101,85 @@ tests:
           path: data["daemonset-config.yaml"]
           pattern: 'proxy/metrics/cadvisor'
         template: templates/daemonset-configmap.yaml
+  - it: provider GKE_AUTOPILOT with gkeAutopilotAllowList keeps the host-fs mount and root_path
+    set:
+      cluster: my-cluster
+      licenseKey: us-whatever
+      provider: GKE_AUTOPILOT
+      gkeAutopilotAllowList: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: host-fs
+            hostPath:
+              path: /
+        template: templates/daemonset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: host-fs
+            mountPath: /hostfs
+            readOnly: true
+        template: templates/daemonset.yaml
+      - matchRegex:
+          path: data["daemonset-config.yaml"]
+          pattern: 'root_path: /hostfs'
+        template: templates/daemonset-configmap.yaml
+  - it: provider GKE_AUTOPILOT without gkeAutopilotAllowList strips the host-fs mount and root_path
+    set:
+      cluster: my-cluster
+      licenseKey: us-whatever
+      provider: GKE_AUTOPILOT
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: host-fs
+            hostPath:
+              path: /
+        template: templates/daemonset.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: host-fs
+            mountPath: /hostfs
+            readOnly: true
+        template: templates/daemonset.yaml
+      - notMatchRegex:
+          path: data["daemonset-config.yaml"]
+          pattern: 'root_path: /hostfs'
+        template: templates/daemonset-configmap.yaml
+  - it: daemonset.hostPID true sets hostPID on the pod spec
+    set:
+      cluster: my-cluster
+      licenseKey: us-whatever
+      daemonset:
+        hostPID: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostPID
+          value: true
+        template: templates/daemonset.yaml
+  - it: daemonset.hostNetwork true sets hostNetwork on the pod spec
+    set:
+      cluster: my-cluster
+      licenseKey: us-whatever
+      daemonset:
+        hostNetwork: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+        template: templates/daemonset.yaml
+  - it: daemonset host namespaces are unset by default
+    set:
+      cluster: my-cluster
+      licenseKey: us-whatever
+    asserts:
+      - notExists:
+          path: spec.template.spec.hostPID
+        template: templates/daemonset.yaml
+      - notExists:
+          path: spec.template.spec.hostNetwork
+        template: templates/daemonset.yaml

--- a/charts/nr-k8s-otel-collector/values.yaml
+++ b/charts/nr-k8s-otel-collector/values.yaml
@@ -169,6 +169,10 @@ daemonset:
   podAnnotations: {}
   # -- Sets security context (at pod level) for the daemonset. Overrides `podSecurityContext` and `global.podSecurityContext`
   podSecurityContext: {}
+  # -- (bool) Share the host PID namespace with the daemonset pods. Required for the hostmetrics `process` scraper to see processes outside the collector's own container (node-wide `process.*`).
+  hostPID: false
+  # -- (bool) Use the host network namespace for the daemonset pods. Re-scopes the hostmetrics network scraper from the pod's own interface to the node's, so `system.network.*` reflect node-level traffic.
+  hostNetwork: false
   # -- Sets security context (at container level) for the daemonset. Overrides `containerSecurityContext` and `global.containerSecurityContext`
   containerSecurityContext:
     privileged: false

--- a/charts/nr-k8s-otel-collector/values.yaml
+++ b/charts/nr-k8s-otel-collector/values.yaml
@@ -77,6 +77,10 @@ kube-state-metrics:
 # -- The provider that you are deploying your cluster into. Sets known config constraints for your specific provider. Currently supporting OpenShift and GKE autopilot. If set, provider must be one of "GKE_AUTOPILOT" or "OPEN_SHIFT"
 provider: ""
 
+# -- (bool) Only applies when `provider: GKE_AUTOPILOT`. When true, keeps the host root filesystem mount (`host-fs` -> `/hostfs`) and the hostmetrics `root_path` that GKE Autopilot normally strips, so a GKE Autopilot partner WorkloadAllowlist can admit them and the hostmetrics filesystem scraper can read the node's filesystems (`system.filesystem.*`). Requires an applied WorkloadAllowlist that permits the `/` hostPath.
+# @default -- `false`
+gkeAutopilotAllowList: false
+
 # -- Images used by the chart.
 images:
   # -- The secrets that are needed to pull images from a custom registry.

--- a/charts/nr-k8s-otel-collector/values.yaml
+++ b/charts/nr-k8s-otel-collector/values.yaml
@@ -77,7 +77,7 @@ kube-state-metrics:
 # -- The provider that you are deploying your cluster into. Sets known config constraints for your specific provider. Currently supporting OpenShift and GKE autopilot. If set, provider must be one of "GKE_AUTOPILOT" or "OPEN_SHIFT"
 provider: ""
 
-# -- (bool) Only applies when `provider: GKE_AUTOPILOT`. When true, keeps the host root filesystem mount (`host-fs` -> `/hostfs`) and the hostmetrics `root_path` that GKE Autopilot normally strips, so a GKE Autopilot partner WorkloadAllowlist can admit them and the hostmetrics filesystem scraper can read the node's filesystems (`system.filesystem.*`). Requires an applied WorkloadAllowlist that permits the `/` hostPath.
+# -- (bool) Only applies when `provider: GKE_AUTOPILOT`. When true, keeps the host root filesystem mount (`host-fs` -> `/hostfs`) and the hostmetrics `root_path` that GKE Autopilot normally strips, so the hostmetrics filesystem scraper can read the node's filesystems (`system.filesystem.*`). Requires a GKE Autopilot allowlist admitting the `/` hostPath: a `WorkloadAllowlist` installed by an `AllowlistSynchronizer` (`auto.gke.io/v1`). Has no effect without one.
 # @default -- `false`
 gkeAutopilotAllowList: false
 


### PR DESCRIPTION
Adds three opt-in values to the nr-k8s-otel-collector chart for the GKE Autopilot partner allowlist work (NR-593526 / NR-606183). All default to false, so existing installs are unchanged.

## What's added

- `gkeAutopilotAllowList` (default false): when true and provider=GKE_AUTOPILOT, keeps the host root filesystem mount (host-fs to /hostfs) and the hostmetrics root_path that Autopilot normally strips. Lets a partner WorkloadAllowlist admit the mount so the filesystem scraper can read node filesystems (system.filesystem.*).
- `daemonset.hostPID` (default false): shares the host PID namespace so the hostmetrics process scraper can see node processes.
- `daemonset.hostNetwork` (default false): uses the host network namespace, which re-scopes the network scraper from the pod's own veth to the node's interfaces.

## Why

On GKE Autopilot, Warden blocks host mounts and host namespaces by default. These flags produce the exact pod shape a partner WorkloadAllowlist can admit, which is what unlocks node-level metrics. The namespace flags have no provider gating, so on GKE Standard or other clusters they apply directly with no allowlist involved.

## What hostNetwork changes

No new metric names appear. What changes is the scope of system.network.*:

| | Without hostNetwork | With hostNetwork |
|---|---|---|
| Interfaces reported | 1 (the collector pod's own eth0 veth) | 28 (node interfaces) |
| Example throughput | rx ~823 KB, tx ~66 KB | physical eth0 rx ~7.29 MB, tx ~6.6 MB |
| Coverage | pod-local traffic only | node eth0, cilium_host/net, docker0, all pod lxc* veths |
| Scope | pod | node |

This is the one capability that genuinely needs the host namespace grant. kubelet only emits per-pod k8s.pod.network.io, so node-level network on Autopilot has a single path: hostNetwork plus the allowlist exemption.

hostPID adds one metric, process.cpu.time (verified 372 datapoints with it, 0 without over 3 days). Coverage is partial, around 7 of 31 processes, not node-wide.

## Notes

- hostNetwork does not crash the collector. The :8888 self-telemetry bind conflict only occurs if self-telemetry is enabled, which is off by default.
- No entity-definitions changes required. These are existing metric names, and node/process metrics land as raw datapoints on Autopilot either way.
- `hostPID`/`hostNetwork` are exposed as daemonset-scoped values rather than wired to the common-library `newrelic.common.hostNetwork` helper, because host namespaces only apply to the node-level daemonset (never the cluster-level deployment) and `hostPID` has no common-library equivalent, so keeping both as explicit `daemonset.*` values scopes them correctly and keeps the two flags on one mechanism.

## Testing

Live-tested on a GKE Autopilot cluster against a partner WorkloadAllowlist. Unit coverage in charts/nr-k8s-otel-collector/tests/gke_auto_pilot_test.yaml. Full capability breakdown and NRDB verification captured under NR-606183.

#### Checklist
- [x] Title of the PR starts with chart name

_Chart version is handled by the automated release process for `nr-k8s-otel-collector`, so no manual version bump is included. Three new values were added (`gkeAutopilotAllowList`, `daemonset.hostPID`, `daemonset.hostNetwork`), so the README was regenerated via `make generate-nr-k8s-chart-docs`._

# Release Notes to Publish (nr-k8s-otel-collector)

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Add opt-in `gkeAutopilotAllowList`, `daemonset.hostPID`, and `daemonset.hostNetwork` flags to enable node-level filesystem, process, and network metrics on GKE Autopilot (via a partner WorkloadAllowlist) and other clusters; all default false
<!--END-RELEASE-NOTES-->

