### PR TITLE
[synthetics-job-manager] Bump ping-runtime, node-api-runtime, and SJM release versions

### DIFF
--- a/charts/synthetics-job-manager/Chart.yaml
+++ b/charts/synthetics-job-manager/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: synthetics-job-manager
 description: New Relic Synthetics Containerized Job Manager
 type: application
-version: 3.0.82
-appVersion: release-612
+version: 3.0.83
+appVersion: release-618
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: kaschaefer-nr
@@ -28,10 +28,10 @@ keywords:
   - newrelic
 dependencies:
   - name: ping-runtime
-    version: 1.0.50
+    version: 1.0.51
     condition: ping-runtime.enabled
   - name: node-api-runtime
-    version: 1.0.64
+    version: 1.0.65
     condition: node-api-runtime.enabled
   - name: node-browser-runtime
     version: 2.0.32

--- a/charts/synthetics-job-manager/charts/node-api-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/node-api-runtime/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: node-api-runtime
 description: New Relic Synthetics Api Runtime
 type: application
-version: 1.0.64
-appVersion: 1.2.258
+version: 1.0.65
+appVersion: 1.2.262
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith

--- a/charts/synthetics-job-manager/charts/ping-runtime/Chart.yaml
+++ b/charts/synthetics-job-manager/charts/ping-runtime/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: ping-runtime
 description: New Relic Synthetics Ping Runtime
 type: application
-version: 1.0.50
-appVersion: 1.79.0
+version: 1.0.51
+appVersion: 1.80.0
 home: https://github.com/orgs/newrelic/teams/proactive-monitoring
 maintainers:
   - name: Philip-R-Beckwith


### PR DESCRIPTION
## What this PR does / why we need it:
Updates the following recently released Synthetics runtime images/job manager:
- `ping-runtime`: 1.79.0 → 1.80.0 (chart version 1.0.50 → 1.0.51)
- `node-api-runtime`: 1.2.258 → 1.2.262 (chart version 1.0.64 → 1.0.65)
- `synthetics-job-manager`: release-612 → release-618 (chart version 3.0.82 → 3.0.83)

Dependency version pins in the parent `Chart.yaml` are synced accordingly.

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name