### PR TITLE
feat(mysql-otel): add chart to monitor MySQL via NRDOT

### DIFF
--- a/charts/mysql-otel/.helmignore
+++ b/charts/mysql-otel/.helmignore
@@ -1,0 +1,5 @@
+.git/
+.gitignore
+*.swp
+.DS_Store
+ci/

--- a/charts/mysql-otel/Chart.lock
+++ b/charts/mysql-otel/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common-library
+  repository: https://helm-charts.newrelic.com
+  version: 2.3.3
+digest: sha256:0b85ba8fc894ed0fd1832688a954efdaeb80df7c9fe60c225eb124db7fbd409c
+generated: "2026-09-03T22:02:17.044044+05:30"

--- a/charts/mysql-otel/Chart.yaml
+++ b/charts/mysql-otel/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: mysql-otel
+description: A Helm chart to monitor MySQL with New Relic's OpenTelemetry distribution (NRDOT)
+type: application
+version: 0.1.0
+appVersion: "2.4.0"
+home: https://github.com/newrelic/helm-charts
+icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
+dependencies:
+  - name: common-library
+    version: 2.3.3
+    repository: "https://helm-charts.newrelic.com"
+keywords:
+  - mysql
+  - opentelemetry
+  - newrelic
+  - monitoring
+  - database
+maintainers:
+  - name: newrelic
+    url: https://github.com/newrelic/helm-charts

--- a/charts/mysql-otel/README.md
+++ b/charts/mysql-otel/README.md
@@ -93,12 +93,6 @@ GRANT SELECT ON performance_schema.* TO 'nr_monitor'@'%';
 FLUSH PRIVILEGES;
 ```
 
-## Testing
-
-See [`TESTING.md`](./TESTING.md) for a full local/EC2 setup and end-to-end
-validation runbook, including a disposable MySQL instance for testing
-without touching production.
-
 ## Values
 
 | Key | Description | Default |

--- a/charts/mysql-otel/README.md
+++ b/charts/mysql-otel/README.md
@@ -1,0 +1,129 @@
+# mysql-otel
+
+Deploys New Relic's NRDOT OpenTelemetry collector configured with the
+`nrmysql` receiver to scrape one MySQL instance and export the results to
+New Relic over OTLP.
+
+## What this chart does not do
+
+- Monitor more than one MySQL instance per release — install the chart
+  once per database.
+- Support Unix-socket monitoring (`transport: unix`). The `nrmysql`
+  receiver supports connecting via a local socket file, but that only
+  makes sense when the collector runs on the same host/filesystem as
+  MySQL. This chart runs the collector as a Kubernetes Deployment reaching
+  MySQL remotely over the network, so `transport` is always `tcp` and is
+  not exposed as a value at all.
+- Report host/infrastructure metrics for the machine MySQL runs on. New
+  Relic's docs show a "Full-feature configuration" that adds a
+  `host_metrics` receiver and split host/db/traces pipelines — that only
+  makes sense for a collector running directly on the MySQL host's own OS.
+  This chart implements only the standalone "Standard configuration" shape.
+- Auto-select an Amazon RDS CA bundle for you. `mysql.tls.caFile` is a
+  plain value you supply — a chart-hardcoded default risks going stale as
+  Amazon rotates CA bundles.
+
+## Choosing `mysql.topology`
+
+| Your setup | `mysql.topology` |
+|---|---|
+| Amazon RDS for MySQL | `rds` |
+| Self-hosted MySQL (reached over the network) | `self-hosted` |
+
+This value is always required, but does not currently change any rendered
+output — it exists for documentation clarity and as a validated,
+forward-compatible schema slot, same precedent as `mssql-otel`'s
+`mssql.topology`.
+
+## Networking prerequisites
+
+- **Self-hosted**: the collector Pod needs a routed path to
+  `mysql.server:mysql.port` (VPN, peering, or shared network), DNS
+  resolution if it's a hostname, and the MySQL-side firewall must allow the
+  connection's actual source IP (which may be a NAT gateway, not the Pod IP
+  itself).
+- **RDS**: your cluster needs VPC peering, a transit gateway, or shared-VPC
+  placement with the RDS instance, and the RDS security group must allow
+  the MySQL port (3306 by default) from the cluster's egress source.
+
+## TLS
+
+Set `mysql.tls.insecure: false` (the default) to require an encrypted
+connection, `mysql.tls.insecureSkipVerify: true` to skip certificate
+validation (useful for self-signed certs in test environments, but weakens
+the connection's security guarantees), and `mysql.tls.caFile` to a CA
+bundle path mounted into the collector container if the MySQL server's
+certificate isn't in the default trust store — for example, an **Amazon
+RDS instance with "Require SSL/TLS" enforcement needs `caFile` pointed at
+Amazon's RDS CA bundle**. Confirm these flags' actual behavior against a
+real MySQL instance requiring TLS before relying on this in production —
+see `TESTING.md`.
+
+## Automated setup (`setupJob.enabled: true`)
+
+If enabled, a Helm hook Job creates the monitoring user
+(`mysql.username`/`mysql.existingSecret`) and grants it `SELECT` on
+`performance_schema.*`, using a separate admin credential
+(`setupJob.mysqlAdmin.existingSecret` — **required**, no plain-value path,
+since it can `CREATE USER` and grant broad `performance_schema` access).
+Set `setupJob.enableWaitTimeMetrics: true` to also grant `UPDATE` on
+`performance_schema.setup_consumers`, needed for wait-time data — this is
+optional per New Relic's docs.
+
+This requires a `mysql`-CLI-capable image. Unlike the other two charts in
+this family, `setupJob.image` defaults to the official, actively-maintained
+`mysql:8.4` image — no license click-through required, so enabling the
+setup Job needs no extra `--set` flags for the image. Override
+`setupJob.image.repository`/`tag` if you need a different version.
+
+**Known limitation:** the setup Job builds its `CREATE USER`/`GRANT`
+statements by shell-expanding the monitoring credentials directly into a
+SQL heredoc. This is not injection-safe against an adversarial password (a
+password containing `'` could break out of the quoted SQL string) — the
+same trust model as this chart family's other setup Jobs. Credentials are
+expected to come from the same operator running the install, not
+attacker-controlled input.
+
+If you'd rather not grant this chart admin-level MySQL access at all,
+leave `setupJob.enabled: false` and create the monitoring user yourself
+before installing:
+```sql
+CREATE USER IF NOT EXISTS 'nr_monitor'@'%' IDENTIFIED BY '<password>';
+GRANT SELECT ON performance_schema.* TO 'nr_monitor'@'%';
+FLUSH PRIVILEGES;
+```
+
+## Testing
+
+See [`TESTING.md`](./TESTING.md) for a full local/EC2 setup and end-to-end
+validation runbook, including a disposable MySQL instance for testing
+without touching production.
+
+## Values
+
+| Key | Description | Default |
+|---|---|---|
+| `image.repository` | Collector image | `newrelic/nrdot-collector` |
+| `image.tag` | Collector image tag | `2.4.0` |
+| `mysql.topology` | `self-hosted` or `rds` — always required | `""` |
+| `mysql.server` | MySQL host/endpoint | `""` |
+| `mysql.port` | MySQL port | `3306` |
+| `mysql.username` / `mysql.password` | Plain-value monitoring credentials | `""` |
+| `mysql.existingSecret` | Pre-existing Secret (keys `username`, `password`), wins over plain values | `""` |
+| `mysql.database` | Restrict monitoring to one database; empty monitors all | `""` |
+| `mysql.allowNativePasswords` | Receiver's allow_native_passwords | `true` |
+| `mysql.collectionInterval` | Scrape interval | `10s` |
+| `mysql.initialDelay` | Delay before first scrape | `1s` |
+| `mysql.explainMode` | `inline` or `procedure` | `inline` |
+| `mysql.tls.insecure` / `insecureSkipVerify` / `caFile` | TLS connection settings | `false` / `false` / `""` |
+| `mysql.statementEvents.*` | `digestTextLimit`, `timeLimit`, `limit` | `4096` / `24h` / `500` |
+| `mysql.querySampleCollection.*` | `maxRowsPerQuery`, `allowedCommentKeys` | `100` / `[nr_service_guid]` |
+| `mysql.topQueryCollection.*` | `lookbackTime`, `maxQuerySampleCount`, `topQueryCount`, `collectionInterval`, `queryPlanCacheSize`, `queryPlanCacheTtl`, `allowedCommentKeys` | see `values.yaml` |
+| `mysql.events.querySample.enabled` / `topQuery.enabled` | Enable the query-sample/top-query log events | `true` / `true` |
+| `otlpEndpoint` | New Relic OTLP/gRPC endpoint, bare host:port, no scheme | `""` |
+| `licenseKey` / `customSecretName` / `customSecretLicenseKey` | New Relic license key, standard `common-library` fields | `""` |
+| `additionalReceiverConfig` | Merged into the `nrmysql` receiver block | `{}` |
+| `setupJob.enabled` | Run the automated user-creation Job | `false` |
+| `setupJob.image.repository` / `setupJob.image.tag` | `mysql`-CLI image | `mysql` / `8.4` |
+| `setupJob.mysqlAdmin.existingSecret` | Admin credential Secret (keys `username`, `password`) — required if enabled | `""` |
+| `setupJob.enableWaitTimeMetrics` | Also grant `UPDATE` on `performance_schema.setup_consumers` | `false` |

