### PR TITLE
[nr-ebpf-agent] Bump chart version

### DIFF
--- a/charts/nr-ebpf-agent/Chart.yaml
+++ b/charts/nr-ebpf-agent/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.0
+version: 1.6.1
 
 dependencies:
   - name: common-library


### PR DESCRIPTION
Just a bump in chart version to include the eBPF chart version 1.6.0 in `nri-bundle`. 