--- a/charts/mysql-otel/ci/test-values.yaml
+++ b/charts/mysql-otel/ci/test-values.yaml
@@ -1,0 +1,12 @@
+mysql:
+  server: "mysql.example.internal"
+  port: 3306
+  topology: "self-hosted"
+  username: "nr_monitor"
+  password: "test-password-not-real"
+
+otlpEndpoint: "otlp.nr-data.net:4317"
+licenseKey: "0000000000000000000000000000000000000000"
+
+setupJob:
+  enabled: false

--- a/charts/mysql-otel/templates/_helpers.tpl
+++ b/charts/mysql-otel/templates/_helpers.tpl
@@ -1,0 +1,72 @@
+{{/* vim: set filetype=mustache: */}}
+{{- define "mysql-otel.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "mysql-otel.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mysql-otel.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "mysql-otel.labels" -}}
+app.kubernetes.io/name: {{ include "mysql-otel.name" . }}
+helm.sh/chart: {{ include "mysql-otel.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "mysql-otel.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mysql-otel.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "mysql-otel.validate.mysql" -}}
+{{- if not .Values.mysql.server -}}
+{{- fail "mysql.server is required" -}}
+{{- end -}}
+{{- if not (or .Values.mysql.existingSecret (and .Values.mysql.username .Values.mysql.password)) -}}
+{{- fail "You must set mysql.existingSecret, or both mysql.username and mysql.password" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mysql-otel.credentials.secretName" -}}
+{{- .Values.mysql.existingSecret | default (printf "%s-mysql" (include "mysql-otel.fullname" .)) -}}
+{{- end -}}
+
+{{- define "mysql-otel.validate.topology" -}}
+{{- if not (has .Values.mysql.topology (list "self-hosted" "rds")) -}}
+{{- fail "mysql.topology must be one of: self-hosted, rds" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mysql-otel.validate.otlpEndpoint" -}}
+{{- if not .Values.otlpEndpoint -}}
+{{- fail "otlpEndpoint is required" -}}
+{{- end -}}
+{{- if or (hasPrefix "http://" .Values.otlpEndpoint) (hasPrefix "https://" .Values.otlpEndpoint) -}}
+{{- fail (printf "otlpEndpoint must be a bare host:port with no scheme -- the otlp (gRPC) exporter rejects a URL, unlike mssql-otel's otlphttp. Got: %q. New Relic's US OTLP/gRPC endpoint is otlp.nr-data.net:4317" .Values.otlpEndpoint) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mysql-otel.validate.setupJob" -}}
+{{- if .Values.setupJob.enabled -}}
+{{- if not .Values.setupJob.mysqlAdmin.existingSecret -}}
+{{- fail "setupJob.mysqlAdmin.existingSecret is required when setupJob.enabled is true" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/mysql-otel/templates/configmap.yaml
+++ b/charts/mysql-otel/templates/configmap.yaml
@@ -1,10 +1,10 @@
 {{- include "mysql-otel.validate.topology" . -}}
 {{- include "mysql-otel.validate.otlpEndpoint" . -}}
-{{- $tls := dict "insecure" .Values.mysql.tls.insecure "insecure_skip_verify" .Values.mysql.tls.insecureSkipVerify -}}
+{{- $tlsDefaults := dict "insecure" .Values.mysql.tls.insecure "insecure_skip_verify" .Values.mysql.tls.insecureSkipVerify -}}
 {{- if .Values.mysql.tls.caFile }}
-{{- $tls = set $tls "ca_file" .Values.mysql.tls.caFile -}}
+{{- $tlsDefaults = set $tlsDefaults "ca_file" .Values.mysql.tls.caFile -}}
 {{- end }}
-{{- $receiver := dict
+{{- $receiverDefaults := dict
       "endpoint" (printf "%s:%d" .Values.mysql.server (.Values.mysql.port | int))
       "transport" "tcp"
       "username" "${env:MYSQL_USERNAME}"
@@ -13,7 +13,7 @@
       "collection_interval" .Values.mysql.collectionInterval
       "initial_delay" .Values.mysql.initialDelay
       "explain_mode" .Values.mysql.explainMode
-      "tls" $tls
+      "tls" $tlsDefaults
       "statement_events" (dict
         "digest_text_limit" (.Values.mysql.statementEvents.digestTextLimit | int)
         "time_limit" .Values.mysql.statementEvents.timeLimit
@@ -38,13 +38,22 @@
       )
 -}}
 {{- if .Values.mysql.database }}
-{{- $receiver = set $receiver "database" .Values.mysql.database -}}
+{{- $receiverDefaults = set $receiverDefaults "database" .Values.mysql.database -}}
 {{- end }}
-{{- $receiver = mergeOverwrite $receiver (.Values.additionalReceiverConfig | default dict) -}}
-{{- $resourceAttrs := list
-      (dict "key" "server.address" "value" .Values.mysql.server "action" "upsert")
-      (dict "key" "server.port" "value" (.Values.mysql.port | toString) "action" "upsert")
--}}
+{{- $receiver := mergeOverwrite $receiverDefaults (.Values.additionalReceiverConfig | default dict) -}}
+{{- $tls := index $receiver "tls" -}}
+{{- $stmt := index $receiver "statement_events" -}}
+{{- $qsc := index $receiver "query_sample_collection" -}}
+{{- $tqc := index $receiver "top_query_collection" -}}
+{{- $events := index $receiver "events" -}}
+{{- $knownReceiverKeys := list "endpoint" "transport" "username" "password" "database" "allow_native_passwords" "collection_interval" "initial_delay" "tls" "explain_mode" "statement_events" "query_sample_collection" "top_query_collection" "events" -}}
+{{- $extraReceiverKeys := list -}}
+{{- range $k, $v := $receiver }}
+{{- if not (has $k $knownReceiverKeys) }}
+{{- $extraReceiverKeys = append $extraReceiverKeys $k -}}
+{{- end }}
+{{- end }}
+{{- $extraReceiverKeys = sortAlpha $extraReceiverKeys -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -56,18 +65,58 @@ data:
   config.yaml: |
     receivers:
       nrmysql:
-{{ toYaml $receiver | indent 8 }}
+        endpoint: {{ index $receiver "endpoint" | quote }}
+        transport: {{ index $receiver "transport" }}
+        username: {{ index $receiver "username" | quote }}
+        password: {{ index $receiver "password" | quote }}
+        {{- if hasKey $receiver "database" }}
+        database: {{ index $receiver "database" | quote }}
+        {{- end }}
+        allow_native_passwords: {{ index $receiver "allow_native_passwords" }}
+        collection_interval: {{ index $receiver "collection_interval" }}
+        initial_delay: {{ index $receiver "initial_delay" }}
+        tls:
+          insecure: {{ index $tls "insecure" }}
+          insecure_skip_verify: {{ index $tls "insecure_skip_verify" }}
+          {{- if hasKey $tls "ca_file" }}
+          ca_file: {{ index $tls "ca_file" | quote }}
+          {{- end }}
+        explain_mode: {{ index $receiver "explain_mode" }}
+        statement_events:
+          digest_text_limit: {{ index $stmt "digest_text_limit" }}
+          time_limit: {{ index $stmt "time_limit" }}
+          limit: {{ index $stmt "limit" }}
+        query_sample_collection:
+          max_rows_per_query: {{ index $qsc "max_rows_per_query" }}
+          allowed_comment_keys: [{{ index $qsc "allowed_comment_keys" | join ", " }}]
+        top_query_collection:
+          lookback_time: {{ index $tqc "lookback_time" }}
+          max_query_sample_count: {{ index $tqc "max_query_sample_count" }}
+          top_query_count: {{ index $tqc "top_query_count" }}
+          collection_interval: {{ index $tqc "collection_interval" }}
+          query_plan_cache_size: {{ index $tqc "query_plan_cache_size" }}
+          query_plan_cache_ttl: {{ index $tqc "query_plan_cache_ttl" }}
+          allowed_comment_keys: [{{ index $tqc "allowed_comment_keys" | join ", " }}]
+        events:
+          db.server.query_sample:
+            enabled: {{ index (index $events "db.server.query_sample") "enabled" }}
+          db.server.top_query:
+            enabled: {{ index (index $events "db.server.top_query") "enabled" }}
+        {{- range $k := $extraReceiverKeys }}
+        {{ $k }}: {{ toYaml (index $receiver $k) }}
+        {{- end }}
     processors:
-      memory_limiter:
-        check_interval: ${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
-        limit_mib: ${env:NR_MEM_LIMITER_LIMIT_MIB:-200}
-        spike_limit_mib: ${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+      batch:
       resource/mysql:
         attributes:
-{{ toYaml $resourceAttrs | indent 8 }}
-      batch:
+          - key: server.address
+            value: {{ .Values.mysql.server | quote }}
+            action: upsert
+          - key: server.port
+            value: {{ .Values.mysql.port | int }}
+            action: upsert
     exporters:
-      otlp:
+      otlp/newrelic:
         endpoint: {{ .Values.otlpEndpoint | quote }}
         headers:
           api-key: "${env:NEW_RELIC_LICENSE_KEY}"
@@ -81,9 +130,9 @@ data:
       pipelines:
         metrics:
           receivers: [nrmysql]
-          processors: [memory_limiter, resource/mysql, batch]
-          exporters: [otlp]
+          processors: [resource/mysql, batch]
+          exporters: [otlp/newrelic]
         logs:
           receivers: [nrmysql]
-          processors: [memory_limiter, resource/mysql, batch]
-          exporters: [otlp]
+          processors: [resource/mysql, batch]
+          exporters: [otlp/newrelic]

--- a/charts/mysql-otel/templates/configmap.yaml
+++ b/charts/mysql-otel/templates/configmap.yaml
@@ -1,0 +1,89 @@
+{{- include "mysql-otel.validate.topology" . -}}
+{{- include "mysql-otel.validate.otlpEndpoint" . -}}
+{{- $tls := dict "insecure" .Values.mysql.tls.insecure "insecure_skip_verify" .Values.mysql.tls.insecureSkipVerify -}}
+{{- if .Values.mysql.tls.caFile }}
+{{- $tls = set $tls "ca_file" .Values.mysql.tls.caFile -}}
+{{- end }}
+{{- $receiver := dict
+      "endpoint" (printf "%s:%d" .Values.mysql.server (.Values.mysql.port | int))
+      "transport" "tcp"
+      "username" "${env:MYSQL_USERNAME}"
+      "password" "${env:MYSQL_PASSWORD}"
+      "allow_native_passwords" .Values.mysql.allowNativePasswords
+      "collection_interval" .Values.mysql.collectionInterval
+      "initial_delay" .Values.mysql.initialDelay
+      "explain_mode" .Values.mysql.explainMode
+      "tls" $tls
+      "statement_events" (dict
+        "digest_text_limit" (.Values.mysql.statementEvents.digestTextLimit | int)
+        "time_limit" .Values.mysql.statementEvents.timeLimit
+        "limit" (.Values.mysql.statementEvents.limit | int)
+      )
+      "query_sample_collection" (dict
+        "max_rows_per_query" (.Values.mysql.querySampleCollection.maxRowsPerQuery | int)
+        "allowed_comment_keys" .Values.mysql.querySampleCollection.allowedCommentKeys
+      )
+      "top_query_collection" (dict
+        "lookback_time" (.Values.mysql.topQueryCollection.lookbackTime | int)
+        "max_query_sample_count" (.Values.mysql.topQueryCollection.maxQuerySampleCount | int)
+        "top_query_count" (.Values.mysql.topQueryCollection.topQueryCount | int)
+        "collection_interval" .Values.mysql.topQueryCollection.collectionInterval
+        "query_plan_cache_size" (.Values.mysql.topQueryCollection.queryPlanCacheSize | int)
+        "query_plan_cache_ttl" .Values.mysql.topQueryCollection.queryPlanCacheTtl
+        "allowed_comment_keys" .Values.mysql.topQueryCollection.allowedCommentKeys
+      )
+      "events" (dict
+        "db.server.query_sample" (dict "enabled" .Values.mysql.events.querySample.enabled)
+        "db.server.top_query" (dict "enabled" .Values.mysql.events.topQuery.enabled)
+      )
+-}}
+{{- if .Values.mysql.database }}
+{{- $receiver = set $receiver "database" .Values.mysql.database -}}
+{{- end }}
+{{- $receiver = mergeOverwrite $receiver (.Values.additionalReceiverConfig | default dict) -}}
+{{- $resourceAttrs := list
+      (dict "key" "server.address" "value" .Values.mysql.server "action" "upsert")
+      (dict "key" "server.port" "value" (.Values.mysql.port | toString) "action" "upsert")
+-}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mysql-otel.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mysql-otel.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    receivers:
+      nrmysql:
+{{ toYaml $receiver | indent 8 }}
+    processors:
+      memory_limiter:
+        check_interval: ${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
+        limit_mib: ${env:NR_MEM_LIMITER_LIMIT_MIB:-200}
+        spike_limit_mib: ${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+      resource/mysql:
+        attributes:
+{{ toYaml $resourceAttrs | indent 8 }}
+      batch:
+    exporters:
+      otlp:
+        endpoint: {{ .Values.otlpEndpoint | quote }}
+        headers:
+          api-key: "${env:NEW_RELIC_LICENSE_KEY}"
+        compression: gzip
+        retry_on_failure:
+          enabled: true
+          initial_interval: 5s
+          max_interval: 30s
+          max_elapsed_time: 300s
+    service:
+      pipelines:
+        metrics:
+          receivers: [nrmysql]
+          processors: [memory_limiter, resource/mysql, batch]
+          exporters: [otlp]
+        logs:
+          receivers: [nrmysql]
+          processors: [memory_limiter, resource/mysql, batch]
+          exporters: [otlp]

--- a/charts/mysql-otel/templates/deployment.yaml
+++ b/charts/mysql-otel/templates/deployment.yaml
@@ -1,0 +1,66 @@
+{{- include "mysql-otel.validate.mysql" . -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mysql-otel.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mysql-otel.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "mysql-otel.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mysql-otel.labels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      containers:
+        - name: mysql-otel
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --config=/etc/mysql-otel/config.yaml
+          env:
+            - name: MYSQL_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mysql-otel.credentials.secretName" . }}
+                  key: username
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mysql-otel.credentials.secretName" . }}
+                  key: password
+            - name: NEW_RELIC_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "newrelic.common.license.secretName" . }}
+                  key: {{ include "newrelic.common.license.secretKeyName" . }}
+          {{- if .Values.resources }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mysql-otel
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "mysql-otel.fullname" . }}-config
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/mysql-otel/templates/license-secret.yaml
+++ b/charts/mysql-otel/templates/license-secret.yaml
@@ -1,0 +1,2 @@
+{{- /* common-library takes care of creating the Secret, or not, on its own. */}}
+{{- include "newrelic.common.license.secret" . }}

--- a/charts/mysql-otel/templates/secret.yaml
+++ b/charts/mysql-otel/templates/secret.yaml
@@ -1,0 +1,14 @@
+{{- include "mysql-otel.validate.mysql" . -}}
+{{- if not .Values.mysql.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mysql-otel.credentials.secretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mysql-otel.labels" . | nindent 4 }}
+type: Opaque
+data:
+  username: {{ .Values.mysql.username | b64enc }}
+  password: {{ .Values.mysql.password | b64enc }}
+{{- end }}

--- a/charts/mysql-otel/templates/setup-job.yaml
+++ b/charts/mysql-otel/templates/setup-job.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.setupJob.enabled }}
+{{- include "mysql-otel.validate.setupJob" . -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "mysql-otel.fullname" . }}-setup
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mysql-otel.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        {{- include "mysql-otel.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: mysql-otel-setup
+          image: "{{ .Values.setupJob.image.repository }}:{{ .Values.setupJob.image.tag }}"
+          imagePullPolicy: {{ .Values.setupJob.image.pullPolicy }}
+          env:
+            - name: MYSQL_ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.setupJob.mysqlAdmin.existingSecret }}
+                  key: username
+            - name: MYSQL_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.setupJob.mysqlAdmin.existingSecret }}
+                  key: password
+            - name: MYSQL_MONITOR_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mysql-otel.credentials.secretName" . }}
+                  key: username
+            - name: MYSQL_MONITOR_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mysql-otel.credentials.secretName" . }}
+                  key: password
+            - name: MYSQL_SERVER
+              value: {{ .Values.mysql.server | quote }}
+            - name: MYSQL_PORT
+              value: {{ .Values.mysql.port | quote }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              mysql -h "$MYSQL_SERVER" -P "$MYSQL_PORT" -u "$MYSQL_ADMIN_USERNAME" -p"$MYSQL_ADMIN_PASSWORD" <<SQL
+              CREATE USER IF NOT EXISTS '$MYSQL_MONITOR_USERNAME'@'%' IDENTIFIED BY '$MYSQL_MONITOR_PASSWORD';
+              GRANT SELECT ON performance_schema.* TO '$MYSQL_MONITOR_USERNAME'@'%';
+              FLUSH PRIVILEGES;
+              SQL
+              {{- if .Values.setupJob.enableWaitTimeMetrics }}
+              mysql -h "$MYSQL_SERVER" -P "$MYSQL_PORT" -u "$MYSQL_ADMIN_USERNAME" -p"$MYSQL_ADMIN_PASSWORD" <<SQL
+              GRANT UPDATE ON performance_schema.setup_consumers TO '$MYSQL_MONITOR_USERNAME'@'%';
+              FLUSH PRIVILEGES;
+              SQL
+              {{- end }}
+{{- end }}

--- a/charts/mysql-otel/tests/configmap_test.yaml
+++ b/charts/mysql-otel/tests/configmap_test.yaml
@@ -1,0 +1,148 @@
+suite: configmap
+templates:
+  - templates/configmap.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+set:
+  mysql.server: "mysql.internal"
+  mysql.topology: "self-hosted"
+  mysql.username: "nr_monitor"
+  mysql.password: "s3cret"
+  otlpEndpoint: "otlp.nr-data.net:4317"
+tests:
+  - it: fails when mysql.topology is unset or invalid
+    set:
+      mysql.topology: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "mysql.topology must be one of: self-hosted, rds"
+  - it: fails when otlpEndpoint has a scheme
+    set:
+      otlpEndpoint: "https://otlp.nr-data.net:4318"
+    asserts:
+      - failedTemplate:
+          errorMessage: "otlpEndpoint must be a bare host:port with no scheme -- the otlp (gRPC) exporter rejects a URL, unlike mssql-otel's otlphttp. Got: \"https://otlp.nr-data.net:4318\". New Relic's US OTLP/gRPC endpoint is otlp.nr-data.net:4317"
+  - it: renders the nrmysql receiver with env-substitution credentials, never literal ones
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "endpoint: mysql\\.internal:3306"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "transport: tcp"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "username: \\$\\{env:MYSQL_USERNAME\\}"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "password: \\$\\{env:MYSQL_PASSWORD\\}"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "collection_interval: 10s"
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "s3cret"
+  - it: omits database when unset
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "database:"
+  - it: includes database when mysql.database is set
+    set:
+      mysql.database: "appdb"
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "database: appdb"
+  - it: renders TLS fields from mysql.tls, omitting ca_file when unset
+    set:
+      mysql.tls.insecure: true
+      mysql.tls.insecureSkipVerify: true
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "insecure: true"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "insecure_skip_verify: true"
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "ca_file:"
+  - it: includes ca_file when mysql.tls.caFile is set
+    set:
+      mysql.tls.caFile: "/etc/ssl/rds-ca-bundle.pem"
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "ca_file: /etc/ssl/rds-ca-bundle\\.pem"
+  - it: renders statement_events, query_sample_collection, top_query_collection, and events from values
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "digest_text_limit: 4096"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "time_limit: 24h"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "max_rows_per_query: 100"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "lookback_time: 120"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "max_query_sample_count: 5000"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "query_plan_cache_ttl: 1h"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "nr_service_guid"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "db\\.server\\.query_sample:\\s*\\n\\s*enabled: true"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "db\\.server\\.top_query:\\s*\\n\\s*enabled: true"
+  - it: renders the resource/mysql processor with server.address and server.port
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "resource/mysql:"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "action: upsert\\s*\\n\\s*key: server\\.address\\s*\\n\\s*value: mysql\\.internal"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "action: upsert\\s*\\n\\s*key: server\\.port\\s*\\n\\s*value: \"3306\""
+  - it: renders the otlp exporter with a bare endpoint and env-substitution api-key, never a literal one
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "endpoint: \"otlp\\.nr-data\\.net:4317\""
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "api-key: \"\\$\\{env:NEW_RELIC_LICENSE_KEY\\}\""
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "retry_on_failure:"
+  - it: wires the metrics and logs pipelines to the receiver, processors, and exporter
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "receivers:\\s*\\[nrmysql\\]"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "exporters:\\s*\\[otlp\\]"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "processors:\\s*\\[memory_limiter, resource/mysql, batch\\]"
+  - it: merges additionalReceiverConfig into the receiver block
+    set:
+      additionalReceiverConfig:
+        allow_native_passwords: false
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "allow_native_passwords: false"

--- a/charts/mysql-otel/tests/configmap_test.yaml
+++ b/charts/mysql-otel/tests/configmap_test.yaml
@@ -27,16 +27,16 @@ tests:
     asserts:
       - matchRegex:
           path: data["config.yaml"]
-          pattern: "endpoint: mysql\\.internal:3306"
+          pattern: "endpoint: \"mysql\\.internal:3306\""
       - matchRegex:
           path: data["config.yaml"]
           pattern: "transport: tcp"
       - matchRegex:
           path: data["config.yaml"]
-          pattern: "username: \\$\\{env:MYSQL_USERNAME\\}"
+          pattern: "username: \"\\$\\{env:MYSQL_USERNAME\\}\""
       - matchRegex:
           path: data["config.yaml"]
-          pattern: "password: \\$\\{env:MYSQL_PASSWORD\\}"
+          pattern: "password: \"\\$\\{env:MYSQL_PASSWORD\\}\""
       - matchRegex:
           path: data["config.yaml"]
           pattern: "collection_interval: 10s"
@@ -54,7 +54,7 @@ tests:
     asserts:
       - matchRegex:
           path: data["config.yaml"]
-          pattern: "database: appdb"
+          pattern: "database: \"appdb\""
   - it: renders TLS fields from mysql.tls, omitting ca_file when unset
     set:
       mysql.tls.insecure: true
@@ -75,7 +75,7 @@ tests:
     asserts:
       - matchRegex:
           path: data["config.yaml"]
-          pattern: "ca_file: /etc/ssl/rds-ca-bundle\\.pem"
+          pattern: "ca_file: \"/etc/ssl/rds-ca-bundle\\.pem\""
   - it: renders statement_events, query_sample_collection, top_query_collection, and events from values
     asserts:
       - matchRegex:
@@ -112,11 +112,11 @@ tests:
           pattern: "resource/mysql:"
       - matchRegex:
           path: data["config.yaml"]
-          pattern: "action: upsert\\s*\\n\\s*key: server\\.address\\s*\\n\\s*value: mysql\\.internal"
+          pattern: "key: server\\.address\\s*\\n\\s*value: \"mysql\\.internal\"\\s*\\n\\s*action: upsert"
       - matchRegex:
           path: data["config.yaml"]
-          pattern: "action: upsert\\s*\\n\\s*key: server\\.port\\s*\\n\\s*value: \"3306\""
-  - it: renders the otlp exporter with a bare endpoint and env-substitution api-key, never a literal one
+          pattern: "key: server\\.port\\s*\\n\\s*value: 3306\\s*\\n\\s*action: upsert"
+  - it: renders the otlp/newrelic exporter with a bare endpoint and env-substitution api-key, never a literal one
     asserts:
       - matchRegex:
           path: data["config.yaml"]
@@ -134,10 +134,10 @@ tests:
           pattern: "receivers:\\s*\\[nrmysql\\]"
       - matchRegex:
           path: data["config.yaml"]
-          pattern: "exporters:\\s*\\[otlp\\]"
+          pattern: "exporters:\\s*\\[otlp/newrelic\\]"
       - matchRegex:
           path: data["config.yaml"]
-          pattern: "processors:\\s*\\[memory_limiter, resource/mysql, batch\\]"
+          pattern: "processors:\\s*\\[resource/mysql, batch\\]"
   - it: merges additionalReceiverConfig into the receiver block
     set:
       additionalReceiverConfig:

--- a/charts/mysql-otel/tests/credentials_test.yaml
+++ b/charts/mysql-otel/tests/credentials_test.yaml
@@ -1,0 +1,32 @@
+suite: credentials
+templates:
+  - templates/secret.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+set:
+  mysql.server: "mysql.internal"
+  otlpEndpoint: "otlp.nr-data.net:4317"
+tests:
+  - it: renders a chart-owned Secret when plain username/password are given
+    set:
+      mysql.username: "nr_monitor"
+      mysql.password: "s3cret"
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: my-release-mysql-otel-mysql
+      - equal:
+          path: data.username
+          value: bnJfbW9uaXRvcg==
+      - equal:
+          path: data.password
+          value: czNjcmV0
+  - it: renders nothing when existingSecret is given
+    set:
+      mysql.existingSecret: "my-mysql-secret"
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/mysql-otel/tests/deployment_test.yaml
+++ b/charts/mysql-otel/tests/deployment_test.yaml
@@ -1,0 +1,75 @@
+suite: deployment
+templates:
+  - templates/deployment.yaml
+  - templates/configmap.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+set:
+  mysql.server: "mysql.internal"
+  mysql.topology: "self-hosted"
+  otlpEndpoint: "otlp.nr-data.net:4317"
+  licenseKey: "testlicensekey"
+tests:
+  - it: uses a chart-owned secretKeyRef when plain mysql credentials are given
+    set:
+      mysql.username: "nr_monitor"
+      mysql.password: "s3cret"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0]
+          value:
+            name: MYSQL_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: my-release-mysql-otel-mysql
+                key: username
+        template: templates/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].env[1]
+          value:
+            name: MYSQL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-release-mysql-otel-mysql
+                key: password
+        template: templates/deployment.yaml
+  - it: uses the existingSecret name when mysql.existingSecret is set
+    set:
+      mysql.existingSecret: "my-mysql-secret"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
+          value: my-mysql-secret
+        template: templates/deployment.yaml
+  - it: mounts the collector config and sets image/resources from values
+    set:
+      mysql.username: "u"
+      mysql.password: "p"
+      image.repository: "newrelic/nrdot-collector"
+      image.tag: "2.4.0"
+      resources.limits.memory: "256Mi"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: newrelic/nrdot-collector:2.4.0
+        template: templates/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 256Mi
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: config
+            configMap:
+              name: my-release-mysql-otel-config
+        template: templates/deployment.yaml
+  - it: sets a config checksum annotation so a config-only change forces a Pod restart on upgrade
+    set:
+      mysql.username: "u"
+      mysql.password: "p"
+    asserts:
+      - isNotEmpty:
+          path: spec.template.metadata.annotations["checksum/config"]
+        template: templates/deployment.yaml

--- a/charts/mysql-otel/tests/setup_job_test.yaml
+++ b/charts/mysql-otel/tests/setup_job_test.yaml
@@ -1,0 +1,117 @@
+suite: setup job
+templates:
+  - templates/setup-job.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+set:
+  mysql.server: "mysql.internal"
+  mysql.port: 3306
+  mysql.topology: "self-hosted"
+  mysql.username: "nr_monitor"
+  mysql.password: "s3cret"
+  otlpEndpoint: "otlp.nr-data.net:4317"
+  setupJob.mysqlAdmin.existingSecret: "admin-secret"
+tests:
+  - it: renders nothing when setupJob.enabled is false
+    set:
+      setupJob.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: fails when setupJob.enabled is true and mysqlAdmin.existingSecret is unset
+    set:
+      setupJob.enabled: true
+      setupJob.mysqlAdmin.existingSecret: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "setupJob.mysqlAdmin.existingSecret is required when setupJob.enabled is true"
+  - it: has pre-install/pre-upgrade hook annotations with the documented delete policy
+    set:
+      setupJob.enabled: true
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-install,pre-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+  - it: wires admin and monitoring credentials as env vars, never as CLI args
+    set:
+      setupJob.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0]
+          value:
+            name: MYSQL_ADMIN_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: admin-secret
+                key: username
+      - equal:
+          path: spec.template.spec.containers[0].env[1]
+          value:
+            name: MYSQL_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: admin-secret
+                key: password
+      - equal:
+          path: spec.template.spec.containers[0].env[2]
+          value:
+            name: MYSQL_MONITOR_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: my-release-mysql-otel-mysql
+                key: username
+      - equal:
+          path: spec.template.spec.containers[0].env[3]
+          value:
+            name: MYSQL_MONITOR_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-release-mysql-otel-mysql
+                key: password
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "s3cret"
+  - it: uses the default mysql:8.4 image and restarts on failure
+    set:
+      setupJob.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: mysql:8.4
+      - equal:
+          path: spec.template.spec.restartPolicy
+          value: Never
+  - it: overrides the setup image when setupJob.image is set
+    set:
+      setupJob.enabled: true
+      setupJob.image.repository: "mycompany/mysql-client"
+      setupJob.image.tag: "8.0"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: mycompany/mysql-client:8.0
+  - it: runs the base grant heredoc, omitting the wait-time grant by default
+    set:
+      setupJob.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "CREATE USER IF NOT EXISTS '\\$MYSQL_MONITOR_USERNAME'@'%' IDENTIFIED BY '\\$MYSQL_MONITOR_PASSWORD';"
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "GRANT SELECT ON performance_schema\\.\\* TO '\\$MYSQL_MONITOR_USERNAME'@'%';"
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "GRANT UPDATE ON performance_schema\\.setup_consumers"
+  - it: adds the wait-time grant heredoc when enableWaitTimeMetrics is true
+    set:
+      setupJob.enabled: true
+      setupJob.enableWaitTimeMetrics: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "GRANT UPDATE ON performance_schema\\.setup_consumers TO '\\$MYSQL_MONITOR_USERNAME'@'%';"

--- a/charts/mysql-otel/tests/validation_test.yaml
+++ b/charts/mysql-otel/tests/validation_test.yaml
@@ -1,0 +1,22 @@
+suite: validation
+templates:
+  - templates/secret.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+tests:
+  - it: fails when mysql.server is unset
+    set:
+      mysql.username: "u"
+      mysql.password: "p"
+      otlpEndpoint: "otlp.nr-data.net:4317"
+    asserts:
+      - failedTemplate:
+          errorMessage: "mysql.server is required"
+  - it: fails when no credential path is provided
+    set:
+      mysql.server: "mysql.internal"
+      otlpEndpoint: "otlp.nr-data.net:4317"
+    asserts:
+      - failedTemplate:
+          errorMessage: "You must set mysql.existingSecret, or both mysql.username and mysql.password"

--- a/charts/mysql-otel/values.yaml
+++ b/charts/mysql-otel/values.yaml
@@ -1,0 +1,92 @@
+image:
+  repository: newrelic/nrdot-collector
+  tag: "2.4.0"
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+mysql:
+  # -- Required. One of: self-hosted, rds. Documentation/validation only -- no rendered difference.
+  topology: ""
+  # -- Required. MySQL host/endpoint (no port).
+  server: ""
+  # -- MySQL port.
+  port: 3306
+  # -- Plain-value monitoring username. Ignored if existingSecret is set.
+  username: ""
+  # -- Plain-value monitoring password. Ignored if existingSecret is set.
+  password: ""
+  # -- Name of a pre-existing Secret with keys `username` and `password`. Wins over the plain values above if set.
+  existingSecret: ""
+  # -- Restrict monitoring to one database. Leave empty to monitor all databases.
+  database: ""
+  # -- Maps to the receiver's allow_native_passwords.
+  allowNativePasswords: true
+  # -- How often the receiver scrapes MySQL.
+  collectionInterval: 10s
+  # -- Delay before the receiver's first scrape.
+  initialDelay: 1s
+  # -- inline or procedure. "inline" is the receiver's real default -- New Relic's own doc example sets "procedure" to demonstrate the alternative, not because it's the default.
+  explainMode: inline
+  tls:
+    # -- Maps to the receiver's tls.insecure.
+    insecure: false
+    # -- Maps to the receiver's tls.insecure_skip_verify.
+    insecureSkipVerify: false
+    # -- CA bundle path, e.g. Amazon's RDS CA bundle when topology=rds and TLS is required. Maps to tls.ca_file. Left to the operator deliberately -- see README.
+    caFile: ""
+  statementEvents:
+    digestTextLimit: 4096
+    timeLimit: 24h
+    limit: 500
+  querySampleCollection:
+    maxRowsPerQuery: 100
+    allowedCommentKeys:
+      - nr_service_guid
+  topQueryCollection:
+    lookbackTime: 120
+    maxQuerySampleCount: 5000
+    topQueryCount: 200
+    collectionInterval: 60s
+    queryPlanCacheSize: 1000
+    queryPlanCacheTtl: 1h
+    allowedCommentKeys:
+      - nr_service_guid
+  events:
+    querySample:
+      enabled: true
+    topQuery:
+      enabled: true
+
+# -- Required. New Relic OTLP/gRPC endpoint for the account's region, bare host:port with NO scheme, e.g. otlp.nr-data.net:4317
+otlpEndpoint: ""
+
+# -- Plain-value New Relic license key. Can also be set as global.licenseKey.
+licenseKey: ""
+# -- Name of a pre-existing Secret holding the license key. Can also be set as global.customSecretName.
+customSecretName: ""
+# -- Key inside customSecretName that holds the license key. Can also be set as global.customSecretLicenseKey.
+customSecretLicenseKey: ""
+
+# -- Escape hatch merged into the nrmysql receiver block.
+additionalReceiverConfig: {}
+
+setupJob:
+  # -- If true, a Helm hook Job creates the monitoring user and grants it read-only access before install/upgrade.
+  enabled: false
+  image:
+    # -- mysql CLI image. Defaults to the official, actively-maintained, freely-pullable image -- unlike mssql-otel/oracle-otel, which leave this blank.
+    repository: mysql
+    tag: "8.4"
+    pullPolicy: IfNotPresent
+  mysqlAdmin:
+    # -- Required when setupJob.enabled is true. Name of a pre-existing Secret with keys `username` and `password`. No plain-value path. Must be able to CREATE USER and GRANT SELECT on performance_schema.
+    existingSecret: ""
+  # -- Also grants UPDATE ON performance_schema.setup_consumers, needed for wait-time data. Optional per the doc.
+  enableWaitTimeMetrics: false
+
+resources: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
<!--
Thank you for contributing to New Relic's Helm charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements:

* https://github.com/newrelic-experimental/helm-charts/blob/master/CONTRIBUTING.md#technical-requirements

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/newrelic-experimental/helm-charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Adds a new standalone chart, `mysql-otel`. It deploys New Relic's NRDOT OpenTelemetry collector configured with the `nrmysql` receiver to scrape one MySQL instance (self-hosted or Amazon RDS, reached over the network) and export metrics/logs to New Relic over OTLP.

Every `nrmysql` config field (connection, TLS, statement/query-sample/top-query tuning, events) is exposed as its own typed value rather than baked-in defaults, since these are query-performance knobs an operator is likely to tune per instance. A `resource/mysql` processor is always rendered to inject `server.address`/`server.port`, since the receiver
doesn't emit them itself.

An optional `setupJob` (off by default) can provision the monitoring user and its `performance_schema` grants via a Helm hook Job — it defaults to the official `mysql:8.4` image, so enabling it needs no extra `--set` flags for the image, unlike the sibling charts.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

# Release Notes to Publish (nr-k8s-otel-collector)
If this PR contains changes in `nr-k8s-otel-collector`, please complete the following section. All other charts should ignore this section.

<!--BEGIN-RELEASE-NOTES-->
## 🚀 What's Changed
* Tell the world about the latest changes in the chart.
<!--END-RELEASE-NOTES-->
